### PR TITLE
Handle token recognition error in REPL

### DIFF
--- a/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
@@ -97,5 +97,8 @@ ID : AYA_LETTER AYA_LETTER_FOLLOW* | '-' AYA_LETTER AYA_LETTER_FOLLOW*;
 WS : [ \t\r\n]+ -> channel(HIDDEN);
 fragment COMMENT_CONTENT : ~[\r\n]*;
 DOC_COMMENT : '--|' COMMENT_CONTENT;
-LINE_COMMENT : '--' COMMENT_CONTENT -> skip;
+LINE_COMMENT : '--' COMMENT_CONTENT -> channel(HIDDEN);
 COMMENT : '{-' (COMMENT|.)*? '-}' -> channel(HIDDEN);
+
+// avoid token recognition error in REPL
+ERROR_CHAR : .;

--- a/cli/src/main/java/org/aya/cli/repl/Repl.java
+++ b/cli/src/main/java/org/aya/cli/repl/Repl.java
@@ -6,6 +6,7 @@ import kala.collection.immutable.ImmutableSeq;
 import org.aya.api.distill.AyaDocile;
 import org.aya.api.distill.DistillerOptions;
 import org.aya.api.util.AyaHome;
+import org.aya.api.util.InterruptException;
 import org.aya.api.util.NormalizeMode;
 import org.aya.cli.repl.command.Command;
 import org.aya.cli.repl.command.CommandArg;
@@ -122,7 +123,8 @@ public abstract class Repl implements Closeable, Runnable {
       return false;
     } catch (InterruptedException ignored) {
       // user send ctrl-c
-      return true;
+    } catch (InterruptException ignored) {
+      // compilation errors are already printed by reporters
     } catch (Throwable e) {
       var stackTrace = new StringWriter();
       e.printStackTrace(new PrintWriter(stackTrace));


### PR DESCRIPTION
fix `-`, `;` or chars not listed in AyaLexer.g4 will case token recoginition error