### PR TITLE
Tyck of one SCC will not be interrupted by unrelated failed SCCs

### DIFF
--- a/base/src/main/java/org/aya/concrete/desugar/BinOpSet.java
+++ b/base/src/main/java/org/aya/concrete/desugar/BinOpSet.java
@@ -23,7 +23,7 @@ public record BinOpSet(
     () -> new OpDecl.Operator("application", Assoc.InfixL));
 
   public BinOpSet(@NotNull Reporter reporter) {
-    this(reporter, MutableSet.of(APP_ELEM), MutableGraph.empty());
+    this(reporter, MutableSet.of(APP_ELEM), MutableGraph.create());
   }
 
   public void bind(@NotNull OpDecl op, @NotNull Command.BindPred pred, @NotNull OpDecl target, @NotNull SourcePos sourcePos) {

--- a/base/src/main/java/org/aya/concrete/resolve/ResolveInfo.java
+++ b/base/src/main/java/org/aya/concrete/resolve/ResolveInfo.java
@@ -18,7 +18,7 @@ public record ResolveInfo(
   @NotNull MutableGraph<Stmt> sampleGraph
 ) {
   public ResolveInfo(@NotNull BinOpSet opSet) {
-    this(opSet, MutableGraph.empty(), MutableGraph.empty());
+    this(opSet, MutableGraph.create(), MutableGraph.create());
   }
 
   public @NotNull ResolveInfo toUsageInfo() {

--- a/base/src/main/java/org/aya/concrete/resolve/ResolveInfo.java
+++ b/base/src/main/java/org/aya/concrete/resolve/ResolveInfo.java
@@ -20,4 +20,8 @@ public record ResolveInfo(
   public ResolveInfo(@NotNull BinOpSet opSet) {
     this(opSet, MutableGraph.empty(), MutableGraph.empty());
   }
+
+  public @NotNull ResolveInfo toUsageInfo() {
+    return new ResolveInfo(opSet, declGraph.transpose(), sampleGraph.transpose());
+  }
 }

--- a/base/src/main/java/org/aya/concrete/resolve/module/FileModuleLoader.java
+++ b/base/src/main/java/org/aya/concrete/resolve/module/FileModuleLoader.java
@@ -92,7 +92,8 @@ public record FileModuleLoader(
     // in case we have un-messaged TyckException
     try (delayedReporter) {
       var SCCs = resolveInfo.declGraph().topologicalOrder()
-        .view().appendedAll(resolveInfo.sampleGraph().topologicalOrder());
+        .view().appendedAll(resolveInfo.sampleGraph().topologicalOrder())
+        .toImmutableSeq();
       SCCs.forEach(sccTycker::tyckSCC);
     } finally {
       onResolved.acceptChecked(shallowResolveInfo);

--- a/base/src/main/java/org/aya/concrete/resolve/module/FileModuleLoader.java
+++ b/base/src/main/java/org/aya/concrete/resolve/module/FileModuleLoader.java
@@ -91,10 +91,8 @@ public record FileModuleLoader(
       var sccTycker = new SCCTycker(builder, delayedReporter);
       var SCCs = resolveInfo.declGraph().topologicalOrder()
         .view().appendedAll(resolveInfo.sampleGraph().topologicalOrder());
-      var wellTyped = SCCs
-        .flatMap(sccTycker::tyckSCC)
-        .toImmutableSeq();
-      onTycked.acceptChecked(wellTyped);
+      SCCs.forEach(sccTycker::tyckSCC);
+      onTycked.acceptChecked(sccTycker.wellTyped().toImmutableSeq());
     } catch (SCCTycker.SCCTyckingFailed ignored) {
       // stop tycking the rest of groups since some of their dependencies are failed.
       // Random thought: we may assume their signatures are correct and try to tyck

--- a/base/src/main/java/org/aya/concrete/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/concrete/resolve/visitor/StmtResolver.java
@@ -146,7 +146,7 @@ public final class StmtResolver implements Stmt.Visitor<ResolveInfo, Unit> {
 
   private void visitSample(@NotNull Sample sample, ResolveInfo info) {
     var delegate = sample.delegate();
-    var delegateInfo = new ResolveInfo(info.opSet(), MutableGraph.empty(), MutableGraph.empty());
+    var delegateInfo = new ResolveInfo(info.opSet(), MutableGraph.create(), MutableGraph.create());
     delegate.accept(this, delegateInfo);
     // little hacky: transfer dependencies from `delegate` to `sample`
     info.sampleGraph().suc(sample).addAll(delegateInfo.declGraph().suc(delegate));

--- a/base/src/main/java/org/aya/tyck/order/IncrementalTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/IncrementalTycker.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.tyck.order;
+
+import kala.collection.SeqLike;
+import kala.collection.mutable.MutableSet;
+import org.aya.concrete.resolve.ResolveInfo;
+import org.aya.concrete.stmt.Decl;
+import org.aya.concrete.stmt.Stmt;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Incremental and non-stopping compiler for SCCs.
+ *
+ * @author kiva
+ */
+public record IncrementalTycker(
+  @NotNull SCCTycker sccTycker,
+  @NotNull ResolveInfo resolveInfo,
+  @NotNull MutableSet<Stmt> skipped
+) {
+  public IncrementalTycker(@NotNull SCCTycker sccTycker, @NotNull ResolveInfo resolveInfo) {
+    this(sccTycker, resolveInfo, MutableSet.of());
+  }
+
+  public void tyckSCC(@NotNull SeqLike<Stmt> scc) {
+    try {
+      // we are more likely to check correct programs.
+      // I'm not sure whether it's necessary to optimize on our own.
+      if (skipped.isEmpty()) sccTycker.tyckSCC(scc);
+      else sccTycker.tyckSCC(scc.view().filterNot(skipped::contains));
+    } catch (SCCTycker.SCCTyckingFailed failed) {
+      failed.what.forEach(this::skip);
+    }
+  }
+
+  private void skip(@NotNull Stmt failed) {
+    if (skipped.contains(failed)) return;
+    skipped.add(failed);
+    var graph = failed instanceof Decl ? resolveInfo.declGraph() : resolveInfo.sampleGraph();
+    graph.E().forEach((v, deps) -> {
+      if (deps.contains(failed)) skip(v);
+    });
+  }
+}

--- a/base/src/main/java/org/aya/tyck/order/IncrementalTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/IncrementalTycker.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck.order;
 
-import kala.collection.SeqLike;
+import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableSet;
 import org.aya.concrete.resolve.ResolveInfo;
 import org.aya.concrete.stmt.Decl;
@@ -23,12 +23,12 @@ public record IncrementalTycker(
     this(sccTycker, resolveInfo, MutableSet.of());
   }
 
-  public void tyckSCC(@NotNull SeqLike<Stmt> scc) {
+  public void tyckSCC(@NotNull ImmutableSeq<Stmt> scc) {
     try {
       // we are more likely to check correct programs.
       // I'm not sure whether it's necessary to optimize on our own.
       if (skipped.isEmpty()) sccTycker.tyckSCC(scc);
-      else sccTycker.tyckSCC(scc.view().filterNot(skipped::contains));
+      else sccTycker.tyckSCC(scc.filterNot(skipped::contains));
     } catch (SCCTycker.SCCTyckingFailed failed) {
       failed.what.forEach(this::skip);
     }

--- a/base/src/main/java/org/aya/tyck/order/IncrementalTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/IncrementalTycker.java
@@ -16,11 +16,11 @@ import org.jetbrains.annotations.NotNull;
  */
 public record IncrementalTycker(
   @NotNull SCCTycker sccTycker,
-  @NotNull ResolveInfo resolveInfo,
+  @NotNull ResolveInfo usageInfo,
   @NotNull MutableSet<Stmt> skipped
 ) {
   public IncrementalTycker(@NotNull SCCTycker sccTycker, @NotNull ResolveInfo resolveInfo) {
-    this(sccTycker, resolveInfo, MutableSet.of());
+    this(sccTycker, resolveInfo.toUsageInfo(), MutableSet.of());
   }
 
   public void tyckSCC(@NotNull ImmutableSeq<Stmt> scc) {
@@ -37,9 +37,7 @@ public record IncrementalTycker(
   private void skip(@NotNull Stmt failed) {
     if (skipped.contains(failed)) return;
     skipped.add(failed);
-    var graph = failed instanceof Decl ? resolveInfo.declGraph() : resolveInfo.sampleGraph();
-    graph.E().forEach((v, deps) -> {
-      if (deps.contains(failed)) skip(v);
-    });
+    var graph = failed instanceof Decl ? usageInfo.declGraph() : usageInfo.sampleGraph();
+    graph.suc(failed).forEach(this::skip);
   }
 }

--- a/base/src/main/java/org/aya/tyck/order/SCCTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/SCCTycker.java
@@ -3,7 +3,8 @@
 package org.aya.tyck.order;
 
 import kala.collection.Seq;
-import kala.collection.immutable.ImmutableSeq;
+import kala.collection.SeqLike;
+import kala.collection.SeqView;
 import kala.collection.mutable.DynamicSeq;
 import kala.control.Option;
 import org.aya.api.error.CollectingReporter;
@@ -33,7 +34,7 @@ public record SCCTycker(@NotNull StmtTycker tycker, @NotNull CollectingReporter 
     this(new StmtTycker(reporter, builder), reporter, DynamicSeq.create());
   }
 
-  public void tyckSCC(@NotNull ImmutableSeq<Stmt> scc) throws SCCTyckingFailed {
+  public void tyckSCC(@NotNull SeqLike<Stmt> scc) throws SCCTyckingFailed {
     if (scc.sizeEquals(1)) checkBody(scc.first());
     else {
       var headerOrder = headerOrder(scc);
@@ -55,7 +56,7 @@ public record SCCTycker(@NotNull StmtTycker tycker, @NotNull CollectingReporter 
       case Remark remark -> Option.of(remark.literate).forEach(l -> l.tyck(tycker.newTycker()));
       default -> {}
     }
-    if (reporter.problems().anyMatch(Problem::isError)) throw new SCCTyckingFailed(Seq.of(stmt));
+    if (reporter.problems().anyMatch(Problem::isError)) throw new SCCTyckingFailed(SeqView.of(stmt));
   }
 
   /**
@@ -63,15 +64,15 @@ public record SCCTycker(@NotNull StmtTycker tycker, @NotNull CollectingReporter 
    *
    * @author re-xyr, kiva
    */
-  public @NotNull ImmutableSeq<Stmt> headerOrder(@NotNull Seq<Stmt> stmts) {
+  public @NotNull SeqLike<Stmt> headerOrder(@NotNull SeqLike<Stmt> stmts) {
     var graph = MutableGraph.<Stmt>empty();
     stmts.forEach(stmt -> {
       var reference = DynamicSeq.<Stmt>create();
       stmt.accept(SigRefFinder.HEADER_ONLY, reference);
       graph.suc(stmt).addAll(reference);
     });
-    var order = graph.topologicalOrder();
-    var cycle = order.view().filter(s -> s.sizeGreaterThan(1));
+    var order = graph.topologicalOrder().view();
+    var cycle = order.filter(s -> s.sizeGreaterThan(1));
     if (cycle.isNotEmpty()) {
       cycle.forEach(c -> reporter.report(new CircularSignatureError(c)));
       throw new SCCTyckingFailed(stmts);
@@ -80,9 +81,9 @@ public record SCCTycker(@NotNull StmtTycker tycker, @NotNull CollectingReporter 
   }
 
   public static class SCCTyckingFailed extends InterruptException {
-    public @NotNull Seq<Stmt> what;
+    public @NotNull SeqLike<Stmt> what;
 
-    public SCCTyckingFailed(@NotNull Seq<Stmt> what) {
+    public SCCTyckingFailed(@NotNull SeqLike<Stmt> what) {
       this.what = what;
     }
 

--- a/base/src/main/java/org/aya/tyck/order/SCCTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/SCCTycker.java
@@ -63,7 +63,7 @@ public record SCCTycker(@NotNull StmtTycker tycker, @NotNull CollectingReporter 
    * @author re-xyr, kiva
    */
   public @NotNull ImmutableSeq<Stmt> headerOrder(@NotNull ImmutableSeq<Stmt> stmts) {
-    var graph = MutableGraph.<Stmt>empty();
+    var graph = MutableGraph.<Stmt>create();
     stmts.forEach(stmt -> {
       var reference = DynamicSeq.<Stmt>create();
       stmt.accept(SigRefFinder.HEADER_ONLY, reference);

--- a/base/src/main/java/org/aya/tyck/order/SCCTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/SCCTycker.java
@@ -28,35 +28,34 @@ import java.util.function.Function;
  *
  * @author kiva
  */
-public record SCCTycker(@NotNull StmtTycker tycker, @NotNull CollectingReporter reporter) {
+public record SCCTycker(@NotNull StmtTycker tycker, @NotNull CollectingReporter reporter, DynamicSeq<Def> wellTyped) {
   public SCCTycker(@Nullable Trace.Builder builder, @NotNull CollectingReporter reporter) {
-    this(new StmtTycker(reporter, builder), reporter);
+    this(new StmtTycker(reporter, builder), reporter, DynamicSeq.create());
   }
 
-  public @NotNull ImmutableSeq<Def> tyckSCC(@NotNull ImmutableSeq<Stmt> scc) {
-    var wellTyped = DynamicSeq.<Def>create();
-    if (scc.sizeEquals(1)) checkBody(scc.first(), wellTyped);
+  public void tyckSCC(@NotNull ImmutableSeq<Stmt> scc) throws SCCTyckingFailed {
+    if (scc.sizeEquals(1)) checkBody(scc.first());
     else {
       var headerOrder = headerOrder(scc);
       headerOrder.forEach(this::checkHeader);
-      headerOrder.forEach(tup -> checkBody(tup, wellTyped));
+      headerOrder.forEach(this::checkBody);
     }
-    return wellTyped.toImmutableSeq();
   }
 
   private void checkHeader(@NotNull Stmt stmt) {
     if (stmt instanceof Decl decl) tycker.tyckHeader(decl, tycker.newTycker());
     else if (stmt instanceof Sample sample) sample.tyckHeader(tycker);
+    if (reporter.problems().anyMatch(Problem::isError)) throw new SCCTyckingFailed(Seq.of(stmt));
   }
 
-  private void checkBody(@NotNull Stmt stmt, @NotNull DynamicSeq<Def> wellTyped) {
+  private void checkBody(@NotNull Stmt stmt) {
     switch (stmt) {
       case Decl decl -> wellTyped.append(tycker.tyck(decl, tycker.newTycker()));
       case Sample sample -> wellTyped.append(sample.tyck(tycker));
       case Remark remark -> Option.of(remark.literate).forEach(l -> l.tyck(tycker.newTycker()));
       default -> {}
     }
-    if (reporter.problems().anyMatch(Problem::isError)) throw new SCCTyckingFailed();
+    if (reporter.problems().anyMatch(Problem::isError)) throw new SCCTyckingFailed(Seq.of(stmt));
   }
 
   /**
@@ -75,12 +74,18 @@ public record SCCTycker(@NotNull StmtTycker tycker, @NotNull CollectingReporter 
     var cycle = order.view().filter(s -> s.sizeGreaterThan(1));
     if (cycle.isNotEmpty()) {
       cycle.forEach(c -> reporter.report(new CircularSignatureError(c)));
-      throw new SCCTyckingFailed();
+      throw new SCCTyckingFailed(stmts);
     }
     return order.flatMap(Function.identity());
   }
 
   public static class SCCTyckingFailed extends InterruptException {
+    public @NotNull Seq<Stmt> what;
+
+    public SCCTyckingFailed(@NotNull Seq<Stmt> what) {
+      this.what = what;
+    }
+
     @Override public InterruptStage stage() {
       return InterruptStage.Tycking;
     }

--- a/base/src/test/java/org/aya/concrete/VisitorTest.java
+++ b/base/src/test/java/org/aya/concrete/VisitorTest.java
@@ -4,13 +4,28 @@ package org.aya.concrete;
 
 import kala.collection.mutable.DynamicSeq;
 import kala.tuple.Unit;
+import org.aya.api.Global;
 import org.aya.concrete.visitor.StmtConsumer;
+import org.aya.core.def.PrimDef;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VisitorTest {
+  @BeforeAll public static void enableTest() {
+    PrimDef.Factory.INSTANCE.clear();
+    Global.NO_RANDOM_NAME = true;
+    Global.UNITE_SOURCE_POS = true;
+  }
+
+  @AfterAll public static void exit() {
+    PrimDef.Factory.INSTANCE.clear();
+    Global.reset();
+  }
+
   @Test public void stmt() {
     var exprs = DynamicSeq.<Expr>create();
     var visitor = new StmtConsumer<Unit>() {

--- a/lsp/src/main/java/org/aya/lsp/server/AyaService.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaService.java
@@ -63,13 +63,8 @@ public class AyaService implements WorkspaceService, TextDocumentService {
     var compilerFlags = new CompilerFlags(
       CompilerFlags.Message.EMOJI, false, null,
       libraryManager.modulePath.view());
-<<<<<<< HEAD
-
     var symbols = DynamicSeq.<HighlightResult.Symbol>create();
-=======
     libraryManager.loadedFiles.remove(filePath);
-    var symbols = Buffer.<HighlightResult.Symbol>create();
->>>>>>> d8ed41d4 (TYCK: tyck as much as possible)
     try {
       compiler.compile(filePath, compilerFlags, new FileModuleLoader.FileModuleLoaderCallback() {
         @Override

--- a/lsp/src/main/java/org/aya/lsp/server/AyaService.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaService.java
@@ -63,8 +63,13 @@ public class AyaService implements WorkspaceService, TextDocumentService {
     var compilerFlags = new CompilerFlags(
       CompilerFlags.Message.EMOJI, false, null,
       libraryManager.modulePath.view());
+<<<<<<< HEAD
 
     var symbols = DynamicSeq.<HighlightResult.Symbol>create();
+=======
+    libraryManager.loadedFiles.remove(filePath);
+    var symbols = Buffer.<HighlightResult.Symbol>create();
+>>>>>>> d8ed41d4 (TYCK: tyck as much as possible)
     try {
       compiler.compile(filePath, compilerFlags, new FileModuleLoader.FileModuleLoaderCallback() {
         @Override

--- a/tools/src/main/java/org/aya/util/MutableGraph.java
+++ b/tools/src/main/java/org/aya/util/MutableGraph.java
@@ -7,7 +7,7 @@ import kala.collection.mutable.*;
 import org.jetbrains.annotations.NotNull;
 
 public record MutableGraph<T>(@NotNull MutableHashMap<T, @NotNull MutableSet<@NotNull T>> E) {
-  public static @NotNull <T> MutableGraph<T> empty() {
+  public static @NotNull <T> MutableGraph<T> create() {
     return new MutableGraph<>(MutableHashMap.create());
   }
 
@@ -40,7 +40,7 @@ public record MutableGraph<T>(@NotNull MutableHashMap<T, @NotNull MutableSet<@No
   }
 
   public @NotNull MutableGraph<T> transpose() {
-    var tr = MutableGraph.<T>empty();
+    var tr = MutableGraph.<T>create();
     E.forEach((v, ws) -> ws.forEach(w -> tr.suc(w).add(v)));
     return tr;
   }

--- a/tools/src/main/java/org/aya/util/MutableGraph.java
+++ b/tools/src/main/java/org/aya/util/MutableGraph.java
@@ -39,6 +39,12 @@ public record MutableGraph<T>(@NotNull MutableHashMap<T, @NotNull MutableSet<@No
     return new Tarjan().tarjan();
   }
 
+  public @NotNull MutableGraph<T> transpose() {
+    var tr = MutableGraph.<T>empty();
+    E.forEach((v, ws) -> ws.forEach(w -> tr.suc(w).add(v)));
+    return tr;
+  }
+
   private static class Info {
     static final int INDEX_NONE = Integer.MAX_VALUE;
     int index = INDEX_NONE;


### PR DESCRIPTION
In the past, we will stop tycking immediately when a statement fails. Now we can skip the failed statement and its dependents and try to tyck as much as possible and always produce a `wellTyped` list, which is quite good for our LSP frontend.
