### PR TITLE
Print `new` expressions as blocks

### DIFF
--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -162,18 +162,14 @@ public class ConcreteDistiller extends BaseDistiller implements
   }
 
   @Override public Doc visitNew(Expr.@NotNull NewExpr expr, Outer outer) {
-    return Doc.sep(
-      Doc.styled(KEYWORD, "new"),
-      expr.struct().accept(this, Outer.Free),
-      Doc.symbol("{"),
-      Doc.sep(expr.fields().view().map(t ->
+    return Doc.cblock(
+      Doc.sep(Doc.styled(KEYWORD, "new"), expr.struct().accept(this, Outer.Free)),
+      2, Doc.vcat(expr.fields().view().map(t ->
         Doc.sep(Doc.symbol("|"), Doc.plain(t.name()),
           Doc.emptyIf(t.bindings().isEmpty(), () ->
             Doc.sep(t.bindings().map(v -> varDoc(v.data())))),
           Doc.plain("=>"), t.body().accept(this, Outer.Free))
-      )),
-      Doc.symbol("}")
-    );
+      )));
   }
 
   @Override public Doc visitLitInt(Expr.@NotNull LitIntExpr expr, Outer outer) {

--- a/base/src/test/resources/failure/tyck/nonstruct-new.aya.txt
+++ b/base/src/test/resources/failure/tyck/nonstruct-new.aya.txt
@@ -4,7 +4,7 @@ In file $FILE:1:12 ->
                   ^---------^
 
 Error: Unable to construct the expression
-         new Type {  }
+         new Type
        because the type you gave is not a struct type, but instead:
          Type
          (Normalized: Type)

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -372,6 +372,20 @@ public sealed interface Doc extends Docile {
     return nest(indent, cat(plain(" ".repeat(indent)), doc));
   }
 
+  /**
+   * Creates a C-style indented block of statements.
+   * <pre>
+   *   prefix {
+   *   [indent]block
+   *   }
+   * </pre>
+   */
+  @Contract("_, _, _ -> new")
+  static @NotNull Doc cblock(@NotNull Doc prefix, int indent, @NotNull Doc block) {
+    if (!block.isNotEmpty()) return prefix;
+    return Doc.vcat(Doc.sep(prefix, Doc.symbol("{")), Doc.nest(indent, Doc.vcat(block)), Doc.symbol("}"));
+  }
+
   @Contract("_ -> new")
   static @NotNull Doc ordinal(int n) {
     var m = n % 100;


### PR DESCRIPTION
Fix #28 