### PR TITLE
REPL: choose parser by param type (currently only Path.class uses a shell like parser)

### DIFF
--- a/cli/src/main/java/org/aya/cli/repl/Repl.java
+++ b/cli/src/main/java/org/aya/cli/repl/Repl.java
@@ -50,7 +50,7 @@ public abstract class Repl implements Closeable, Runnable {
       CommandArg.STRING,
       CommandArg.STRICT_BOOLEAN,
       CommandArg.STRICT_INT,
-      CommandArg.from(Path.class, new Completers.FileNameCompleter(), this::resolveFile),
+      CommandArg.shellLike(Path.class, new Completers.FileNameCompleter(), this::resolveFile),
       CommandArg.from(ReplCommands.Code.class, new AyaCompleters.Code(this), ReplCommands.Code::new),
       CommandArg.from(ReplCommands.HelpItem.class, new AyaCompleters.Help(this), ReplCommands.HelpItem::new),
       CommandArg.fromEnum(NormalizeMode.class)

--- a/cli/src/main/java/org/aya/cli/repl/command/CommandArg.java
+++ b/cli/src/main/java/org/aya/cli/repl/command/CommandArg.java
@@ -16,7 +16,7 @@ public interface CommandArg {
   @Nullable Completer completer();
   boolean shellLike();
 
-  record CommandArgImpl<R>(@NotNull Class<?> type, @Nullable Completer completer, boolean shellLike,
+  record CommandArgImpl<R>(@NotNull Class<? extends R> type, @Nullable Completer completer, boolean shellLike,
                            @NotNull Function<String, R> f) implements CommandArg {
     @Override public @NotNull Object parse(@NotNull String input) throws IllegalArgumentException {
       return f.apply(input);

--- a/cli/src/main/java/org/aya/cli/repl/command/CommandArg.java
+++ b/cli/src/main/java/org/aya/cli/repl/command/CommandArg.java
@@ -14,25 +14,29 @@ public interface CommandArg {
   @NotNull Class<?> type();
   @NotNull Object parse(@NotNull String input) throws IllegalArgumentException;
   @Nullable Completer completer();
+  boolean shellLike();
+
+  record CommandArgImpl<R>(@NotNull Class<?> type, @Nullable Completer completer, boolean shellLike,
+                           @NotNull Function<String, R> f) implements CommandArg {
+    @Override public @NotNull Object parse(@NotNull String input) throws IllegalArgumentException {
+      return f.apply(input);
+    }
+  }
+
+  private static <R> CommandArg from(@NotNull Class<? extends R> type, boolean shellLike, @Nullable Completer completer, @NotNull Function<String, R> f) {
+    return new CommandArgImpl<>(type, completer, shellLike, f);
+  }
 
   static <R> CommandArg from(@NotNull Class<? extends R> type, @Nullable Completer completer, @NotNull Function<String, R> f) {
-    return new CommandArg() {
-      @NotNull @Override public Class<?> type() {
-        return type;
-      }
+    return from(type, false, completer, f);
+  }
 
-      @Override public @NotNull Object parse(@NotNull String input) throws IllegalArgumentException {
-        return f.apply(input);
-      }
-
-      @Override public @Nullable Completer completer() {
-        return completer;
-      }
-    };
+  static <R> CommandArg shellLike(@NotNull Class<? extends R> type, @Nullable Completer completer, @NotNull Function<String, R> f) {
+    return from(type, true, completer, f);
   }
 
   static <T extends Enum<T>> CommandArg fromEnum(@NotNull Class<T> enumClass) {
-    return from(enumClass, new AyaCompleters.EnumCompleter<>(enumClass), input -> Enum.valueOf(enumClass, input));
+    return from(enumClass, false, new AyaCompleters.EnumCompleter<>(enumClass), input -> Enum.valueOf(enumClass, input));
   }
 
   @NotNull CommandArg STRING = from(String.class, null, Function.identity());

--- a/cli/src/main/java/org/aya/cli/repl/jline/AyaReplParser.java
+++ b/cli/src/main/java/org/aya/cli/repl/jline/AyaReplParser.java
@@ -16,7 +16,11 @@ import org.jline.reader.impl.DefaultParser;
 import java.util.Collections;
 import java.util.List;
 
-public record AyaReplParser(@NotNull CommandManager cmd) implements Parser {
+public record AyaReplParser(@NotNull CommandManager cmd, @NotNull DefaultParser shellLike) implements Parser {
+  public AyaReplParser(@NotNull CommandManager cmd) {
+    this(cmd, new DefaultParser());
+  }
+
   public record AyaParsedLine(
     int wordCursor,
     @NotNull List<@NotNull String> words,
@@ -70,9 +74,8 @@ public record AyaReplParser(@NotNull CommandManager cmd) implements Parser {
     if (trim.startsWith(Command.PREFIX)) {
       var shellLike = cmd.parse(trim.substring(1)).command()
         .flatMap(c -> Option.of(c.argFactory()))
-        .map(CommandArg::shellLike)
-        .getOrDefault(false);
-      if (shellLike) return new DefaultParser().parse(line, cursor, context);
+        .map(CommandArg::shellLike).getOrDefault(false);
+      if (shellLike) return shellLike().parse(line, cursor, context);
     }
     // Drop whitespaces
     var tokens = tokensNoEOF(line)

--- a/cli/src/main/java/org/aya/cli/repl/jline/AyaReplParser.java
+++ b/cli/src/main/java/org/aya/cli/repl/jline/AyaReplParser.java
@@ -8,7 +8,6 @@ import org.aya.cli.repl.command.Command;
 import org.aya.concrete.parse.AyaParsing;
 import org.jetbrains.annotations.NotNull;
 import org.jline.reader.*;
-import org.jline.reader.impl.DefaultParser;
 
 import java.util.Collections;
 import java.util.List;
@@ -63,8 +62,6 @@ public class AyaReplParser implements Parser {
       && line.startsWith(Command.MULTILINE_BEGIN) && !line.endsWith(Command.MULTILINE_END)) {
       throw new EOFError(-1, cursor, "In multiline mode");
     }
-    // use a shell like parser for completion only
-    if (context == ParseContext.COMPLETE) return new DefaultParser().parse(line, cursor, context);
     // Drop whitespaces
     var tokens = tokensNoEOF(line)
       .filter(token -> token.getChannel() != Token.HIDDEN_CHANNEL);

--- a/cli/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
+++ b/cli/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
@@ -41,7 +41,7 @@ public final class JlineRepl extends Repl {
       .appName("Aya REPL")
       .terminal(terminal)
       .history(new DefaultHistory())
-      .parser(new AyaReplParser())
+      .parser(new AyaReplParser(commandManager))
       .highlighter(new AyaReplHighlighter())
       .completer(new AggregateCompleter(
         new CmdCompleter(this, commandManager)

--- a/cli/src/main/java/org/aya/cli/repl/jline/completer/AyaCompleters.java
+++ b/cli/src/main/java/org/aya/cli/repl/jline/completer/AyaCompleters.java
@@ -54,10 +54,10 @@ public interface AyaCompleters {
       var fixed = fixWord(word, line);
       var context = repl.replCompiler.getContext();
       context.modules.view().forEach((mod, contents) -> {
-        var modName = mod.joinToString(Constants.SCOPE_SEPARATOR) + Constants.SCOPE_SEPARATOR;
+        var modName = mod.joinToString(Constants.SCOPE_SEPARATOR, "", Constants.SCOPE_SEPARATOR);
         if (!modName.startsWith(fixed._1)) return;
         contents.keysView()
-          .map(name -> fixed._2 ? Constants.SCOPE_SEPARATOR + name : modName + name)
+          .map(name -> (fixed._2 ? Constants.SCOPE_SEPARATOR : modName) + name)
           .map(Candidate::new)
           .forEach(candidates::add);
       });

--- a/cli/src/test/java/JlineTest.java
+++ b/cli/src/test/java/JlineTest.java
@@ -1,6 +1,8 @@
 // Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 
+import kala.collection.immutable.ImmutableSeq;
+import org.aya.cli.repl.command.CommandManager;
 import org.aya.cli.repl.jline.AyaReplParser;
 import org.aya.cli.repl.jline.JlineRepl;
 import org.aya.pretty.doc.Doc;
@@ -13,7 +15,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JlineTest {
-  public static @NotNull AyaReplParser PARSER = new AyaReplParser();
+  public static @NotNull CommandManager EMPTY = new CommandManager(ImmutableSeq.empty(), ImmutableSeq.empty());
+  public static @NotNull AyaReplParser PARSER = new AyaReplParser(EMPTY);
 
   @Test public void initializeJline() throws IOException {
     new JlineRepl(PlainReplTest.config).renderDoc(Doc.empty());


### PR DESCRIPTION
This adds back completion for `(Ty <tab>` and also supports path completion.