### PR TITLE
Add bind block & remove abuse block

### DIFF
--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -59,7 +59,7 @@ public sealed interface Expr extends ConcreteExpr {
   }
 
   @Override default @NotNull Expr desugar(@NotNull Reporter reporter) {
-    return accept(new Desugarer(reporter, new BinOpSet(reporter)), Unit.unit());
+    return accept(new Desugarer(new BinOpSet(reporter)), Unit.unit());
   }
 
   @Override default @NotNull Doc toDoc(@NotNull DistillerOptions options) {

--- a/base/src/main/java/org/aya/concrete/desugar/BinOpSet.java
+++ b/base/src/main/java/org/aya/concrete/desugar/BinOpSet.java
@@ -8,7 +8,6 @@ import org.aya.api.error.SourcePos;
 import org.aya.api.util.Assoc;
 import org.aya.concrete.desugar.error.OperatorProblem;
 import org.aya.concrete.resolve.context.Context;
-import org.aya.concrete.stmt.Command;
 import org.aya.concrete.stmt.OpDecl;
 import org.aya.util.MutableGraph;
 import org.jetbrains.annotations.NotNull;
@@ -19,14 +18,13 @@ public record BinOpSet(
   @NotNull MutableSet<BinOP> ops,
   @NotNull MutableGraph<BinOP> tighterGraph
 ) {
-  static final @NotNull BinOpSet.BinOP APP_ELEM = BinOP.from(SourcePos.NONE,
-    () -> new OpDecl.Operator("application", Assoc.InfixL));
+  static final @NotNull BinOpSet.BinOP APP_ELEM = BinOP.from(SourcePos.NONE, OpDecl.APPLICATION);
 
   public BinOpSet(@NotNull Reporter reporter) {
     this(reporter, MutableSet.of(APP_ELEM), MutableGraph.create());
   }
 
-  public void bind(@NotNull OpDecl op, @NotNull Command.BindPred pred, @NotNull OpDecl target, @NotNull SourcePos sourcePos) {
+  public void bind(@NotNull OpDecl op, @NotNull OpDecl.BindPred pred, @NotNull OpDecl target, @NotNull SourcePos sourcePos) {
     var opElem = ensureHasElem(op, sourcePos);
     var targetElem = ensureHasElem(target, sourcePos);
     if (opElem == targetElem) {
@@ -55,7 +53,7 @@ public record BinOpSet(
   }
 
   public boolean isOperand(@Nullable OpDecl opDecl) {
-    return opDecl == null || opDecl.getOperator() == null;
+    return opDecl == null || opDecl.opInfo() == null;
   }
 
   public BinOP ensureHasElem(@NotNull OpDecl opDecl) {
@@ -89,8 +87,8 @@ public record BinOpSet(
     @NotNull String name,
     @NotNull Assoc assoc
   ) {
-    private static @NotNull OpDecl.Operator ensureOperator(@NotNull OpDecl opDecl) {
-      var op = opDecl.getOperator();
+    private static @NotNull OpDecl.OpInfo ensureOperator(@NotNull OpDecl opDecl) {
+      var op = opDecl.opInfo();
       if (op == null) throw new IllegalArgumentException("not an operator");
       return op;
     }

--- a/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
+++ b/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
@@ -4,7 +4,6 @@ package org.aya.concrete.desugar;
 
 import kala.function.CheckedSupplier;
 import kala.tuple.Unit;
-import org.aya.api.error.Reporter;
 import org.aya.api.ref.PreLevelVar;
 import org.aya.concrete.Expr;
 import org.aya.concrete.desugar.error.LevelProblem;
@@ -16,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author ice1000, kiva
  */
-public record Desugarer(@NotNull Reporter reporter, @NotNull BinOpSet opSet) implements StmtFixpoint<Unit> {
+public record Desugarer(@NotNull BinOpSet opSet) implements StmtFixpoint<Unit> {
   @Override public @NotNull Expr visitApp(@NotNull Expr.AppExpr expr, Unit unit) {
     if (expr.function() instanceof Expr.RawUnivExpr univ) return desugarUniv(expr, univ);
     return StmtFixpoint.super.visitApp(expr, unit);
@@ -55,7 +54,7 @@ public record Desugarer(@NotNull Reporter reporter, @NotNull BinOpSet opSet) imp
       case Expr.RefExpr ref && ref.resolvedVar() instanceof PreLevelVar lv -> new Level.Reference<>(lv);
       case Expr.HoleExpr hole -> new Level.Reference<>(new PreLevelVar(Constants.randomName(hole), hole.sourcePos()));
       default -> {
-        reporter.report(new LevelProblem.BadLevelExpr(expr));
+        opSet.reporter().report(new LevelProblem.BadLevelExpr(expr));
         throw new DesugarInterruption();
       }
     };

--- a/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
+++ b/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
@@ -113,8 +113,6 @@ public final class AyaProducer {
     if (mod != null) return ImmutableSeq.of(visitModule(mod));
     var levels = ctx.levels();
     if (levels != null) return ImmutableSeq.of(visitLevels(levels));
-    var bind = ctx.bind();
-    if (bind != null) return ImmutableSeq.of(visitBind(bind));
     var remark = ctx.remark();
     if (remark != null) return ImmutableSeq.of(visitRemark(remark));
     return unreachable(ctx);
@@ -139,17 +137,25 @@ public final class AyaProducer {
       .collect(ImmutableSeq.factory()));
   }
 
-  public Command.@NotNull Bind visitBind(AyaParser.BindContext ctx) {
-    var bindOp = ctx.qualifiedId();
-    return new Command.Bind(
-      sourcePosOf(ctx),
-      visitQualifiedId(bindOp.get(0)),
-      ctx.TIGHTER() != null ? Command.BindPred.Tighter : Command.BindPred.Looser,
-      visitQualifiedId(bindOp.get(1)),
-      new Ref<>(null),
-      new Ref<>(null),
-      new Ref<>(null)
-    );
+  public OpDecl.@NotNull BindBlock visitBind(AyaParser.BindBlockContext ctx) {
+    if (ctx.LOOSER() != null) return new OpDecl.BindBlock(sourcePosOf(ctx), new Ref<>(),
+      visitQIdsComma(ctx.qIdsComma()), ImmutableSeq.empty());
+    else if (ctx.TIGHTER() != null) return new OpDecl.BindBlock(sourcePosOf(ctx), new Ref<>(),
+      ImmutableSeq.empty(), visitQIdsComma(ctx.qIdsComma()));
+    else return new OpDecl.BindBlock(sourcePosOf(ctx), new Ref<>(),
+        visitLoosers(ctx.loosers()), visitTighters(ctx.tighters()));
+  }
+
+  public @NotNull ImmutableSeq<QualifiedID> visitLoosers(List<AyaParser.LoosersContext> ctx) {
+    return ctx.stream().flatMap(c -> visitQIdsComma(c.qIdsComma()).stream()).collect(ImmutableSeq.factory());
+  }
+
+  public @NotNull ImmutableSeq<QualifiedID> visitTighters(List<AyaParser.TightersContext> ctx) {
+    return ctx.stream().flatMap(c -> visitQIdsComma(c.qIdsComma()).stream()).collect(ImmutableSeq.factory());
+  }
+
+  public @NotNull ImmutableSeq<QualifiedID> visitQIdsComma(AyaParser.QIdsCommaContext ctx) {
+    return ctx.qualifiedId().stream().map(this::visitQualifiedId).collect(ImmutableSeq.factory());
   }
 
   public @NotNull Sample visitSample(AyaParser.SampleContext ctx) {
@@ -175,7 +181,7 @@ public final class AyaProducer {
     return unreachable(ctx);
   }
 
-  public Tuple2<@NotNull String, OpDecl.@Nullable Operator> visitDeclNameOrInfix(@NotNull AyaParser.DeclNameOrInfixContext ctx) {
+  public Tuple2<@NotNull String, OpDecl.@Nullable OpInfo> visitDeclNameOrInfix(@NotNull AyaParser.DeclNameOrInfixContext ctx) {
     var assoc = ctx.assoc();
     var id = ctx.ID().getText();
     if (assoc == null) return Tuple.of(id, null);
@@ -183,10 +189,10 @@ public final class AyaProducer {
     return Tuple.of(infix.name(), infix);
   }
 
-  private @NotNull OpDecl.Operator makeInfix(@NotNull AyaParser.AssocContext assoc, @NotNull String id) {
-    if (assoc.INFIX() != null) return new OpDecl.Operator(id, Assoc.Infix);
-    if (assoc.INFIXL() != null) return new OpDecl.Operator(id, Assoc.InfixL);
-    if (assoc.INFIXR() != null) return new OpDecl.Operator(id, Assoc.InfixR);
+  private @NotNull OpDecl.OpInfo makeInfix(@NotNull AyaParser.AssocContext assoc, @NotNull String id) {
+    if (assoc.INFIX() != null) return new OpDecl.OpInfo(id, Assoc.Infix);
+    if (assoc.INFIXL() != null) return new OpDecl.OpInfo(id, Assoc.InfixL);
+    if (assoc.INFIXR() != null) return new OpDecl.OpInfo(id, Assoc.InfixR);
     throw new IllegalArgumentException("Unknown assoc: " + assoc.getText());
   }
 
@@ -195,7 +201,7 @@ public final class AyaProducer {
       .map(this::visitFnModifiers)
       .distinct()
       .collect(Collectors.toCollection(() -> EnumSet.noneOf(Modifier.class)));
-    var abuseCtx = ctx.abuse();
+    var bind = ctx.bindBlock();
     var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix());
 
     return new Decl.FnDecl(
@@ -208,7 +214,7 @@ public final class AyaProducer {
       visitTelescope(ctx.tele()),
       type(ctx.type(), sourcePosOf(ctx)),
       visitFnBody(ctx.fnBody()),
-      abuseCtx == null ? ImmutableSeq.empty() : visitAbuse(abuseCtx)
+      bind == null ? null : visitBind(bind)
     );
   }
 
@@ -222,10 +228,6 @@ public final class AyaProducer {
 
   public @NotNull ImmutableSeq<Expr.@NotNull Param> visitForallTelescope(List<AyaParser.TeleContext> telescope) {
     return ImmutableSeq.from(telescope).flatMap(t -> visitTele(t, true));
-  }
-
-  public @NotNull ImmutableSeq<@NotNull Stmt> visitAbuse(AyaParser.AbuseContext ctx) {
-    return ImmutableSeq.from(ctx.stmt()).flatMap(this::visitStmt);
   }
 
   public @NotNull Either<Expr, ImmutableSeq<Pattern.Clause>> visitFnBody(AyaParser.FnBodyContext ctx) {
@@ -535,7 +537,7 @@ public final class AyaProducer {
 
   public @NotNull
   Tuple2<Decl, ImmutableSeq<Stmt>> visitDataDecl(AyaParser.DataDeclContext ctx, Stmt.Accessibility accessibility) {
-    var abuseCtx = ctx.abuse();
+    var bind = ctx.bindBlock();
     var openAccessibility = ctx.PUBLIC() != null ? Stmt.Accessibility.Public : Stmt.Accessibility.Private;
     var body = ctx.dataBody().stream().map(this::visitDataBody).collect(ImmutableSeq.factory());
     checkRedefinition(RedefinitionError.Kind.Ctor,
@@ -550,7 +552,7 @@ public final class AyaProducer {
       visitTelescope(ctx.tele()),
       type(ctx.type(), sourcePosOf(ctx)),
       body,
-      abuseCtx == null ? ImmutableSeq.empty() : visitAbuse(abuseCtx)
+      bind == null ? null : visitBind(bind)
     );
     return Tuple2.of(data, ctx.OPEN() == null ? ImmutableSeq.empty() : ImmutableSeq.of(
       new Command.Open(
@@ -678,7 +680,7 @@ public final class AyaProducer {
   }
 
   public @NotNull Decl.StructDecl visitStructDecl(AyaParser.StructDeclContext ctx, Stmt.Accessibility accessibility) {
-    var abuseCtx = ctx.abuse();
+    var bind = ctx.bindBlock();
     var fields = visitFields(ctx.field());
     checkRedefinition(RedefinitionError.Kind.Field,
       fields.view().map(field -> new WithPos<>(field.sourcePos, field.ref.name())));
@@ -693,7 +695,7 @@ public final class AyaProducer {
       type(ctx.type(), sourcePosOf(ctx)),
       // ctx.ids(),
       fields,
-      abuseCtx == null ? ImmutableSeq.empty() : visitAbuse(abuseCtx)
+      bind == null ? null : visitBind(bind)
     );
   }
 

--- a/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
+++ b/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
@@ -139,11 +139,11 @@ public final class AyaProducer {
 
   public OpDecl.@NotNull BindBlock visitBind(AyaParser.BindBlockContext ctx) {
     if (ctx.LOOSER() != null) return new OpDecl.BindBlock(sourcePosOf(ctx), new Ref<>(),
-      visitQIdsComma(ctx.qIdsComma()), ImmutableSeq.empty());
+      visitQIdsComma(ctx.qIdsComma()), ImmutableSeq.empty(), new Ref<>(), new Ref<>());
     else if (ctx.TIGHTER() != null) return new OpDecl.BindBlock(sourcePosOf(ctx), new Ref<>(),
-      ImmutableSeq.empty(), visitQIdsComma(ctx.qIdsComma()));
+      ImmutableSeq.empty(), visitQIdsComma(ctx.qIdsComma()), new Ref<>(), new Ref<>());
     else return new OpDecl.BindBlock(sourcePosOf(ctx), new Ref<>(),
-        visitLoosers(ctx.loosers()), visitTighters(ctx.tighters()));
+        visitLoosers(ctx.loosers()), visitTighters(ctx.tighters()), new Ref<>(), new Ref<>());
   }
 
   public @NotNull ImmutableSeq<QualifiedID> visitLoosers(List<AyaParser.LoosersContext> ctx) {

--- a/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
+++ b/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
@@ -139,23 +139,26 @@ public final class AyaProducer {
 
   public OpDecl.@NotNull BindBlock visitBind(AyaParser.BindBlockContext ctx) {
     if (ctx.LOOSER() != null) return new OpDecl.BindBlock(sourcePosOf(ctx), new Ref<>(),
-      visitQIdsComma(ctx.qIdsComma()), ImmutableSeq.empty(), new Ref<>(), new Ref<>());
+      visitQIdsComma(ctx.qIdsComma()).collect(ImmutableSeq.factory()), ImmutableSeq.empty(),
+      new Ref<>(), new Ref<>());
     else if (ctx.TIGHTER() != null) return new OpDecl.BindBlock(sourcePosOf(ctx), new Ref<>(),
-      ImmutableSeq.empty(), visitQIdsComma(ctx.qIdsComma()), new Ref<>(), new Ref<>());
+      ImmutableSeq.empty(), visitQIdsComma(ctx.qIdsComma()).collect(ImmutableSeq.factory()),
+      new Ref<>(), new Ref<>());
     else return new OpDecl.BindBlock(sourcePosOf(ctx), new Ref<>(),
-        visitLoosers(ctx.loosers()), visitTighters(ctx.tighters()), new Ref<>(), new Ref<>());
+        visitLoosers(ctx.loosers()), visitTighters(ctx.tighters()),
+        new Ref<>(), new Ref<>());
   }
 
   public @NotNull ImmutableSeq<QualifiedID> visitLoosers(List<AyaParser.LoosersContext> ctx) {
-    return ctx.stream().flatMap(c -> visitQIdsComma(c.qIdsComma()).stream()).collect(ImmutableSeq.factory());
+    return ctx.stream().flatMap(c -> visitQIdsComma(c.qIdsComma())).collect(ImmutableSeq.factory());
   }
 
   public @NotNull ImmutableSeq<QualifiedID> visitTighters(List<AyaParser.TightersContext> ctx) {
-    return ctx.stream().flatMap(c -> visitQIdsComma(c.qIdsComma()).stream()).collect(ImmutableSeq.factory());
+    return ctx.stream().flatMap(c -> visitQIdsComma(c.qIdsComma())).collect(ImmutableSeq.factory());
   }
 
-  public @NotNull ImmutableSeq<QualifiedID> visitQIdsComma(AyaParser.QIdsCommaContext ctx) {
-    return ctx.qualifiedId().stream().map(this::visitQualifiedId).collect(ImmutableSeq.factory());
+  public @NotNull Stream<QualifiedID> visitQIdsComma(AyaParser.QIdsCommaContext ctx) {
+    return ctx.qualifiedId().stream().map(this::visitQualifiedId);
   }
 
   public @NotNull Sample visitSample(AyaParser.SampleContext ctx) {
@@ -214,7 +217,7 @@ public final class AyaProducer {
       visitTelescope(ctx.tele()),
       type(ctx.type(), sourcePosOf(ctx)),
       visitFnBody(ctx.fnBody()),
-      bind == null ? null : visitBind(bind)
+      bind == null ? OpDecl.BindBlock.EMPTY : visitBind(bind)
     );
   }
 
@@ -552,7 +555,7 @@ public final class AyaProducer {
       visitTelescope(ctx.tele()),
       type(ctx.type(), sourcePosOf(ctx)),
       body,
-      bind == null ? null : visitBind(bind)
+      bind == null ? OpDecl.BindBlock.EMPTY : visitBind(bind)
     );
     return Tuple2.of(data, ctx.OPEN() == null ? ImmutableSeq.empty() : ImmutableSeq.of(
       new Command.Open(
@@ -589,7 +592,7 @@ public final class AyaProducer {
       visitClauses(ctx.clauses()),
       patterns,
       ctx.COERCE() != null,
-      bind == null ? null : visitBind(bind)
+      bind == null ? OpDecl.BindBlock.EMPTY : visitBind(bind)
     );
   }
 
@@ -696,7 +699,7 @@ public final class AyaProducer {
       type(ctx.type(), sourcePosOf(ctx)),
       // ctx.ids(),
       fields,
-      bind == null ? null : visitBind(bind)
+      bind == null ? OpDecl.BindBlock.EMPTY : visitBind(bind)
     );
   }
 
@@ -722,7 +725,7 @@ public final class AyaProducer {
       Option.of(ctx.expr()).map(this::visitExpr),
       ImmutableSeq.empty(),
       false,
-      bind == null ? null : visitBind(bind)
+      bind == null ? OpDecl.BindBlock.EMPTY : visitBind(bind)
     );
   }
 
@@ -740,7 +743,7 @@ public final class AyaProducer {
       Option.none(),
       visitClauses(ctx.clauses()),
       ctx.COERCE() != null,
-      bind == null ? null : visitBind(bind)
+      bind == null ? OpDecl.BindBlock.EMPTY : visitBind(bind)
     );
   }
 

--- a/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
+++ b/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
@@ -579,7 +579,7 @@ public final class AyaProducer {
   public Decl.DataCtor visitDataCtor(@NotNull ImmutableSeq<Pattern> patterns, AyaParser.DataCtorContext ctx) {
     var telescope = visitTelescope(ctx.tele());
     var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix());
-
+    var bind = ctx.bindBlock();
     return new Decl.DataCtor(
       sourcePosOf(ctx.declNameOrInfix()),
       sourcePosOf(ctx),
@@ -588,7 +588,8 @@ public final class AyaProducer {
       telescope,
       visitClauses(ctx.clauses()),
       patterns,
-      ctx.COERCE() != null
+      ctx.COERCE() != null,
+      bind == null ? null : visitBind(bind)
     );
   }
 
@@ -710,6 +711,7 @@ public final class AyaProducer {
   public Decl.StructField visitFieldImpl(AyaParser.FieldImplContext ctx) {
     var telescope = visitTelescope(ctx.tele());
     var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix());
+    var bind = ctx.bindBlock();
     return new Decl.StructField(
       sourcePosOf(ctx.declNameOrInfix()),
       sourcePosOf(ctx),
@@ -719,13 +721,15 @@ public final class AyaProducer {
       type(ctx.type(), sourcePosOf(ctx)),
       Option.of(ctx.expr()).map(this::visitExpr),
       ImmutableSeq.empty(),
-      false
+      false,
+      bind == null ? null : visitBind(bind)
     );
   }
 
   public Decl.StructField visitFieldDecl(AyaParser.FieldDeclContext ctx) {
     var telescope = visitTelescope(ctx.tele());
     var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix());
+    var bind = ctx.bindBlock();
     return new Decl.StructField(
       sourcePosOf(ctx.declNameOrInfix()),
       sourcePosOf(ctx),
@@ -735,7 +739,8 @@ public final class AyaProducer {
       type(ctx.type(), sourcePosOf(ctx)),
       Option.none(),
       visitClauses(ctx.clauses()),
-      ctx.COERCE() != null
+      ctx.COERCE() != null,
+      bind == null ? null : visitBind(bind)
     );
   }
 

--- a/base/src/main/java/org/aya/concrete/resolve/module/FileModuleLoader.java
+++ b/base/src/main/java/org/aya/concrete/resolve/module/FileModuleLoader.java
@@ -84,9 +84,7 @@ public record FileModuleLoader(
     var shallowResolver = new StmtShallowResolver(recurseLoader, shallowResolveInfo);
     program.forEach(s -> s.accept(shallowResolver, context));
     var resolveInfo = new ResolveInfo(new BinOpSet(reporter));
-    program.forEach(s -> s.resolve(resolveInfo));
-    resolveInfo.opSet().reportIfCyclic();
-    program.forEach(s -> s.desugar(reporter, resolveInfo.opSet()));
+    Stmt.resolve(program, resolveInfo);
     var delayedReporter = new DelayedReporter(reporter);
     var sccTycker = new IncrementalTycker(new SCCTycker(builder, delayedReporter), resolveInfo);
     // in case we have un-messaged TyckException

--- a/base/src/main/java/org/aya/concrete/resolve/visitor/BindResolver.java
+++ b/base/src/main/java/org/aya/concrete/resolve/visitor/BindResolver.java
@@ -1,0 +1,104 @@
+// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.concrete.resolve.visitor;
+
+import kala.tuple.Unit;
+import org.aya.api.ref.DefVar;
+import org.aya.concrete.desugar.BinOpSet;
+import org.aya.concrete.remark.Remark;
+import org.aya.concrete.resolve.ResolveInfo;
+import org.aya.concrete.resolve.context.Context;
+import org.aya.concrete.resolve.error.UnknownOperatorError;
+import org.aya.concrete.stmt.*;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Resolve bind blocks, after {@link StmtResolver}
+ *
+ * @author kiva
+ */
+public final class BindResolver implements Stmt.Visitor<ResolveInfo, Unit> {
+  public static final @NotNull BindResolver INSTANCE = new BindResolver();
+
+  private BindResolver() {
+  }
+
+  @Override public Unit visitModule(Command.@NotNull Module mod, ResolveInfo info) {
+    visitAll(mod.contents(), info);
+    return Unit.unit();
+  }
+
+  @Override public Unit visitImport(Command.@NotNull Import cmd, ResolveInfo info) {
+    return Unit.unit();
+  }
+
+  @Override public Unit visitOpen(Command.@NotNull Open cmd, ResolveInfo info) {
+    return Unit.unit();
+  }
+
+  public void visitBind(@NotNull OpDecl self, OpDecl.@NotNull BindBlock bind, ResolveInfo info) {
+    if (bind == OpDecl.BindBlock.EMPTY) return;
+    var ctx = bind.context().value;
+    assert ctx != null : "no shallow resolver?";
+    var opSet = info.opSet();
+    bind.resolvedLoosers().value = bind.loosers().map(looser -> bind(self, opSet, ctx, OpDecl.BindPred.Looser, looser));
+    bind.resolvedTighters().value = bind.tighters().map(tighter -> bind(self, opSet, ctx, OpDecl.BindPred.Tighter, tighter));
+  }
+
+  private @NotNull DefVar<?, ?> bind(@NotNull OpDecl self, @NotNull BinOpSet opSet, @NotNull Context ctx,
+                                     @NotNull OpDecl.BindPred pred, @NotNull QualifiedID id) {
+    var var = ctx.get(id);
+    if (var instanceof DefVar<?, ?> defVar && defVar.concrete instanceof OpDecl op) {
+      opSet.bind(self, pred, op, id.sourcePos());
+      return defVar;
+    } else {
+      opSet.reporter().report(new UnknownOperatorError(id.sourcePos(), id.join()));
+      throw new Context.ResolvingInterruptedException();
+    }
+  }
+
+  @Override public Unit visitCtor(@NotNull Decl.DataCtor ctor, ResolveInfo info) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public Unit visitField(@NotNull Decl.StructField field, ResolveInfo info) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public Unit visitData(Decl.@NotNull DataDecl decl, ResolveInfo info) {
+    decl.body.forEach(ctor -> visitBind(ctor, ctor.bindBlock, info));
+    visitBind(decl, decl.bindBlock, info);
+    return Unit.unit();
+  }
+
+  @Override public Unit visitStruct(Decl.@NotNull StructDecl decl, ResolveInfo info) {
+    decl.fields.forEach(field -> visitBind(field, field.bindBlock, info));
+    visitBind(decl, decl.bindBlock, info);
+    return Unit.unit();
+  }
+
+  @Override public Unit visitFn(Decl.@NotNull FnDecl decl, ResolveInfo info) {
+    visitBind(decl, decl.bindBlock, info);
+    return Unit.unit();
+  }
+
+  @Override public Unit visitPrim(@NotNull Decl.PrimDecl decl, ResolveInfo info) {
+    return Unit.unit();
+  }
+
+  @Override public Unit visitLevels(Generalize.@NotNull Levels levels, ResolveInfo info) {
+    return Unit.unit();
+  }
+
+  @Override public Unit visitExample(Sample.@NotNull Working example, ResolveInfo info) {
+    return Unit.unit();
+  }
+
+  @Override public Unit visitCounterexample(Sample.@NotNull Counter example, ResolveInfo info) {
+    return Unit.unit();
+  }
+
+  @Override public Unit visitRemark(@NotNull Remark remark, ResolveInfo info) {
+    return Unit.unit();
+  }
+}

--- a/base/src/main/java/org/aya/concrete/resolve/visitor/BindResolver.java
+++ b/base/src/main/java/org/aya/concrete/resolve/visitor/BindResolver.java
@@ -47,8 +47,7 @@ public final class BindResolver implements Stmt.Visitor<ResolveInfo, Unit> {
 
   private @NotNull DefVar<?, ?> bind(@NotNull OpDecl self, @NotNull BinOpSet opSet, @NotNull Context ctx,
                                      @NotNull OpDecl.BindPred pred, @NotNull QualifiedID id) {
-    var var = ctx.get(id);
-    if (var instanceof DefVar<?, ?> defVar && defVar.concrete instanceof OpDecl op) {
+    if (ctx.get(id) instanceof DefVar<?, ?> defVar && defVar.concrete instanceof OpDecl op) {
       opSet.bind(self, pred, op, id.sourcePos());
       return defVar;
     } else {
@@ -91,11 +90,11 @@ public final class BindResolver implements Stmt.Visitor<ResolveInfo, Unit> {
   }
 
   @Override public Unit visitExample(Sample.@NotNull Working example, ResolveInfo info) {
-    return Unit.unit();
+    return example.delegate().accept(this, info);
   }
 
   @Override public Unit visitCounterexample(Sample.@NotNull Counter example, ResolveInfo info) {
-    return Unit.unit();
+    return example.delegate().accept(this, info);
   }
 
   @Override public Unit visitRemark(@NotNull Remark remark, ResolveInfo info) {

--- a/base/src/main/java/org/aya/concrete/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/concrete/resolve/visitor/StmtResolver.java
@@ -90,6 +90,7 @@ public final class StmtResolver implements Stmt.Visitor<ResolveInfo, Unit> {
       var ctorLocal = bodyResolver.resolveParams(ctor.telescope, localCtxWithPat.value);
       ctor.telescope = ctorLocal._1;
       ctor.clauses = ctor.clauses.map(clause -> PatResolver.INSTANCE.matchy(clause, ctorLocal._2, bodyResolver));
+      visitBind(ctor, ctor.bindBlock, info);
     }
     visitBind(decl, decl.bindBlock, info);
     info.declGraph().suc(decl).appendAll(reference);
@@ -109,6 +110,7 @@ public final class StmtResolver implements Stmt.Visitor<ResolveInfo, Unit> {
       field.result = field.result.accept(bodyResolver, fieldLocal._2);
       field.body = field.body.map(e -> e.accept(bodyResolver, fieldLocal._2));
       field.clauses = field.clauses.map(clause -> PatResolver.INSTANCE.matchy(clause, fieldLocal._2, bodyResolver));
+      visitBind(field, field.bindBlock, info);
     });
     visitBind(decl, decl.bindBlock, info);
     info.declGraph().suc(decl).appendAll(reference);

--- a/base/src/main/java/org/aya/concrete/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/concrete/resolve/visitor/StmtResolver.java
@@ -48,14 +48,15 @@ public final class StmtResolver implements Stmt.Visitor<ResolveInfo, Unit> {
     if (bind == null) return;
     var ctx = bind.context().value;
     assert ctx != null : "no shallow resolver?";
-    bind.loosers().forEach(looser -> bind(looser.sourcePos(), self, info.opSet(), ctx, OpDecl.BindPred.Looser, looser));
-    bind.tighters().forEach(tighter -> bind(tighter.sourcePos(), self, info.opSet(), ctx, OpDecl.BindPred.Tighter, tighter));
+    bind.resolvedLoosers().value = bind.loosers().map(looser -> bind(looser.sourcePos(), self, info.opSet(), ctx, OpDecl.BindPred.Looser, looser));
+    bind.resolvedTighters().value = bind.tighters().map(tighter -> bind(tighter.sourcePos(), self, info.opSet(), ctx, OpDecl.BindPred.Tighter, tighter));
   }
 
-  private void bind(@NotNull SourcePos sourcePos, @NotNull OpDecl self, @NotNull BinOpSet opSet, @NotNull Context ctx,
-                    @NotNull OpDecl.BindPred pred, @NotNull QualifiedID id) {
+  private @NotNull OpDecl bind(@NotNull SourcePos sourcePos, @NotNull OpDecl self, @NotNull BinOpSet opSet, @NotNull Context ctx,
+                               @NotNull OpDecl.BindPred pred, @NotNull QualifiedID id) {
     var target = resolveOp(opSet.reporter(), ctx, id);
     opSet.bind(self, pred, target, sourcePos);
+    return target;
   }
 
   private @NotNull OpDecl resolveOp(@NotNull Reporter reporter, @NotNull Context ctx, @NotNull QualifiedID id) {

--- a/base/src/main/java/org/aya/concrete/resolve/visitor/StmtShallowResolver.java
+++ b/base/src/main/java/org/aya/concrete/resolve/visitor/StmtShallowResolver.java
@@ -141,12 +141,14 @@ public record StmtShallowResolver(
   @Override public Unit visitCtor(@NotNull Decl.DataCtor ctor, @NotNull ModuleContext context) {
     ctor.ref().module = context.moduleName();
     context.addGlobalSimple(Stmt.Accessibility.Public, ctor.ref, ctor.sourcePos);
+    visitBind(ctor.bindBlock, context);
     return Unit.unit();
   }
 
   @Override public Unit visitField(@NotNull Decl.StructField field, @NotNull ModuleContext context) {
     field.ref().module = context.moduleName();
     context.addGlobalSimple(Stmt.Accessibility.Public, field.ref, field.sourcePos);
+    visitBind(field.bindBlock, context);
     return Unit.unit();
   }
 }

--- a/base/src/main/java/org/aya/concrete/resolve/visitor/StmtShallowResolver.java
+++ b/base/src/main/java/org/aya/concrete/resolve/visitor/StmtShallowResolver.java
@@ -54,9 +54,8 @@ public record StmtShallowResolver(
     return Unit.unit();
   }
 
-  public Unit visitBind(OpDecl.@Nullable BindBlock bind, @NotNull ModuleContext context) {
-    if (bind != null) bind.context().value = context;
-    return Unit.unit();
+  public void visitBind(OpDecl.@NotNull BindBlock bind, @NotNull ModuleContext context) {
+    if (bind != OpDecl.BindBlock.EMPTY) bind.context().value = context;
   }
 
   @Override public Unit visitRemark(@NotNull Remark remark, @NotNull ModuleContext context) {

--- a/base/src/main/java/org/aya/concrete/stmt/Command.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Command.java
@@ -3,45 +3,11 @@
 package org.aya.concrete.stmt;
 
 import kala.collection.immutable.ImmutableSeq;
-import kala.value.Ref;
 import org.aya.api.error.SourcePos;
-import org.aya.concrete.resolve.context.Context;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public sealed interface Command extends Stmt {
-  enum BindPred {
-    Tighter("tighter"),
-    Looser("looser");
-
-    public final @NotNull String keyword;
-
-    BindPred(@NotNull String keyword) {
-      this.keyword = keyword;
-    }
-  }
-
-  /**
-   * @author kiva
-   */
-  record Bind(
-    @Override @NotNull SourcePos sourcePos,
-    @NotNull QualifiedID op,
-    @NotNull BindPred pred,
-    @NotNull QualifiedID target,
-    @NotNull Ref<@Nullable Context> context,
-    @NotNull Ref<@Nullable OpDecl> resolvedOp,
-    @NotNull Ref<@Nullable OpDecl> resolvedTarget
-  ) implements Command {
-    @Override public @NotNull Accessibility accessibility() {
-      return Accessibility.Public;
-    }
-
-    @Override public <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p) {
-      return visitor.visitBind(this, p);
-    }
-  }
-
   /**
    * @author re-xyr
    */

--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -127,7 +127,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
     public @NotNull ImmutableSeq<Pattern.Clause> clauses;
     public @NotNull ImmutableSeq<Pattern> patterns;
     public final @Nullable OpDecl.OpInfo opInfo;
-    public final @Nullable OpDecl.BindBlock bindBlock;
+    public final @NotNull OpDecl.BindBlock bindBlock;
     public final boolean coerce;
 
     public DataCtor(
@@ -138,7 +138,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
       @NotNull ImmutableSeq<Pattern.Clause> clauses,
       @NotNull ImmutableSeq<Pattern> patterns,
       boolean coerce,
-      @Nullable OpDecl.BindBlock bindBlock
+      @NotNull OpDecl.BindBlock bindBlock
     ) {
       super(sourcePos, entireSourcePos, telescope);
       this.clauses = clauses;
@@ -169,7 +169,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
     public @NotNull Expr result;
     public final @NotNull ImmutableSeq<DataCtor> body;
     public final @Nullable OpDecl.OpInfo opInfo;
-    public final @Nullable OpDecl.BindBlock bindBlock;
+    public final @NotNull OpDecl.BindBlock bindBlock;
 
     public DataDecl(
       @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
@@ -179,7 +179,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
       @NotNull ImmutableSeq<Expr.Param> telescope,
       @NotNull Expr result,
       @NotNull ImmutableSeq<DataCtor> body,
-      @Nullable OpDecl.BindBlock bindBlock
+      @NotNull OpDecl.BindBlock bindBlock
     ) {
       super(sourcePos, entireSourcePos, accessibility, telescope);
       this.result = result;
@@ -213,7 +213,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
     public @NotNull
     final ImmutableSeq<StructField> fields;
     public final @Nullable OpDecl.OpInfo opInfo;
-    public final @Nullable OpDecl.BindBlock bindBlock;
+    public final @NotNull OpDecl.BindBlock bindBlock;
     public @NotNull Expr result;
 
     public StructDecl(
@@ -225,7 +225,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
       @NotNull Expr result,
       // @NotNull ImmutableSeq<String> superClassNames,
       @NotNull ImmutableSeq<StructField> fields,
-      @Nullable OpDecl.BindBlock bindBlock
+      @NotNull OpDecl.BindBlock bindBlock
     ) {
       super(sourcePos, entireSourcePos, accessibility, telescope);
       this.opInfo = opInfo;
@@ -255,7 +255,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
     public @NotNull ImmutableSeq<Pattern.Clause> clauses;
     public @NotNull Expr result;
     public final @Nullable OpDecl.OpInfo opInfo;
-    public final @Nullable OpDecl.BindBlock bindBlock;
+    public final @NotNull OpDecl.BindBlock bindBlock;
     public @NotNull Option<Expr> body;
 
     public final boolean coerce;
@@ -269,7 +269,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
       @NotNull Option<Expr> body,
       @NotNull ImmutableSeq<Pattern.Clause> clauses,
       boolean coerce,
-      @Nullable OpDecl.BindBlock bindBlock
+      @NotNull OpDecl.BindBlock bindBlock
     ) {
       super(sourcePos, entireSourcePos, telescope);
       this.coerce = coerce;
@@ -299,7 +299,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
   public static final class FnDecl extends Decl implements OpDecl {
     public final @NotNull EnumSet<Modifier> modifiers;
     public final @Nullable OpDecl.OpInfo opInfo;
-    public final @Nullable OpDecl.BindBlock bindBlock;
+    public final @NotNull OpDecl.BindBlock bindBlock;
     public final @NotNull DefVar<FnDef, FnDecl> ref;
     public @NotNull Expr result;
     public @NotNull Either<Expr, ImmutableSeq<Pattern.Clause>> body;
@@ -313,7 +313,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
       @NotNull ImmutableSeq<Expr.Param> telescope,
       @NotNull Expr result,
       @NotNull Either<Expr, ImmutableSeq<Pattern.Clause>> body,
-      @Nullable OpDecl.BindBlock bindBlock
+      @NotNull OpDecl.BindBlock bindBlock
     ) {
       super(sourcePos, entireSourcePos, accessibility, telescope);
       this.modifiers = modifiers;

--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -127,6 +127,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
     public @NotNull ImmutableSeq<Pattern.Clause> clauses;
     public @NotNull ImmutableSeq<Pattern> patterns;
     public final @Nullable OpDecl.OpInfo opInfo;
+    public final @Nullable OpDecl.BindBlock bindBlock;
     public final boolean coerce;
 
     public DataCtor(
@@ -136,7 +137,8 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
       @NotNull ImmutableSeq<Expr.Param> telescope,
       @NotNull ImmutableSeq<Pattern.Clause> clauses,
       @NotNull ImmutableSeq<Pattern> patterns,
-      boolean coerce
+      boolean coerce,
+      @Nullable OpDecl.BindBlock bindBlock
     ) {
       super(sourcePos, entireSourcePos, telescope);
       this.clauses = clauses;
@@ -144,6 +146,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
       this.coerce = coerce;
       this.patterns = patterns;
       this.ref = DefVar.concrete(this, name);
+      this.bindBlock = bindBlock;
     }
 
     @Override public @NotNull DefVar<CtorDef, DataCtor> ref() {
@@ -252,6 +255,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
     public @NotNull ImmutableSeq<Pattern.Clause> clauses;
     public @NotNull Expr result;
     public final @Nullable OpDecl.OpInfo opInfo;
+    public final @Nullable OpDecl.BindBlock bindBlock;
     public @NotNull Option<Expr> body;
 
     public final boolean coerce;
@@ -264,7 +268,8 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
       @NotNull Expr result,
       @NotNull Option<Expr> body,
       @NotNull ImmutableSeq<Pattern.Clause> clauses,
-      boolean coerce
+      boolean coerce,
+      @Nullable OpDecl.BindBlock bindBlock
     ) {
       super(sourcePos, entireSourcePos, telescope);
       this.coerce = coerce;
@@ -273,6 +278,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
       this.body = body;
       this.opInfo = opInfo;
       this.ref = DefVar.concrete(this, name);
+      this.bindBlock = bindBlock;
     }
 
     @Override public @NotNull DefVar<? extends Def, StructField> ref() {

--- a/base/src/main/java/org/aya/concrete/stmt/OpDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/OpDecl.java
@@ -34,6 +34,7 @@ public interface OpDecl {
     @NotNull Ref<ImmutableSeq<DefVar<?, ?>>> resolvedLoosers,
     @NotNull Ref<ImmutableSeq<DefVar<?, ?>>> resolvedTighters
   ) {
+    public static final BindBlock EMPTY = new BindBlock(SourcePos.NONE, new Ref<>(), ImmutableSeq.empty(), ImmutableSeq.empty(), new Ref<>(), new Ref<>());
   }
 
   @Nullable OpInfo opInfo();

--- a/base/src/main/java/org/aya/concrete/stmt/OpDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/OpDecl.java
@@ -5,6 +5,7 @@ package org.aya.concrete.stmt;
 import kala.collection.immutable.ImmutableSeq;
 import kala.value.Ref;
 import org.aya.api.error.SourcePos;
+import org.aya.api.ref.DefVar;
 import org.aya.api.util.Assoc;
 import org.aya.concrete.resolve.context.Context;
 import org.jetbrains.annotations.NotNull;
@@ -30,8 +31,8 @@ public interface OpDecl {
     @NotNull Ref<@Nullable Context> context,
     @NotNull ImmutableSeq<QualifiedID> loosers,
     @NotNull ImmutableSeq<QualifiedID> tighters,
-    @NotNull Ref<ImmutableSeq<OpDecl>> resolvedLoosers,
-    @NotNull Ref<ImmutableSeq<OpDecl>> resolvedTighters
+    @NotNull Ref<ImmutableSeq<DefVar<?, ?>>> resolvedLoosers,
+    @NotNull Ref<ImmutableSeq<DefVar<?, ?>>> resolvedTighters
   ) {
   }
 

--- a/base/src/main/java/org/aya/concrete/stmt/OpDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/OpDecl.java
@@ -2,13 +2,41 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.stmt;
 
+import kala.collection.immutable.ImmutableSeq;
+import kala.value.Ref;
+import org.aya.api.error.SourcePos;
 import org.aya.api.util.Assoc;
+import org.aya.concrete.resolve.context.Context;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface OpDecl {
-  @Nullable Operator getOperator();
+  enum BindPred {
+    Tighter("tighter"),
+    Looser("looser");
 
-  record Operator(@NotNull String name, @NotNull Assoc assoc) {
+    public final @NotNull String keyword;
+
+    BindPred(@NotNull String keyword) {
+      this.keyword = keyword;
+    }
   }
+
+  /**
+   * @author kiva
+   */
+  record BindBlock(
+    @Override @NotNull SourcePos sourcePos,
+    @NotNull Ref<@Nullable Context> context,
+    @NotNull ImmutableSeq<QualifiedID> loosers,
+    @NotNull ImmutableSeq<QualifiedID> tighters
+  ) {
+  }
+
+  @Nullable OpInfo opInfo();
+
+  record OpInfo(@NotNull String name, @NotNull Assoc assoc) {
+  }
+
+  @NotNull OpDecl APPLICATION = () -> new OpInfo("application", Assoc.InfixL);
 }

--- a/base/src/main/java/org/aya/concrete/stmt/OpDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/OpDecl.java
@@ -29,7 +29,9 @@ public interface OpDecl {
     @Override @NotNull SourcePos sourcePos,
     @NotNull Ref<@Nullable Context> context,
     @NotNull ImmutableSeq<QualifiedID> loosers,
-    @NotNull ImmutableSeq<QualifiedID> tighters
+    @NotNull ImmutableSeq<QualifiedID> tighters,
+    @NotNull Ref<ImmutableSeq<OpDecl>> resolvedLoosers,
+    @NotNull Ref<ImmutableSeq<OpDecl>> resolvedTighters
   ) {
   }
 

--- a/base/src/main/java/org/aya/concrete/stmt/Stmt.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Stmt.java
@@ -53,7 +53,6 @@ public sealed interface Stmt extends AyaDocile
     R visitImport(@NotNull Command.Import cmd, P p);
     R visitOpen(@NotNull Command.Open cmd, P p);
     R visitModule(@NotNull Command.Module mod, P p);
-    R visitBind(@NotNull Command.Bind bind, P p);
     R visitRemark(@NotNull Remark remark, P p);
     R visitLevels(@NotNull Generalize.Levels levels, P p);
     R visitExample(@NotNull Sample.Working example, P p);

--- a/base/src/main/java/org/aya/concrete/stmt/Stmt.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Stmt.java
@@ -12,6 +12,7 @@ import org.aya.concrete.desugar.BinOpSet;
 import org.aya.concrete.desugar.Desugarer;
 import org.aya.concrete.remark.Remark;
 import org.aya.concrete.resolve.ResolveInfo;
+import org.aya.concrete.resolve.visitor.BindResolver;
 import org.aya.concrete.resolve.visitor.StmtResolver;
 import org.aya.distill.ConcreteDistiller;
 import org.aya.pretty.doc.Doc;
@@ -31,6 +32,7 @@ public sealed interface Stmt extends AyaDocile
   @Contract(mutates = "this")
   default void resolve(@NotNull ResolveInfo resolveInfo) {
     accept(StmtResolver.INSTANCE, resolveInfo);
+    accept(BindResolver.INSTANCE, resolveInfo);
   }
 
   default void desugar(@NotNull Reporter reporter, @NotNull BinOpSet opSet) {

--- a/base/src/main/java/org/aya/concrete/visitor/StmtConsumer.java
+++ b/base/src/main/java/org/aya/concrete/visitor/StmtConsumer.java
@@ -21,7 +21,6 @@ public interface StmtConsumer<P> extends Stmt.Visitor<P, Unit>, ExprConsumer<P>,
 
   default void visitDecl(@NotNull Decl decl, P pp) {
     visitSignatured(decl, pp);
-    decl.abuseBlock.forEach(stmt -> stmt.accept(this, pp));
   }
 
   default void visitClause(@NotNull Pattern.Clause c, P pp) {
@@ -87,9 +86,6 @@ public interface StmtConsumer<P> extends Stmt.Visitor<P, Unit>, ExprConsumer<P>,
     return Unit.unit();
   }
 
-  @Override default Unit visitBind(Command.@NotNull Bind bind, P p) {
-    return Unit.unit();
-  }
   @Override default Unit visitRemark(@NotNull Remark remark, P p) {
     if (remark.literate != null) remark.literate.visit(this, p);
     return Unit.unit();

--- a/base/src/main/java/org/aya/concrete/visitor/StmtFixpoint.java
+++ b/base/src/main/java/org/aya/concrete/visitor/StmtFixpoint.java
@@ -23,7 +23,6 @@ public interface StmtFixpoint<P> extends ExprFixpoint<P>, Stmt.Visitor<P, Unit> 
 
   default void visitDecl(@NotNull Decl decl, P pp) {
     visitSignatured(decl, pp);
-    decl.abuseBlock.forEach(stmt -> stmt.accept(this, pp));
   }
 
   default @NotNull Pattern.Clause visitClause(@NotNull Pattern.Clause c, P pp) {
@@ -82,10 +81,6 @@ public interface StmtFixpoint<P> extends ExprFixpoint<P>, Stmt.Visitor<P, Unit> 
     field.result = field.result.accept(this, p);
     field.clauses = field.clauses.map(clause -> visitClause(clause, p));
     field.body = field.body.map(expr -> expr.accept(this, p));
-    return Unit.unit();
-  }
-
-  @Override default Unit visitBind(Command.@NotNull Bind bind, P p) {
     return Unit.unit();
   }
 

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -23,7 +23,6 @@ import org.aya.generic.Modifier;
 import org.aya.pretty.doc.Doc;
 import org.aya.util.StringEscapeUtil;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -364,8 +363,8 @@ public class ConcreteDistiller extends BaseDistiller implements
     );
   }
 
-  public Doc visitBindBlock(@Nullable OpDecl.BindBlock bindBlock) {
-    if (bindBlock == null) return Doc.empty();
+  public Doc visitBindBlock(@NotNull OpDecl.BindBlock bindBlock) {
+    if (bindBlock == OpDecl.BindBlock.EMPTY) return Doc.empty();
     var loosers = bindBlock.resolvedLoosers().value;
     var tighters = bindBlock.resolvedTighters().value;
     if (loosers.isEmpty() && tighters.isEmpty()) return Doc.empty();

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -377,8 +377,8 @@ public class ConcreteDistiller extends BaseDistiller implements
       Doc.styled(KEYWORD, "bind"), Doc.styled(KEYWORD, "looser"),
       Doc.commaList(loosers.view().map(BaseDistiller::visitDefVar)))));
     return Doc.cat(Doc.line(), Doc.hang(2, Doc.cat(Doc.styled(KEYWORD, "bind"), Doc.braced(Doc.sep(
-      Doc.styled(KEYWORD, "tighter"), Doc.ONE_WS, Doc.commaList(tighters.view().map(BaseDistiller::visitDefVar)),
-      Doc.styled(KEYWORD, "looser"), Doc.ONE_WS, Doc.commaList(loosers.view().map(BaseDistiller::visitDefVar))
+      Doc.styled(KEYWORD, "tighter"), Doc.commaList(tighters.view().map(BaseDistiller::visitDefVar)),
+      Doc.styled(KEYWORD, "looser"), Doc.commaList(loosers.view().map(BaseDistiller::visitDefVar))
     )))));
   }
 

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -370,15 +370,15 @@ public class ConcreteDistiller extends BaseDistiller implements
     var tighters = bindBlock.resolvedTighters().value;
     if (loosers.isEmpty() && tighters.isEmpty()) return Doc.empty();
 
-    if (loosers.isEmpty()) return Doc.cat(Doc.line(), Doc.hang(2, Doc.cat(
-      Doc.styled(KEYWORD, "bind"), Doc.ONE_WS, Doc.styled(KEYWORD, "tighter"), Doc.ONE_WS,
+    if (loosers.isEmpty()) return Doc.cat(Doc.line(), Doc.hang(2, Doc.sep(
+      Doc.styled(KEYWORD, "bind"), Doc.styled(KEYWORD, "tighter"),
       Doc.commaList(tighters.view().map(BaseDistiller::visitDefVar)))));
-    else if (tighters.isEmpty()) return Doc.cat(Doc.line(), Doc.hang(2, Doc.cat(
-      Doc.styled(KEYWORD, "bind"), Doc.ONE_WS, Doc.styled(KEYWORD, "looser"), Doc.ONE_WS,
+    else if (tighters.isEmpty()) return Doc.cat(Doc.line(), Doc.hang(2, Doc.sep(
+      Doc.styled(KEYWORD, "bind"), Doc.styled(KEYWORD, "looser"),
       Doc.commaList(loosers.view().map(BaseDistiller::visitDefVar)))));
-    return Doc.cat(Doc.line(), Doc.hang(2, Doc.cat(Doc.styled(KEYWORD, "bind"), Doc.braced(Doc.cat(Doc.ONE_WS,
-      Doc.styled(KEYWORD, "tighter"), Doc.ONE_WS, Doc.commaList(tighters.view().map(BaseDistiller::visitDefVar)), Doc.ONE_WS,
-      Doc.styled(KEYWORD, "looser"), Doc.ONE_WS, Doc.commaList(loosers.view().map(BaseDistiller::visitDefVar)), Doc.ONE_WS
+    return Doc.cat(Doc.line(), Doc.hang(2, Doc.cat(Doc.styled(KEYWORD, "bind"), Doc.braced(Doc.sep(
+      Doc.styled(KEYWORD, "tighter"), Doc.ONE_WS, Doc.commaList(tighters.view().map(BaseDistiller::visitDefVar)),
+      Doc.styled(KEYWORD, "looser"), Doc.ONE_WS, Doc.commaList(loosers.view().map(BaseDistiller::visitDefVar))
     )))));
   }
 

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -275,15 +275,6 @@ public class ConcreteDistiller extends BaseDistiller implements
     );
   }
 
-  @Override public Doc visitBind(Command.@NotNull Bind bind, Unit unit) {
-    return Doc.sep(
-      Doc.styled(KEYWORD, "bind"),
-      Doc.plain(bind.op().join()),
-      Doc.styled(KEYWORD, bind.pred().keyword),
-      Doc.plain(bind.target().join())
-    );
-  }
-
   @Override public Doc visitRemark(@NotNull Remark remark, Unit unit) {
     var literate = remark.literate;
     return literate != null ? literate.toDoc() : Doc.plain(remark.raw);
@@ -365,8 +356,7 @@ public class ConcreteDistiller extends BaseDistiller implements
     appendResult(prelude, decl.result);
     return Doc.cat(Doc.sepNonEmpty(prelude),
       decl.body.fold(expr -> Doc.cat(Doc.ONE_WS, Doc.symbol("=>"), Doc.ONE_WS, expr.accept(this, Outer.Free)),
-        clauses -> Doc.cat(Doc.line(), Doc.nest(2, visitClauses(clauses, false)))),
-      Doc.emptyIf(decl.abuseBlock.isEmpty(), () -> Doc.cat(Doc.ONE_WS, Doc.styled(KEYWORD, "abusing"), Doc.ONE_WS, visitAbuse(decl.abuseBlock)))
+        clauses -> Doc.cat(Doc.line(), Doc.nest(2, visitClauses(clauses, false))))
     );
   }
 
@@ -379,10 +369,6 @@ public class ConcreteDistiller extends BaseDistiller implements
       case Inline -> "inline";
       case Erase -> "erase";
     });
-  }
-
-  private Doc visitAbuse(@NotNull ImmutableSeq<Stmt> block) {
-    return Doc.vcat(block.view().map(stmt -> stmt.accept(this, Unit.unit())));
   }
 
   @Override public Doc visitLevels(Generalize.@NotNull Levels levels, Unit unit) {

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -202,7 +202,7 @@ public class CoreDistiller extends BaseDistiller implements
     @NotNull DefVar<?, ?> var, @NotNull Style style,
     @NotNull SeqLike<@NotNull Arg<@NotNull Term>> args, Outer outer
   ) {
-    return visitCalls(var.concrete instanceof OpDecl decl && decl.getOperator() != null,
+    return visitCalls(var.concrete instanceof OpDecl decl && decl.opInfo() != null,
       linkRef(var, style), args.view(), outer);
   }
 

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -6,6 +6,7 @@ import kala.collection.Seq;
 import kala.collection.immutable.ImmutableMap;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.DynamicSeq;
+import kala.collection.mutable.MutableLinkedHashMap;
 import kala.collection.mutable.MutableMap;
 import kala.tuple.Tuple;
 import kala.tuple.Tuple2;
@@ -41,7 +42,6 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -56,7 +56,7 @@ public final class ExprTycker {
   public final @Nullable Trace.Builder traceBuilder;
   public final @NotNull TyckState state = new TyckState();
   public final @NotNull Sort.LvlVar universe = new Sort.LvlVar("u", null);
-  public final @NotNull MutableMap<PreLevelVar, Sort.LvlVar> levelMapping = MutableMap.wrapJava(new LinkedHashMap<>());
+  public final @NotNull MutableMap<PreLevelVar, Sort.LvlVar> levelMapping = MutableLinkedHashMap.of();
 
   private void tracing(@NotNull Consumer<Trace.@NotNull Builder> consumer) {
     if (traceBuilder != null) consumer.accept(traceBuilder);

--- a/base/src/main/java/org/aya/tyck/LocalCtx.java
+++ b/base/src/main/java/org/aya/tyck/LocalCtx.java
@@ -4,6 +4,7 @@ package org.aya.tyck;
 
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.DynamicSeq;
+import kala.collection.mutable.MutableLinkedHashMap;
 import kala.collection.mutable.MutableMap;
 import kala.tuple.Tuple2;
 import org.aya.api.error.SourcePos;
@@ -18,7 +19,6 @@ import org.jetbrains.annotations.Debug;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.LinkedHashMap;
 import java.util.function.Supplier;
 
 /**
@@ -27,8 +27,7 @@ import java.util.function.Supplier;
 @Debug.Renderer(hasChildren = "true", childrenArray = "extract().toArray()")
 public record LocalCtx(@NotNull MutableMap<LocalVar, Term> localMap, @Nullable LocalCtx parent) {
   public LocalCtx() {
-    // See https://github.com/Glavo/kala-common/issues/41
-    this(MutableMap.wrapJava(new LinkedHashMap<>()), null);
+    this(MutableLinkedHashMap.of(), null);
   }
 
   public @NotNull Tuple2<CallTerm.Hole, Term> freshHole(@NotNull Term type, @NotNull SourcePos sourcePos) {
@@ -84,6 +83,6 @@ public record LocalCtx(@NotNull MutableMap<LocalVar, Term> localMap, @Nullable L
   }
 
   @Contract(" -> new") public @NotNull LocalCtx derive() {
-    return new LocalCtx(MutableMap.wrapJava(new LinkedHashMap<>()), this);
+    return new LocalCtx(MutableLinkedHashMap.of(), this);
   }
 }

--- a/base/src/main/java/org/aya/tyck/order/SigRefFinder.java
+++ b/base/src/main/java/org/aya/tyck/order/SigRefFinder.java
@@ -75,10 +75,6 @@ public class SigRefFinder implements
     return Unit.unit();
   }
 
-  @Override public Unit visitBind(Command.@NotNull Bind bind, @NotNull DynamicSeq<Stmt> stmts) {
-    return Unit.unit();
-  }
-
   @Override public Unit visitLevels(Generalize.@NotNull Levels levels, @NotNull DynamicSeq<Stmt> stmts) {
     return Unit.unit();
   }

--- a/base/src/test/java/org/aya/concrete/DesugarTest.java
+++ b/base/src/test/java/org/aya/concrete/DesugarTest.java
@@ -45,7 +45,7 @@ public class DesugarTest {
 
   private void desugarAndPretty(@NotNull @NonNls @Language("TEXT") String code, @NotNull @NonNls @Language("TEXT") String pretty) {
     var stmt = ParseTest.parseStmt(code);
-    stmt.forEach(s -> s.desugar(ThrowingReporter.INSTANCE, new BinOpSet(ThrowingReporter.INSTANCE)));
+    stmt.forEach(s -> s.desugar(new BinOpSet(ThrowingReporter.INSTANCE)));
     assertEquals(pretty.trim(), Doc.vcat(stmt.view()
         .map(s -> s.toDoc(DistillerOptions.debug())))
       .debugRender()

--- a/base/src/test/java/org/aya/concrete/ParseTest.java
+++ b/base/src/test/java/org/aya/concrete/ParseTest.java
@@ -307,8 +307,6 @@ public class ParseTest {
   }
 
   @Test public void globalStmt() {
-    parseAndPretty("bind + tighter =", "bind + tighter =");
-    parseAndPretty("bind + tighter application", "bind + tighter application");
     parseAndPretty("universe uu", "universe uu");
   }
 

--- a/base/src/test/java/org/aya/tyck/TyckDeclTest.java
+++ b/base/src/test/java/org/aya/tyck/TyckDeclTest.java
@@ -39,7 +39,7 @@ public class TyckDeclTest {
   private FnDef successTyckFn(@NotNull @NonNls @Language("TEXT") String code) {
     var decl = ParseTest.parseDecl(code)._1;
     decl.ctx = new EmptyContext(ThrowingReporter.INSTANCE).derive("decl");
-    prepareForTyck(ImmutableSeq.of(decl));
+    resolve(ImmutableSeq.of(decl));
     var def = tyck(decl, null);
     assertNotNull(def);
     assertTrue(def instanceof FnDef);
@@ -69,15 +69,12 @@ public class TyckDeclTest {
     var ssr = new StmtShallowResolver(new EmptyModuleLoader(), null);
     var ctx = new EmptyContext(ThrowingReporter.INSTANCE).derive("decl");
     decls.forEach(d -> d.accept(ssr, ctx));
-    prepareForTyck(decls);
+    resolve(decls);
     return decls;
   }
 
-  private static void prepareForTyck(@NotNull ImmutableSeq<Stmt> decls) {
-    var resolveInfo = new ResolveInfo(new BinOpSet(ThrowingReporter.INSTANCE));
-    decls.forEach(s -> s.resolve(resolveInfo));
-    resolveInfo.opSet().reportIfCyclic();
-    decls.forEach(stmt -> stmt.desugar(ThrowingReporter.INSTANCE, resolveInfo.opSet()));
+  private static void resolve(@NotNull ImmutableSeq<Stmt> decls) {
+    Stmt.resolve(decls, new ResolveInfo(new BinOpSet(ThrowingReporter.INSTANCE)));
   }
 
   public static @NotNull ImmutableSeq<Def> successTyckDecls(@Language("TEXT") @NonNls @NotNull String text) {

--- a/base/src/test/resources/failure/operator/cyclic.aya
+++ b/base/src/test/resources/failure/operator/cyclic.aya
@@ -1,10 +1,10 @@
 def infix a => a
+  bind tighter b
 def infix b => b
+  bind tighter c
 def infix c => c
+  bind tighter d
 def infix d => d
+  bind tighter b
 def infix e => e
 
-bind a tighter b
-bind b tighter c
-bind c tighter d
-bind d tighter b

--- a/base/src/test/resources/failure/operator/cyclic.aya.txt
+++ b/base/src/test/resources/failure/operator/cyclic.aya.txt
@@ -1,9 +1,9 @@
-In file $FILE:9:0 ->
+In file $FILE:6:15 ->
 
-  7 | bind a tighter b
-  8 | bind b tighter c
-  9 | bind c tighter d
-      ^--------------^
+  4 |   bind tighter c
+  5 | def infix c => c
+  6 |   bind tighter d
+                     ^^
 
 Error: Circular precedence found between b, c, d
 

--- a/base/src/test/resources/failure/operator/self-bind.aya
+++ b/base/src/test/resources/failure/operator/self-bind.aya
@@ -1,2 +1,2 @@
 def infix + : Type => +
-bind + looser +
+  bind looser +

--- a/base/src/test/resources/failure/operator/self-bind.aya.txt
+++ b/base/src/test/resources/failure/operator/self-bind.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:2:0 ->
+In file $FILE:2:14 ->
 
   1 | def infix + : Type => +
-  2 | bind + looser +
-      ^-------------^
+  2 |   bind looser +
+                    ^^
 
 Error: Self bind is not allowed
 

--- a/base/src/test/resources/failure/patterns/issues/issue681.aya
+++ b/base/src/test/resources/failure/patterns/issues/issue681.aya
@@ -23,8 +23,7 @@ def infix + (n m : Nat) : Nat
   | n, zero => n
   | suc m, n => suc (m + n)
   | m, suc n => suc (m + n)
-
-bind + tighter =
+  bind tighter =
 
 def +-assoc : Pi (x y z : Nat) -> x + (y + z) = (x + y) + z
   | zero, y, z => idp

--- a/base/src/test/resources/failure/patterns/issues/issue681.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues/issue681.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:30:4 ->
+In file $FILE:29:4 ->
 
-  28 | 
-  29 | def +-assoc : Pi (x y z : Nat) -> x + (y + z) = (x + y) + z
-  30 |   | zero, y, z => idp
+  27 | 
+  28 | def +-assoc : Pi (x y z : Nat) -> x + (y + z) = (x + y) + z
+  29 |   | zero, y, z => idp
            ^--^
 
 Error: There is no parameter for the pattern
@@ -13,11 +13,11 @@ Error: There is no parameter for the pattern
        (and in case it's a function type, you may want to move its parameters before
        the `:` in the signature)
 
-In file $FILE:31:4 ->
+In file $FILE:30:4 ->
 
-  29 | def +-assoc : Pi (x y z : Nat) -> x + (y + z) = (x + y) + z
-  30 |   | zero, y, z => idp
-  31 |   | suc x, y, z => pmap suc (+-assoc x y z)
+  28 | def +-assoc : Pi (x y z : Nat) -> x + (y + z) = (x + y) + z
+  29 |   | zero, y, z => idp
+  30 |   | suc x, y, z => pmap suc (+-assoc x y z)
            ^---^
 
 Error: There is no parameter for the pattern

--- a/base/src/test/resources/success/add-comm.aya
+++ b/base/src/test/resources/success/add-comm.aya
@@ -40,8 +40,7 @@ def infix + (a b : ℕ) : ℕ
  | a, zero => a
  | suc a, b => suc (a + b)
  | a, suc b => suc (a + b)
-
-bind + tighter =
+ bind tighter =
 
 def +-comm (a b : ℕ) : a + b = b + a
   | zero, a => idp

--- a/base/src/test/resources/success/assoc.aya
+++ b/base/src/test/resources/success/assoc.aya
@@ -58,22 +58,17 @@ def pmap {A B : Type} (f : A -> B) {a b : A} (p : a = b)
   : f a = f b => path (\ i => f (p.at i))
 
 def infixr >== {A : Type} {a b c : A} (p : a = b) (q : b = c) => p *> q
+  bind looser qed, ==<
 def infix  ==< {A : Type} (a : A) {b : A} (p : a = b) => p
 
 def infix qed {A : Type} (a : A) : a = a => idp a
-
-bind >== looser qed
-bind >== looser ==<
 
 -----------------------------------------
 
 def infix + (a b : Nat) : Nat
  | a, zero => a
  | a, suc b => suc (a + b)
-
-bind + tighter =
-bind + tighter ==<
-bind + tighter qed
+ bind tighter =, ==<, qed
 
 def +-comm (a b : Nat) : a + b = b + a
   | zero, zero => idp _

--- a/base/src/test/resources/success/issues/issue726.aya
+++ b/base/src/test/resources/success/issues/issue726.aya
@@ -16,8 +16,7 @@ def pmap {A B : Type} (f : A -> B) {a b : A} (p : a = b)
 
 def infix ∘ { A B C : Type } ( g : B -> C ) ( f : A -> B ) : A -> C
  => \ x => g (f x)
-
-bind ∘ tighter =
+  bind tighter =
 
 struct Isomorphism { A B : Type } : Type
   | to : A -> B

--- a/base/src/test/resources/success/issues/issue729.aya
+++ b/base/src/test/resources/success/issues/issue729.aya
@@ -16,8 +16,7 @@ def pmap {A B : Type} (f : A -> B) {a b : A} (p : a = b)
 
 def infix ∘ { A B C : Type } ( g : B -> C ) ( f : A -> B ) : A -> C
  => \ x => g (f x)
-
-bind ∘ tighter =
+  bind tighter =
 
 struct Isomorphism { A B : Type } : Type
   | to : A -> B

--- a/base/src/test/resources/success/issues2/issue14.aya
+++ b/base/src/test/resources/success/issues2/issue14.aya
@@ -38,8 +38,7 @@ def infix + (m n : Nat) : Nat
   | n, zero => n
   | suc m, n => suc (m + n)
   | m, suc n => suc (m + n)
-
-bind + tighter =
+  bind tighter =
 
 def +-comm (x y : Nat) : x + y = y + x
   | zero, n => idp
@@ -49,5 +48,4 @@ def flip (m n : Nat) : Nat =>
   (hcomp2d idp idp
     (path (\ i => (+-comm m n).at i))).at left
 
-bind + tighter =
 def err_eq (m n : Nat) : flip m n = n + m => idp

--- a/base/src/test/resources/success/issues2/issue158.aya
+++ b/base/src/test/resources/success/issues2/issue158.aya
@@ -30,8 +30,7 @@ def infix !! {A : Type} (l : List A) (i : Fin (length l)) : A
 def infix ++ {A : Type} (xs ys : List A) : List A
 | nil, ys => ys
 | cons a xs, ys => a cons xs ++ ys
-bind cons looser ++
-bind ++ tighter =
+bind { tighter =, cons }
 
 def ++-assoc {A : Type} {xs ys zs : List A} : (xs ++ ys) ++ zs = xs ++ (ys ++ zs)
   | {A}, {nil} => idp

--- a/base/src/test/resources/success/issues2/issue69.aya
+++ b/base/src/test/resources/success/issues2/issue69.aya
@@ -43,8 +43,7 @@ def infixl + (m n : Nat) : Nat
   | n, zero => n
   | suc m, n => suc (m + n)
   | m, suc n => suc (m + n)
-
-bind + tighter =
+  bind tighter =
 
 def +-comm (x y : Nat) : x + y = y + x
   | zero, n => idp n
@@ -58,14 +57,13 @@ def infixl * (m n : Nat) : Nat
   | zero, n => zero
   | m, zero => zero
   | suc m, suc n => suc (m + n + m * n)
+  bind tighter +
 
 def infixl *' (m n : Nat) : Nat
   | zero, n => zero
   | m, zero => zero
   | suc m, n => n + m *' n
-
-bind * tighter +
-bind *' tighter +
+  bind tighter +
 
 def *'-suc (m n : Nat) : m *' suc n = m + m *' n
   | zero, n => idp _

--- a/base/src/test/resources/success/nat-monoid.aya
+++ b/base/src/test/resources/success/nat-monoid.aya
@@ -32,8 +32,7 @@ def infix + ( a b : Nat ) : Nat
  | a, zero => a
  | suc a, b => suc (a + b)
  | a, suc b => suc (a + b)
-
-bind + tighter =
+ bind tighter =
 
 def +-assoc ( a b c : Nat ) : (a + b) + c = a + (b + c)
   | zero  , b , c => idp (b + c)

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
@@ -40,7 +40,6 @@ BIND_KW : 'bind';
 MATCH : 'match';
 ABSURD : 'impossible';
 VARIABLE : 'variable';
-ABUSING : 'abusing';
 DEF : 'def';
 STRUCT : 'struct';
 DATA : 'data';

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -16,7 +16,6 @@ stmt : decl
      | remark
      | levels
      | generalize
-     | bind
      | sample
      ;
 
@@ -26,7 +25,6 @@ remark : DOC_COMMENT+;
 importCmd : IMPORT qualifiedId (AS ID)?;
 openCmd : PUBLIC? OPEN IMPORT? qualifiedId useHide?;
 module : MODULE_KW ID LBRACE stmt* RBRACE;
-bind : BIND_KW qualifiedId (TIGHTER | LOOSER) qualifiedId;
 
 useHide : use+
         | hide+;
@@ -50,9 +48,12 @@ assoc : INFIX | INFIXL | INFIXR;
 
 declNameOrInfix : ID | assoc ID;
 
-abuse : ABUSING (LBRACE stmt* RBRACE | stmt);
+bindBlock : BIND_KW (TIGHTER | LOOSER) qIdsComma
+          | BIND_KW LBRACE (tighters | loosers)* RBRACE ;
+tighters : TIGHTER qIdsComma;
+loosers : LOOSER qIdsComma;
 
-fnDecl : DEF fnModifiers* declNameOrInfix tele* type? fnBody abuse?;
+fnDecl : DEF fnModifiers* declNameOrInfix tele* type? fnBody bindBlock?;
 
 fnBody : IMPLIES expr
        | (BAR clause)* ;
@@ -61,7 +62,7 @@ fnModifiers : ERASE
             | INLINE
             ;
 
-structDecl : STRUCT declNameOrInfix tele* type? (EXTENDS idsComma)? (BAR field)* abuse?;
+structDecl : STRUCT declNameOrInfix tele* type? (EXTENDS idsComma)? (BAR field)* bindBlock?;
 
 primDecl : PRIM assoc? ID tele* type? ;
 
@@ -69,7 +70,7 @@ field : COERCE? declNameOrInfix tele* type clauses? # fieldDecl
       | declNameOrInfix tele* type? IMPLIES expr    # fieldImpl
       ;
 
-dataDecl : (PUBLIC? OPEN)? DATA declNameOrInfix tele* type? dataBody* abuse?;
+dataDecl : (PUBLIC? OPEN)? DATA declNameOrInfix tele* type? dataBody* bindBlock?;
 
 dataBody : (BAR dataCtor)       # dataCtors
          | dataCtorClause       # dataClauses
@@ -96,7 +97,6 @@ expr : atom                            # single
 
 newArg : BAR ID ids IMPLIES expr;
 
-exprList : (expr COMMA)* expr?;
 atom : literal
      | LPAREN exprList RPAREN
      ;
@@ -145,7 +145,9 @@ teleBinder : expr
 teleMaybeTypedExpr : PATTERN_KW? ids type?;
 
 // utilities
+exprList : (expr COMMA)* expr?;
 idsComma : (ID COMMA)* ID?;
+qIdsComma : (qualifiedId COMMA)* qualifiedId?;
 ids : ID*;
 type : COLON expr;
 

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -66,8 +66,8 @@ structDecl : STRUCT declNameOrInfix tele* type? (EXTENDS idsComma)? (BAR field)*
 
 primDecl : PRIM assoc? ID tele* type? ;
 
-field : COERCE? declNameOrInfix tele* type clauses? # fieldDecl
-      | declNameOrInfix tele* type? IMPLIES expr    # fieldImpl
+field : COERCE? declNameOrInfix tele* type clauses? bindBlock? # fieldDecl
+      | declNameOrInfix tele* type? IMPLIES expr    bindBlock? # fieldImpl
       ;
 
 dataDecl : (PUBLIC? OPEN)? DATA declNameOrInfix tele* type? dataBody* bindBlock?;
@@ -76,7 +76,7 @@ dataBody : (BAR dataCtor)       # dataCtors
          | dataCtorClause       # dataClauses
          ;
 
-dataCtor : COERCE? declNameOrInfix tele* clauses?;
+dataCtor : COERCE? declNameOrInfix tele* clauses? bindBlock?;
 
 dataCtorClause : BAR patterns IMPLIES dataCtor;
 

--- a/lsp/src/main/java/org/aya/lsp/actions/SyntaxHighlight.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/SyntaxHighlight.java
@@ -40,7 +40,8 @@ public final class SyntaxHighlight implements StmtConsumer<@NotNull DynamicSeq<H
     return StmtConsumer.super.visitStruct(decl, buffer);
   }
 
-  @Override public Unit visitField(@NotNull Decl.StructField field, @NotNull DynamicSeq<HighlightResult.Symbol> buffer) {
+  @Override
+  public Unit visitField(@NotNull Decl.StructField field, @NotNull DynamicSeq<HighlightResult.Symbol> buffer) {
     buffer.append(new HighlightResult.Symbol(rangeOf(field), HighlightResult.Symbol.Kind.FieldDef));
     return StmtConsumer.super.visitField(field, buffer);
   }
@@ -55,7 +56,8 @@ public final class SyntaxHighlight implements StmtConsumer<@NotNull DynamicSeq<H
     return StmtConsumer.super.visitPrim(decl, buffer);
   }
 
-  @Override public Unit visitLevels(Generalize.@NotNull Levels levels, @NotNull DynamicSeq<HighlightResult.Symbol> buffer) {
+  @Override
+  public Unit visitLevels(Generalize.@NotNull Levels levels, @NotNull DynamicSeq<HighlightResult.Symbol> buffer) {
     for (var level : levels.levels())
       buffer.append(new HighlightResult.Symbol(LspRange.toRange(level.sourcePos()), HighlightResult.Symbol.Kind.Generalize));
     return StmtConsumer.super.visitLevels(levels, buffer);
@@ -141,12 +143,5 @@ public final class SyntaxHighlight implements StmtConsumer<@NotNull DynamicSeq<H
     if (ref.value == null) return;
     buffer.append(new HighlightResult.Symbol(LspRange.toRange(sourcePos), kindOf(ref.value)));
   }
-
-  @Override public Unit visitBind(Command.@NotNull Bind bind, @NotNull DynamicSeq<HighlightResult.Symbol> buffer) {
-    visitOperator(buffer, bind.op().sourcePos(), bind.resolvedOp());
-    visitOperator(buffer, bind.target().sourcePos(), bind.resolvedTarget());
-    return StmtConsumer.super.visitBind(bind, buffer);
-  }
-
   // endregion
 }

--- a/lsp/src/main/java/org/aya/lsp/actions/SyntaxHighlight.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/SyntaxHighlight.java
@@ -131,7 +131,7 @@ public final class SyntaxHighlight implements StmtConsumer<@NotNull DynamicSeq<H
     return StmtConsumer.super.visitModule(mod, buffer);
   }
 
-  private HighlightResult.Symbol.@NotNull Kind kindOf(@NotNull OpDecl opDecl) {
+  private HighlightResult.Symbol.@NotNull Kind kindOf(@NotNull Object opDecl) {
     return switch (opDecl) {
       case Decl.FnDecl ignored -> HighlightResult.Symbol.Kind.FnCall;
       case Decl.StructDecl ignored -> HighlightResult.Symbol.Kind.StructCall;
@@ -141,9 +141,9 @@ public final class SyntaxHighlight implements StmtConsumer<@NotNull DynamicSeq<H
     };
   }
 
-  private void visitOperator(@NotNull DynamicSeq<HighlightResult.Symbol> buffer, @NotNull SourcePos sourcePos, @Nullable OpDecl op) {
+  private void visitOperator(@NotNull DynamicSeq<HighlightResult.Symbol> buffer, @NotNull SourcePos sourcePos, @Nullable DefVar<?, ?> op) {
     if (op == null) return;
-    buffer.append(new HighlightResult.Symbol(LspRange.toRange(sourcePos), kindOf(op)));
+    buffer.append(new HighlightResult.Symbol(LspRange.toRange(sourcePos), kindOf(op.concrete)));
   }
 
   private void visitBind(@NotNull DynamicSeq<HighlightResult.Symbol> buffer, @Nullable OpDecl.BindBlock bindBlock) {

--- a/lsp/src/main/java/org/aya/lsp/actions/SyntaxHighlight.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/SyntaxHighlight.java
@@ -146,8 +146,8 @@ public final class SyntaxHighlight implements StmtConsumer<@NotNull DynamicSeq<H
     buffer.append(new HighlightResult.Symbol(LspRange.toRange(sourcePos), kindOf(op.concrete)));
   }
 
-  private void visitBind(@NotNull DynamicSeq<HighlightResult.Symbol> buffer, @Nullable OpDecl.BindBlock bindBlock) {
-    if (bindBlock == null) return;
+  private void visitBind(@NotNull DynamicSeq<HighlightResult.Symbol> buffer, @NotNull OpDecl.BindBlock bindBlock) {
+    if (bindBlock == OpDecl.BindBlock.EMPTY) return;
     bindBlock.loosers().view().zip(bindBlock.resolvedLoosers().value.view())
       .forEach(tup -> visitOperator(buffer, tup._1.sourcePos(), tup._2));
     bindBlock.tighters().view().zip(bindBlock.resolvedTighters().value.view())

--- a/tools/src/main/java/org/aya/util/MutableGraph.java
+++ b/tools/src/main/java/org/aya/util/MutableGraph.java
@@ -61,7 +61,7 @@ public record MutableGraph<T>(@NotNull MutableHashMap<T, @NotNull DynamicSeq<@No
    * and return the topological order (need reversing) of the components.
    */
   private class Tarjan {
-    MutableMap<T, Info> info = MutableMap.create();
+    MutableMap<T, Info> info = MutableLinkedHashMap.of();
     DynamicLinkedSeq<T> stack = DynamicLinkedSeq.create();
     DynamicSeq<ImmutableSeq<T>> SCCs = DynamicSeq.create();
     int index = 0;


### PR DESCRIPTION
This PR removes abusing block and introduces bind block.

The old `bind` statement is gone. Now we use:

```aya
def infix +
  | ...
  | ...
  bind { looser op1, op2, ..., tighter op1, op2, ... }
```

And it can be simplified if there's only `looser` or `tighter` clause:

```aya
def infix +
  | ...
  | ...
  bind tighter op1, op2, ...
```