### PR TITLE
REPL: use AYA_HOME to configure the CONFIG_ROOT

### DIFF
--- a/cli/src/main/java/org/aya/cli/repl/Repl.java
+++ b/cli/src/main/java/org/aya/cli/repl/Repl.java
@@ -13,9 +13,11 @@ import java.nio.file.Paths;
 
 public class Repl {
   private static Path CONFIG_ROOT;
+
   static @Nullable Path configRoot() {
     if (CONFIG_ROOT == null) {
-      CONFIG_ROOT = Paths.get(System.getProperty("user.home"), ".aya");
+      String ayaHome = System.getenv("AYA_HOME");
+      CONFIG_ROOT = ayaHome == null ? Paths.get(System.getProperty("user.home"), ".aya") : Paths.get(ayaHome);
     }
     try {
       Files.createDirectories(CONFIG_ROOT);


### PR DESCRIPTION
kala-platform is part of the kala project and is planned to handle platform-related operations.

`Platform::getAppDataDirectory(String)` currently tries to locate the program folder like this:

* Use `%APPDATA%\$name` on Windows.
* Use `~/Library/Application Support/$name` on Mac OS.
* Use `$XDG_DATA_HOME/$name` as the preferred path, and the alternative path is `~/.local/share/$name`.