### PR TITLE
Only enable overlapping pattern semantics on `overlap` modifier

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -61,6 +61,8 @@ check out [how to][proxy] let gradle use a proxy.
 
 + Questions or concerns are welcomed in the discussion area.
   We will try our best to answer your questions, but please be nice.
++ We welcome nitpicks on error reporting! Please let us know anything not perfect.
+  We have already implemented several user-suggested error messages.
 + Before contributing in any form, please read
   [the contribution guideline](https://github.com/aya-prover/aya-dev/blob/master/.github/CONTRIBUTING.md) thoroughly
   and make sure you understand your responsibilities.

--- a/.github/README.md
+++ b/.github/README.md
@@ -23,7 +23,10 @@ Aya is under active development. Nothing guaranteed! However, we can share some 
   and prove [regularity by computation][regularity] thanks to Arend's type theory.
   We also have the classic cubical-flavored [funExt].
   + We are considering moving to cubical type theory.
-+ Overlapping patterns. Very [useful][oop] in theorem proving.
++ Pattern matching with first-match semantics.
+  We can implement [redblack tree][rbtree] (without deletion) elegantly.
++ Overlapping and order-independent patterns.
+  Very [useful][oop] in theorem proving.
 + A literate programming mode with inline code fragment support.
   We already have a prototype, but we plan to revise it before sharing demos.
 + Binary operators, with precedence specified by a [partial ordering][binop]
@@ -84,6 +87,7 @@ check out [how to][proxy] let gradle use a proxy.
 [gadt]: ../base/src/test/resources/success/type-safe-norm.aya
 [regularity]: ../base/src/test/resources/success/regularity.aya
 [funExt]: ../base/src/test/resources/success/funExt.aya
+[rbtree]: ../base/src/test/resources/success/redblack.aya
 [assoc]: ../base/src/test/resources/success/assoc.aya#L73
 [binop]: ../base/src/test/resources/success/issues2/issue69.aya#L46
 [maven-repo]: https://repo1.maven.org/maven2/org/aya-prover

--- a/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
+++ b/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
@@ -835,6 +835,7 @@ public final class AyaProducer {
   public @NotNull Modifier visitFnModifiers(AyaParser.FnModifiersContext ctx) {
     if (ctx.OPAQUE() != null) return Modifier.Opaque;
     if (ctx.INLINE() != null) return Modifier.Inline;
+    if (ctx.OVERLAP() != null) return Modifier.Overlap;
     /*if (ctx.PATTERN_KW() != null)*/
     return Modifier.Pattern;
   }

--- a/base/src/main/java/org/aya/core/visitor/Unfolder.java
+++ b/base/src/main/java/org/aya/core/visitor/Unfolder.java
@@ -114,8 +114,8 @@ public interface Unfolder<P> extends TermFixpoint<P> {
   ) {
     for (var matchy : clauses) {
       var termSubst = PatMatcher.tryBuildSubstArgs(matchy.patterns(), args);
-      if (termSubst != null) {
-        subst.add(termSubst);
+      if (termSubst.isOk()) {
+        subst.add(termSubst.get());
         var newBody = matchy.body().subst(subst, levelSubst).accept(this, p).rename();
         return new WithPos<>(matchy.sourcePos(), newBody);
       }

--- a/base/src/main/java/org/aya/core/visitor/Unfolder.java
+++ b/base/src/main/java/org/aya/core/visitor/Unfolder.java
@@ -50,7 +50,7 @@ public interface Unfolder<P> extends TermFixpoint<P> {
     var levelArgs = conCall.sortArgs();
     var levelSubst = buildSubst(levelParams, levelArgs);
     var dropped = args.drop(conCall.head().dataArgs().size());
-    var volynskaya = tryUnfoldClauses(p, dropped, levelSubst, def.clauses);
+    var volynskaya = tryUnfoldClauses(p, true, dropped, levelSubst, def.clauses);
     return volynskaya != null ? volynskaya.data() : new CallTerm.Con(conCall.head(), dropped);
   }
 
@@ -73,7 +73,8 @@ public interface Unfolder<P> extends TermFixpoint<P> {
       var termSubst = checkAndBuildSubst(def.telescope(), args);
       return body.getLeftValue().subst(termSubst, levelSubst).accept(this, p).rename();
     }
-    var volynskaya = tryUnfoldClauses(p, args, levelSubst, body.getRightValue());
+    var orderIndependent = def.modifiers.contains(Modifier.Overlap);
+    var volynskaya = tryUnfoldClauses(p, orderIndependent, args, levelSubst, body.getRightValue());
     return volynskaya != null ? volynskaya.data().accept(this, p) : new CallTerm.Fn(fnCall.ref(), fnCall.sortArgs(), args);
   }
   private @NotNull Substituter.TermSubst
@@ -101,14 +102,15 @@ public interface Unfolder<P> extends TermFixpoint<P> {
   }
 
   default @Nullable WithPos<Term> tryUnfoldClauses(
-    P p, SeqLike<Arg<Term>> args, LevelSubst levelSubst,
-    @NotNull ImmutableSeq<Matching> clauses
+    P p, boolean orderIndependent, SeqLike<Arg<Term>> args,
+    LevelSubst levelSubst, @NotNull ImmutableSeq<Matching> clauses
   ) {
-    return tryUnfoldClauses(p, args, new Substituter.TermSubst(MutableMap.create()), levelSubst, clauses);
+    return tryUnfoldClauses(p, orderIndependent, args,
+      new Substituter.TermSubst(MutableMap.create()), levelSubst, clauses);
   }
 
   default @Nullable WithPos<Term> tryUnfoldClauses(
-    P p, SeqLike<Arg<Term>> args,
+    P p, boolean orderIndependent, SeqLike<Arg<Term>> args,
     Substituter.@NotNull TermSubst subst, LevelSubst levelSubst,
     @NotNull ImmutableSeq<Matching> clauses
   ) {
@@ -118,7 +120,9 @@ public interface Unfolder<P> extends TermFixpoint<P> {
         subst.add(termSubst.get());
         var newBody = matchy.body().subst(subst, levelSubst).accept(this, p).rename();
         return new WithPos<>(matchy.sourcePos(), newBody);
-      }
+      } else if (!orderIndependent && termSubst.getErr()) return null;
+      // ^ if we have an order-dependent clause and the pattern matching is blocked,
+      // we refuse to unfold the clauses (first-match semantics)
     }
     // Unfold failed
     return null;
@@ -133,7 +137,7 @@ public interface Unfolder<P> extends TermFixpoint<P> {
       var fieldSubst = checkAndBuildSubst(core.fullTelescope(), args);
       var levelSubst = buildSubst(Def.defLevels(field), term.sortArgs());
       var dropped = args.drop(term.structArgs().size());
-      var mischa = tryUnfoldClauses(p, dropped, fieldSubst, levelSubst, core.clauses);
+      var mischa = tryUnfoldClauses(p, true, dropped, fieldSubst, levelSubst, core.clauses);
       return mischa != null ? mischa.data() : new CallTerm.Access(nevv, field,
         term.sortArgs(), term.structArgs(), dropped);
     }

--- a/base/src/main/java/org/aya/generic/Modifier.java
+++ b/base/src/main/java/org/aya/generic/Modifier.java
@@ -9,15 +9,23 @@ import org.jetbrains.annotations.NotNull;
  */
 public enum Modifier {
   /**
-   * Denotes that a function's invocations are never reduced,
-   * and should be removed during elaboration.
+   * Denotes that a function's invocations are never reduced.
+   * Useful in debugging, when you really don't wanna see the full NF.
    */
   Opaque("opaque"),
   /**
    * Denotes that a function's invocations are eagerly reduced.
    */
   Inline("inline"),
+  /**
+   * That this function is a pattern synonym.
+   */
   Pattern("pattern"),
+  /**
+   * That this function uses overlapping and order-insensitive
+   * pattern matching semantics.
+   */
+  Overlap("overlap"),
   ;
 
   public final @NotNull String keyword;

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -21,6 +21,7 @@ import org.aya.core.term.FormTerm;
 import org.aya.core.term.Term;
 import org.aya.core.visitor.Substituter;
 import org.aya.generic.Level;
+import org.aya.generic.Modifier;
 import org.aya.tyck.pat.Conquer;
 import org.aya.tyck.pat.PatClassifier;
 import org.aya.tyck.pat.PatTycker;
@@ -87,8 +88,10 @@ public record StmtTycker(
             var result = patTycker.elabClauses(clauses, signature);
             var matchings = result._2.flatMap(Pat.PrototypeClause::deprototypify);
             var def = factory.apply(result._1, Either.right(matchings));
-            if (patTycker.noError())
-              ensureConfluent(tycker, signature, result._2, matchings, decl.sourcePos, true);
+            if (patTycker.noError()) {
+              var orderIndependent = decl.modifiers.contains(Modifier.Overlap);
+              ensureConfluent(tycker, signature, result._2, matchings, decl.sourcePos, true, orderIndependent);
+            }
             return def;
           }
         );
@@ -193,21 +196,21 @@ public record StmtTycker(
     var implicits = pat.isEmpty() ? dataParamView.map(Term.Param::implicitify).toImmutableSeq() : Pat.extractTele(pat);
     var elaborated = new CtorDef(dataRef, ctor.ref, pat, implicits, tele, matchings, dataCall, ctor.coerce);
     if (patTycker.noError())
-      ensureConfluent(tycker, signature, elabClauses, matchings, ctor.sourcePos, false);
+      ensureConfluent(tycker, signature, elabClauses, matchings, ctor.sourcePos, false, true);
     return elaborated;
   }
 
   private void ensureConfluent(
     ExprTycker tycker, Def.Signature signature, ImmutableSeq<Pat.PrototypeClause> elabClauses,
     ImmutableSeq<@NotNull Matching> matchings, @NotNull SourcePos pos,
-    boolean coverage
+    boolean coverage, boolean orderIndependent
   ) {
     if (!matchings.isNotEmpty()) return;
     tracing(builder -> builder.shift(new Trace.LabelT(pos, "confluence check")));
     var classification = PatClassifier.classify(elabClauses, signature.param(),
       tycker.state, tycker.reporter, pos, coverage);
-    PatClassifier.confluence(elabClauses, tycker, pos, signature.result(), classification);
-    Conquer.against(matchings, tycker, pos, signature);
+    PatClassifier.confluence(orderIndependent, elabClauses, tycker, pos, signature.result(), classification);
+    Conquer.against(matchings, orderIndependent, tycker, pos, signature);
     tycker.solveMetas();
     tracing(TreeBuilder::reduce);
   }
@@ -225,7 +228,7 @@ public record StmtTycker(
     var body = field.body.map(e -> tycker.inherit(e, result).wellTyped());
     var elaborated = new FieldDef(structRef, field.ref, structSig.param(), tele, result, matchings, body, field.coerce);
     if (patTycker.noError())
-      ensureConfluent(tycker, field.signature, elabClauses, matchings, field.sourcePos, false);
+      ensureConfluent(tycker, field.signature, elabClauses, matchings, field.sourcePos, false, true);
     return elaborated;
   }
 

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -209,7 +209,9 @@ public record StmtTycker(
     tracing(builder -> builder.shift(new Trace.LabelT(pos, "confluence check")));
     var classification = PatClassifier.classify(elabClauses, signature.param(),
       tycker.state, tycker.reporter, pos, coverage);
-    PatClassifier.confluence(orderIndependent, elabClauses, tycker, pos, signature.result(), classification);
+    if (orderIndependent) PatClassifier.confluence(elabClauses, tycker, pos, signature.result(), classification);
+    else if (classification.isNotEmpty())
+      PatClassifier.firstMatchDomination(elabClauses, reporter, pos, classification);
     Conquer.against(matchings, orderIndependent, tycker, pos, signature);
     tycker.solveMetas();
     tracing(TreeBuilder::reduce);

--- a/base/src/main/java/org/aya/tyck/pat/ClausesProblem.java
+++ b/base/src/main/java/org/aya/tyck/pat/ClausesProblem.java
@@ -121,4 +121,17 @@ public sealed interface ClausesProblem extends Problem {
       return Severity.WARN;
     }
   }
+
+  record FMDomination(int sub, @Override @NotNull SourcePos sourcePos) implements ClausesProblem {
+    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.sep(
+        Doc.english("The"), Doc.ordinal(sub),
+        Doc.english("clause is dominated by the other clauses, hence unreachable")
+      );
+    }
+
+    @Override public @NotNull Severity level() {
+      return Severity.WARN;
+    }
+  }
 }

--- a/base/src/main/java/org/aya/tyck/pat/Conquer.java
+++ b/base/src/main/java/org/aya/tyck/pat/Conquer.java
@@ -62,7 +62,7 @@ public record Conquer(
     for (int i = 0, size = conditions.size(); i < size; i++) {
       var condition = conditions.get(i);
       var matchy = PatMatcher.tryBuildSubstTerms(params, condition.patterns().view().map(Pat::toTerm));
-      if (matchy != null) checkConditions(ctor, nth, i + 1, condition.body(), matchy, condition.sourcePos());
+      if (matchy.isOk()) checkConditions(ctor, nth, i + 1, condition.body(), matchy.get(), condition.sourcePos());
     }
     return Unit.unit();
   }

--- a/base/src/main/java/org/aya/tyck/pat/Conquer.java
+++ b/base/src/main/java/org/aya/tyck/pat/Conquer.java
@@ -33,16 +33,17 @@ public record Conquer(
   @NotNull ImmutableSeq<Matching> matchings,
   @NotNull SourcePos sourcePos,
   @NotNull Def.Signature signature,
+  boolean orderIndependent,
   @NotNull ExprTycker tycker
 ) implements Pat.Visitor<Integer, Unit> {
   public static void against(
-    @NotNull ImmutableSeq<Matching> matchings,
+    @NotNull ImmutableSeq<Matching> matchings, boolean orderIndependent,
     @NotNull ExprTycker tycker, @NotNull SourcePos pos, @NotNull Def.Signature signature
   ) {
     for (int i = 0, size = matchings.size(); i < size; i++) {
       var matching = matchings.get(i);
       for (var pat : matching.patterns())
-        pat.accept(new Conquer(matchings, pos, signature, tycker), i);
+        pat.accept(new Conquer(matchings, pos, signature, orderIndependent, tycker), i);
     }
   }
 
@@ -76,7 +77,7 @@ public record Conquer(
       }
     }, Unit.unit()), pat.explicit()));
     var volynskaya = new Normalizer(tycker.state).tryUnfoldClauses(
-      NormalizeMode.WHNF, newArgs, LevelSubst.EMPTY, matchings);
+      NormalizeMode.WHNF, orderIndependent, newArgs, LevelSubst.EMPTY, matchings);
     if (volynskaya == null) {
       tycker.reporter.report(new ClausesProblem.Conditions(
         sourcePos, nth + 1, i, newBody, null, conditionPos, currentClause.sourcePos(), null));

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -56,6 +56,7 @@ public record PatClassifier(
   }
 
   public static void confluence(
+    boolean doUnification,
     @NotNull ImmutableSeq<Pat.@NotNull PrototypeClause> clauses,
     @NotNull ExprTycker tycker, @NotNull SourcePos pos,
     @NotNull Term result, @NotNull ImmutableSeq<PatClass> classification
@@ -72,6 +73,7 @@ public record PatClassifier(
         PatUnify.unifyPat(lhsInfo._2.patterns(), rhsInfo._2.patterns(), lhsSubst, rhsSubst);
         domination(rhsSubst, tycker.reporter, lhsInfo._1, rhsInfo._1, rhsInfo._2);
         domination(lhsSubst, tycker.reporter, rhsInfo._1, lhsInfo._1, lhsInfo._2);
+        if (!doUnification) continue;
         var lhsTerm = lhsInfo._2.body().subst(lhsSubst);
         var rhsTerm = rhsInfo._2.body().subst(rhsSubst);
         // TODO: Currently all holes at this point is in an ErrorTerm

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -10,7 +10,6 @@ import kala.control.Option;
 import kala.tuple.Tuple;
 import kala.tuple.primitive.IntObjTuple2;
 import org.aya.api.error.Reporter;
-import org.aya.util.error.SourcePos;
 import org.aya.api.ref.Var;
 import org.aya.api.util.NormalizeMode;
 import org.aya.concrete.Pattern;
@@ -24,6 +23,7 @@ import org.aya.core.visitor.Substituter;
 import org.aya.tyck.ExprTycker;
 import org.aya.tyck.TyckState;
 import org.aya.util.Ordering;
+import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -213,8 +213,8 @@ public record PatClassifier(
           if (ctor.pats.isNotEmpty()) {
             var matchy = PatMatcher.tryBuildSubstArgs(ctor.pats, dataCall.args());
             // If not, forget about this constructor
-            if (matchy == null) continue;
-            conTele = conTele.map(param -> param.subst(matchy));
+            if (matchy.isErr()) continue;
+            conTele = conTele.map(param -> param.subst(matchy.get()));
           }
           // Java wants a final local variable, let's alias it
           var conTeleCapture = conTele;

--- a/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
@@ -4,13 +4,13 @@ package org.aya.tyck.pat;
 
 import org.aya.api.distill.DistillerOptions;
 import org.aya.api.error.Problem;
-import org.aya.util.error.SourcePos;
 import org.aya.concrete.Pattern;
 import org.aya.core.term.CallTerm;
 import org.aya.core.term.Term;
 import org.aya.distill.BaseDistiller;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.doc.Style;
+import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 
 public sealed interface PatternProblem extends Problem {
@@ -18,6 +18,16 @@ public sealed interface PatternProblem extends Problem {
 
   @Override default @NotNull SourcePos sourcePos() {
     return pattern().sourcePos();
+  }
+
+  record BlockedEval(@Override @NotNull Pattern pattern) implements PatternProblem {
+    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.english("Unsure if this pattern is actually impossible as constructor selection is blocked");
+    }
+
+    @Override public @NotNull Severity level() {
+      return Severity.ERROR;
+    }
   }
 
   record PossiblePat(

--- a/base/src/test/java/org/aya/core/NormalizeTest.java
+++ b/base/src/test/java/org/aya/core/NormalizeTest.java
@@ -25,7 +25,7 @@ public class NormalizeTest {
   @Test public void unfoldPatterns() {
     var defs = TyckDeclTest.successTyckDecls("""
       open data Nat : Type | zero | suc Nat
-      def tracy (a b : Nat) : Nat
+      def overlap tracy (a b : Nat) : Nat
        | zero, a => a
        | a, zero => a
        | suc a, b => suc (tracy a b)

--- a/base/src/test/java/org/aya/core/NormalizeTest.java
+++ b/base/src/test/java/org/aya/core/NormalizeTest.java
@@ -32,7 +32,7 @@ public class NormalizeTest {
        | a, suc b => suc (tracy a b)
       def xyr : Nat => tracy zero (suc zero)
       def kiva : Nat => tracy (suc zero) zero
-      def overlap (a : Nat) : Nat => tracy a zero
+      def overlap1 (a : Nat) : Nat => tracy a zero
       def overlap2 (a : Nat) : Nat => tracy zero a""");
     IntFunction<Term> normalizer = i -> ((FnDef) defs.get(i)).body.getLeftValue().normalize(null, NormalizeMode.NF);
     assertTrue(normalizer.apply(2) instanceof CallTerm.Con conCall

--- a/base/src/test/java/org/aya/tyck/PatCCTest.java
+++ b/base/src/test/java/org/aya/tyck/PatCCTest.java
@@ -3,11 +3,11 @@
 package org.aya.tyck;
 
 import kala.collection.immutable.ImmutableSeq;
-import org.aya.util.error.SourcePos;
 import org.aya.core.def.FnDef;
 import org.aya.core.pat.Pat;
 import org.aya.test.ThrowingReporter;
 import org.aya.tyck.pat.PatClassifier;
+import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +25,7 @@ public class PatCCTest {
   @Test public void addCC() {
     var decls = TyckDeclTest.successTyckDecls("""
       open data Nat : Type | zero | suc Nat
-      def add (a b : Nat) : Nat
+      def overlap add (a b : Nat) : Nat
        | zero, b => b
        | a, zero => a
        | suc a, b => suc (add a b)

--- a/base/src/test/resources/failure/counterexamples/basic.aya
+++ b/base/src/test/resources/failure/counterexamples/basic.aya
@@ -2,7 +2,7 @@ open data Nat : Type 0
  | zero
  | suc Nat
 
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (addN a b)

--- a/base/src/test/resources/failure/counterexamples/not-in-ctx.aya
+++ b/base/src/test/resources/failure/counterexamples/not-in-ctx.aya
@@ -2,7 +2,7 @@ open data Nat : Type 0
  | zero
  | suc Nat
 
-counterexample def addN (a b : Nat) : Nat
+counterexample def overlap  addN (a b : Nat) : Nat
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (addN a b)

--- a/base/src/test/resources/failure/holes/issue420.aya
+++ b/base/src/test/resources/failure/holes/issue420.aya
@@ -32,7 +32,7 @@ def pmap {A B : Type} (f : Pi A -> B) {a b : A} (p : Eq a b)
 
 open data Nat : Type | zero | suc Nat
 
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (addN a b)

--- a/base/src/test/resources/failure/holes/pattern-confluence.aya
+++ b/base/src/test/resources/failure/holes/pattern-confluence.aya
@@ -2,7 +2,7 @@ open data Nat : Type
   | zero
   | suc Nat
 
-def add (m n : Nat) : Type
+def overlap add (m n : Nat) : Type
   | zero, n => n
   | m, zero => {??}
   | suc m, n => suc (add m n)

--- a/base/src/test/resources/failure/holes/pattern-confluence.aya.txt
+++ b/base/src/test/resources/failure/holes/pattern-confluence.aya.txt
@@ -1,7 +1,7 @@
 In file $FILE:6:15 ->
 
   4 | 
-  5 | def add (m n : Nat) : Type
+  5 | def overlap add (m n : Nat) : Type
   6 |   | zero, n => n
                      ^^
 
@@ -14,7 +14,7 @@ Error: Cannot check the expression of type
 
 In file $FILE:7:15 ->
 
-  5 | def add (m n : Nat) : Type
+  5 | def overlap add (m n : Nat) : Type
   6 |   | zero, n => n
   7 |   | m, zero => {??}
                      ^--^
@@ -88,7 +88,7 @@ Error: Cannot check the expression of type
 
 In file $FILE:7:15 ->
 
-  5 | def add (m n : Nat) : Type
+  5 | def overlap add (m n : Nat) : Type
   6 |   | zero, n => n
   7 |   | m, zero => {??}
                      ^--^

--- a/base/src/test/resources/failure/holes/ulf-hole-illtype.aya
+++ b/base/src/test/resources/failure/holes/ulf-hole-illtype.aya
@@ -1,5 +1,5 @@
-open data Nat : Type | zero | suc Nat
-data Empty : Type
+open data Nat | zero | suc Nat
+data Empty
 def Neg (T : Type) => T -> Empty
 def test
  (F : Type -> Type)

--- a/base/src/test/resources/failure/patterns/confl.aya
+++ b/base/src/test/resources/failure/patterns/confl.aya
@@ -2,7 +2,7 @@ open data Nat : Type
  | zero
  | suc Nat
 
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
  | zero, a => suc a
  | a, zero => a
  | suc a, b => suc (addN a b)

--- a/base/src/test/resources/failure/patterns/confl.aya.txt
+++ b/base/src/test/resources/failure/patterns/confl.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:5:4 ->
+In file $FILE:5:12 ->
 
   3 |  | suc Nat
   4 | 
-  5 | def addN (a b : Nat) : Nat
+  5 | def overlap addN (a b : Nat) : Nat
   6 |  | zero, a => suc a
          ^--------------^ substituted to `suc zero`
   7 |  | a, zero => a

--- a/base/src/test/resources/failure/patterns/fm-dom.aya
+++ b/base/src/test/resources/failure/patterns/fm-dom.aya
@@ -1,0 +1,6 @@
+open data Nat | suc Nat | zero
+def addN (a b : Nat) : Nat
+| zero, a => a
+| a, zero => a
+| suc a, b => suc (addN a b)
+| a, suc b => suc (addN a b)

--- a/base/src/test/resources/failure/patterns/fm-dom.aya.txt
+++ b/base/src/test/resources/failure/patterns/fm-dom.aya.txt
@@ -1,0 +1,10 @@
+In file $FILE:2:4 ->
+
+  1 | open data Nat | suc Nat | zero
+  2 | def addN (a b : Nat) : Nat
+          ^--^
+  3 | | zero, a => a
+
+Warning: The 4th clause is dominated by the other clauses, hence unreachable
+
+That looks right!

--- a/base/src/test/resources/failure/patterns/issues/issue302.aya
+++ b/base/src/test/resources/failure/patterns/issues/issue302.aya
@@ -1,7 +1,7 @@
 open data Nat : Type
  | zero
  | suc Nat
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (addN b a)

--- a/base/src/test/resources/failure/patterns/issues/issue302.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues/issue302.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:4:4 ->
+In file $FILE:4:12 ->
 
   2 |  | zero
   3 |  | suc Nat
-  4 | def addN (a b : Nat) : Nat
+  4 | def overlap addN (a b : Nat) : Nat
   5 |  | zero, a => a
   6 |  | a, zero => a
   7 |  | suc a, b => suc (addN b a)

--- a/base/src/test/resources/failure/patterns/issues/issue354-reduce.aya
+++ b/base/src/test/resources/failure/patterns/issues/issue354-reduce.aya
@@ -2,7 +2,7 @@ open data Nat : Type 0
  | zero
  | suc Nat
 
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (addN a b)

--- a/base/src/test/resources/failure/patterns/issues/issue366.aya
+++ b/base/src/test/resources/failure/patterns/issues/issue366.aya
@@ -1,5 +1,5 @@
 open data Nat : Type 0 | zero | suc Nat
 open data Ray (a : Nat) : Type | zero => eldath
-def ray-eldath (a : Nat) (ed40 : Ray a) : Nat
+def overlap ray-eldath (a : Nat) (ed40 : Ray a) : Nat
  | zero, eldath => suc zero
  | zero, eldath => zero

--- a/base/src/test/resources/failure/patterns/issues/issue366.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues/issue366.aya.txt
@@ -1,6 +1,6 @@
 In file $FILE:5:3 ->
 
-  3 | def ray-eldath (a : Nat) (ed40 : Ray a) : Nat
+  3 | def overlap ray-eldath (a : Nat) (ed40 : Ray a) : Nat
   4 |  | zero, eldath => suc zero
   5 |  | zero, eldath => zero
          ^------------------^
@@ -10,17 +10,17 @@ Warning: The 1st clause dominates the 2nd clause. The 2nd clause will be unreach
 In file $FILE:4:3 ->
 
   2 | open data Ray (a : Nat) : Type | zero => eldath
-  3 | def ray-eldath (a : Nat) (ed40 : Ray a) : Nat
+  3 | def overlap ray-eldath (a : Nat) (ed40 : Ray a) : Nat
   4 |  | zero, eldath => suc zero
          ^----------------------^
 
 Warning: The 2nd clause dominates the 1st clause. The 1st clause will be unreachable
 
-In file $FILE:3:4 ->
+In file $FILE:3:12 ->
 
   1 | open data Nat : Type 0 | zero | suc Nat
   2 | open data Ray (a : Nat) : Type | zero => eldath
-  3 | def ray-eldath (a : Nat) (ed40 : Ray a) : Nat
+  3 | def overlap ray-eldath (a : Nat) (ed40 : Ray a) : Nat
   4 |  | zero, eldath => suc zero
          ^----------------------^ substituted to `suc zero`
   5 |  | zero, eldath => zero

--- a/base/src/test/resources/failure/patterns/issues/issue681.aya
+++ b/base/src/test/resources/failure/patterns/issues/issue681.aya
@@ -18,7 +18,7 @@ open data Nat : Type 0
   | zero
   | suc Nat
 
-def infix + (n m : Nat) : Nat
+def overlap infix + (n m : Nat) : Nat
   | zero, n => n
   | n, zero => n
   | suc m, n => suc (m + n)

--- a/base/src/test/resources/failure/patterns/issues2/issue99-1.aya
+++ b/base/src/test/resources/failure/patterns/issues2/issue99-1.aya
@@ -1,5 +1,5 @@
-open data Unit : Type | unit
+open data Unit | unit
 
-def test (a : Unit) : Unit
+def overlap test (a : Unit) : Unit
  | a => a
  | unit => unit

--- a/base/src/test/resources/failure/patterns/issues2/issue99-1.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues2/issue99-1.aya.txt
@@ -1,6 +1,6 @@
 In file $FILE:5:3 ->
 
-  3 | def test (a : Unit) : Unit
+  3 | def overlap test (a : Unit) : Unit
   4 |  | a => a
   5 |  | unit => unit
          ^----------^

--- a/base/src/test/resources/failure/patterns/issues2/issue99-2.aya
+++ b/base/src/test/resources/failure/patterns/issues2/issue99-2.aya
@@ -1,6 +1,6 @@
 open data Unit : Type | unit
 
-def test2 (a b : Unit) : Unit
+def overlap test2 (a b : Unit) : Unit
  | x, unit => unit
  | unit, y => unit
  | x, y => unit

--- a/base/src/test/resources/failure/patterns/issues2/issue99-2.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues2/issue99-2.aya.txt
@@ -1,6 +1,6 @@
 In file $FILE:5:3 ->
 
-  3 | def test2 (a b : Unit) : Unit
+  3 | def overlap test2 (a b : Unit) : Unit
   4 |  | x, unit => unit
   5 |  | unit, y => unit
          ^-------------^

--- a/base/src/test/resources/failure/syntax/issue165.aya.txt
+++ b/base/src/test/resources/failure/syntax/issue165.aya.txt
@@ -2,7 +2,7 @@ In file $FILE:2:0 ->
 
   1 | def
 
-Error: Parser error: mismatched input '<EOF>' expecting {'infix', 'infixl', 'infixr', 'opaque', 'inline', 'pattern', ID}
+Error: Parser error: mismatched input '<EOF>' expecting {'infix', 'infixl', 'infixr', 'opaque', 'inline', 'overlap', 'pattern', ID}
 
 Parsing interrupted due to:
 1 error(s), 0 warning(s).

--- a/base/src/test/resources/success/add-comm.aya
+++ b/base/src/test/resources/success/add-comm.aya
@@ -35,7 +35,7 @@ open data ℕ : Type
   | zero
   | suc ℕ
 
-def infix + (a b : ℕ) : ℕ
+def overlap infix + (a b : ℕ) : ℕ
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (a + b)

--- a/base/src/test/resources/success/assoc.aya
+++ b/base/src/test/resources/success/assoc.aya
@@ -70,7 +70,7 @@ def infix + (a b : Nat) : Nat
  | a, suc b => suc (a + b)
  bind tighter =, ==<, qed
 
-def +-comm (a b : Nat) : a + b = b + a
+def overlap +-comm (a b : Nat) : a + b = b + a
   | zero, zero => idp _
   | suc a, zero => pmap suc (+-comm a zero)
   | zero, suc b => pmap suc (+-comm zero b)

--- a/base/src/test/resources/success/examples.aya
+++ b/base/src/test/resources/success/examples.aya
@@ -18,7 +18,7 @@ example def abs (n : Int) : Nat
 
 example def abs2 (n : Int) => abs n
 
-counterexample def abs (n : Int) : Nat
+counterexample def overlap abs (n : Int) : Nat
  | pos (suc n) => suc zero
  | pos zero => suc zero
  | neg n => zero

--- a/base/src/test/resources/success/examples.aya
+++ b/base/src/test/resources/success/examples.aya
@@ -2,7 +2,7 @@ open data Nat : Type 0
  | zero
  | suc Nat
 
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (addN a b)

--- a/base/src/test/resources/success/implicit-pats.aya
+++ b/base/src/test/resources/success/implicit-pats.aya
@@ -7,7 +7,7 @@ def id2 {A : Type} (a : A) : A
 open data Nat : Type
  | zero | suc Nat
 
-def add {a b : Nat} : Nat
+def overlap add {a b : Nat} : Nat
  | {zero}, {b} => b
  | {a}, {zero} => a
  | {suc a}, {b} => suc (add {a} {b})

--- a/base/src/test/resources/success/issues/issue264.aya
+++ b/base/src/test/resources/success/issues/issue264.aya
@@ -2,7 +2,7 @@ open data Nat : Type 0
  | zero
  | suc Nat
 
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
  | zero, zero => zero
  | zero, a => a
  | a, zero => a

--- a/base/src/test/resources/success/issues/issue320.aya
+++ b/base/src/test/resources/success/issues/issue320.aya
@@ -6,7 +6,7 @@ open data Fin (n : Nat) : Type 0
  | suc m => fzero
  | suc m => fsuc (Fin m)
 
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (addN a b)

--- a/base/src/test/resources/success/issues/issue442.aya
+++ b/base/src/test/resources/success/issues/issue442.aya
@@ -37,13 +37,13 @@ open data Int : Type
 | pos Nat
 | neg Nat { | zero => pos zero }
 
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
 | zero, a => a
 | a, zero => a
 | suc a, b => suc (addN a b)
 | a, suc b => suc (addN a b)
 
-def addN-comm (a b : Nat) : Eq (addN a b) (addN b a)
+def overlap addN-comm (a b : Nat) : Eq (addN a b) (addN b a)
  | zero, a => idp a
  | a, zero => idp a
  | suc a, b => pmap suc (addN-comm a _)
@@ -52,12 +52,12 @@ def addN-assoc (a b c : Nat) : Eq (addN a (addN b c)) (addN (addN a b) c)
  | zero, a, b => idp _
  | suc a, b, c => pmap suc (addN-assoc a b c)
 
-def subNI (a b : Nat) : Int
+def overlap subNI (a b : Nat) : Int
 | zero, a => neg a
 | a, zero => pos a
 | suc a, suc b => subNI a b
 
-def addI (a b : Int) : Int
+def overlap addI (a b : Int) : Int
 | pos zero, n => n
 | n, pos zero => n
 | neg zero, n => n

--- a/base/src/test/resources/success/issues/issue521.aya
+++ b/base/src/test/resources/success/issues/issue521.aya
@@ -29,15 +29,15 @@ def hcomp2d {A : Type}
 def sym {A : Type} {a b : A} (p : Eq a b) : Eq b a => hcomp2d idp idp p
 def pmap {A B : Type} (f : A -> B) {a b : A} (p : Eq a b)
   : Eq (f a) (f b) => path (\ i => f (p.at i))
-open data Nat : Type | zero | suc Nat
+open data Nat | zero | suc Nat
 
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
 | zero, a => a
 | a, zero => a
 | suc a, b => suc (addN a b)
 | a, suc b => suc (addN a b)
 
-def addN-comm (a b : Nat) : Eq (addN a b) (addN b a)
+def overlap addN-comm (a b : Nat) : Eq (addN a b) (addN b a)
  | zero, a => idp
  | a, zero => idp
  | suc a, b => pmap suc (addN-comm _ _)

--- a/base/src/test/resources/success/issues/issue743.aya
+++ b/base/src/test/resources/success/issues/issue743.aya
@@ -2,7 +2,7 @@ open data Nat : Type
  | zero
  | suc Nat
 
-def add {a biu : Nat} : Nat
+def overlap add {a biu : Nat} : Nat
  | {zero}, {x} => biu
  | {suc a}, {zero} => biu
  | {suc a}, {bua} => bua

--- a/base/src/test/resources/success/issues2/issue14.aya
+++ b/base/src/test/resources/success/issues2/issue14.aya
@@ -33,7 +33,7 @@ open data Nat : Type
   | zero
   | suc Nat
 
-def infix + (m n : Nat) : Nat
+def overlap infix + (m n : Nat) : Nat
   | zero, n => n
   | n, zero => n
   | suc m, n => suc (m + n)

--- a/base/src/test/resources/success/issues2/issue69.aya
+++ b/base/src/test/resources/success/issues2/issue69.aya
@@ -31,14 +31,14 @@ def infixr ~ {A : Type} {a b c : A} (p : a = b) (q : b = c) : a = c => hcomp2d p
 def pmap {A B : Type} (f : A -> B) {a b : A} (p : a = b)
   : f a = f b => path (\ i => f (p.at i))
 
-def funext {A B : Type} (f g : A -> B) (p : Pi (a : A) -> f a = g a) : f = g
+def funExt {A B : Type} (f g : A -> B) (p : Pi (a : A) -> f a = g a) : f = g
   => path (\ i x => (p x).at i)
 
 open data Nat : Type
   | zero
   | suc Nat
 
-def infixl + (m n : Nat) : Nat
+def overlap infixl + (m n : Nat) : Nat
   | zero, n => n
   | n, zero => n
   | suc m, n => suc (m + n)
@@ -53,13 +53,13 @@ def +-assoc (x y z : Nat) : x + (y + z) = (x + y) + z
   | zero, y, z => idp _
   | suc x, y, z => pmap suc (+-assoc x y z)
 
-def infixl * (m n : Nat) : Nat
+def overlap infixl * (m n : Nat) : Nat
   | zero, n => zero
   | m, zero => zero
   | suc m, suc n => suc (m + n + m * n)
   bind tighter +
 
-def infixl *' (m n : Nat) : Nat
+def overlap infixl *' (m n : Nat) : Nat
   | zero, n => zero
   | m, zero => zero
   | suc m, n => n + m *' n
@@ -77,11 +77,11 @@ def *'-suc-suc (m n : Nat) : suc m *' suc n = suc (m + n + m *' n)
     ~ +-assoc n m (m *' n)
     ~ pmap (+ m *' n) (+-comm n m))
 
-def *-*'-iso (m n : Nat) : m * n = m *' n
+def overlap *-*'-iso (m n : Nat) : m * n = m *' n
   | zero, n => idp _
   | m, zero => idp _
   | suc m, suc n => pmap (\ x => suc (m + n + x)) (*-*'-iso m n) ~ sym (*'-suc-suc m n)
 
-def *-*'-eq : (*) = (*') => funext (*) (*') (\ m => funext (m *) (m *') (*-*'-iso m))
+def *-*'-eq : (*) = (*') => funExt (*) (*') (\ m => funExt (m *) (m *') (*-*'-iso m))
 
 def err_eq (m n : Nat) : m * n = m *' n => pmap (\ f => f m n) *-*'-eq

--- a/base/src/test/resources/success/issues2/issue83.aya
+++ b/base/src/test/resources/success/issues2/issue83.aya
@@ -1,6 +1,6 @@
 open data N : Type | zero | suc N
 
-def infix + (a b : N) : N
+def overlap infix + (a b : N) : N
   | zero, a => a
   | a, zero => a
   | suc a, b => suc (a + b)

--- a/base/src/test/resources/success/lambda-tuple-infer.aya
+++ b/base/src/test/resources/success/lambda-tuple-infer.aya
@@ -2,7 +2,7 @@ open data ℕ : Type
   | zero
   | suc ℕ
 
-def infix + (a b : ℕ) : ℕ
+def overlap infix + (a b : ℕ) : ℕ
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (a + b)

--- a/base/src/test/resources/success/nat-ind-add.aya
+++ b/base/src/test/resources/success/nat-ind-add.aya
@@ -6,23 +6,23 @@ open data Int : Type
  | pos Nat
  | neg Nat { | zero => pos zero }
 
-def addN (a b : Nat) : Nat
+def overlap addN (a b : Nat) : Nat
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (addN a b)
  | a, suc b => suc (addN a b)
 
-def randomTest (a b : Nat) : Type
+def overlap randomTest (a b : Nat) : Type
  | zero, a => Nat -> Nat
  | a, zero => Nat -> Nat
  | suc a, suc b => Sig Nat ** Nat
 
-def subNI (a b : Nat) : Int
+def overlap subNI (a b : Nat) : Int
  | zero, a => neg a
  | a, zero => pos a
  | suc a, suc b => subNI a b
 
-def addI (a b : Int) : Int
+def overlap addI (a b : Int) : Int
  | pos zero, n => n
  | n, pos zero => n
  | neg zero, n => n

--- a/base/src/test/resources/success/nat-monoid.aya
+++ b/base/src/test/resources/success/nat-monoid.aya
@@ -27,7 +27,7 @@ struct Monoid { A : Type } ( op : A -> A -> A ): Type
   | id_r (a: A) : op a (id unit) = a
   | id_l (a: A) : op (id unit) a = a
 
-def infix + ( a b : Nat ) : Nat
+def overlap infix + ( a b : Nat ) : Nat
  | zero, a => a
  | a, zero => a
  | suc a, b => suc (a + b)

--- a/base/src/test/resources/success/redblack.aya
+++ b/base/src/test/resources/success/redblack.aya
@@ -1,0 +1,160 @@
+---- HoTT-I ----
+prim I
+prim left
+prim right
+prim arcoe
+struct Path (A : I -> Type) (a : A left) (b : A right) : Type
+  | at (i : I) : A i {
+    | left => a
+    | right => b
+  }
+def path {A : I -> Type} (p : Pi (i : I) -> A i)
+  => new Path A (p left) (p right) { | at i => p i }
+def infix = {A : Type} (a b : A) : Type => Path (\ i => A) a b
+def idp {A : Type} {a : A} : a = a => path (\ i => a)
+
+def hfill2d {A : Type}
+  {a b c d : A}
+  (p : a = b)
+  (q : b = d)
+  (r : a = c)
+  (i j : I) : A
+  => (arcoe (\ k => r.at k = q.at k) p i).at j
+def hcomp2d {A : Type}
+  {a b c d : A}
+  (p : a = b)
+  (q : b = d)
+  (r : a = c) : c = d
+  => path (hfill2d p q r right)
+
+def sym {A : Type} {a b : A} (p : a = b) : b = a => hcomp2d idp idp p
+def infix <==> {A : Type} {a b c : A} (p : a = b) (q : b = c) : a = c => hcomp2d p q idp
+def pmap {A B : Type} (f : A -> B) {a b : A} (p : a = b)
+  : f a = f b => path (\ i => f (p.at i))
+
+---- Basic types ----
+
+open data Nat | zero | suc Nat
+open data Bool | false | true
+
+open data Fin (n : Nat)
+| suc n => fzero
+| suc n => fsuc (Fin n)
+
+---- List ----
+
+open data List (A : Type) : Type
+| nil
+| infixr cons A (List A)
+bind tighter =
+
+def length {A : Type} (l : List A) : Nat
+| nil => zero
+| a cons l => suc (length l)
+
+def infix !! {A : Type} (l : List A) (i : Fin (length l)) : A
+| a cons l, fzero => a
+| a cons l, fsuc i => l !! i
+
+def overlap infixr ++ {A : Type} (xs ys : List A) : List A
+| nil, ys => ys
+| xs, nil => xs
+| a cons xs, ys => a cons xs ++ ys
+bind tighter cons
+
+def ++-assoc {A : Type} {xs ys zs : List A} : (xs ++ ys) ++ zs = xs ++ (ys ++ zs)
+| {A}, {nil} => idp
+| {A}, {x cons xs} => pmap (x cons) ++-assoc
+
+def ++nil {A : Type} {l : List A} : l ++ nil = l
+| {B}, {nil} => idp
+| {A}, {a cons l} => pmap (a cons) ++nil
+
+def map {A B : Type} (f : A -> B) (l : List A) : List B
+| f, nil => nil
+| f, a cons l => f a cons map f l
+
+def length_map {A B : Type} (f : A -> B) (l : List A) : length (map f l) = length l
+| f, nil => idp
+| f, a cons l => pmap suc (length_map f l)
+
+def map_comp {A B C : Type} (g : B -> C) (f : A -> B) (l : List A) : map (\x => g (f x)) l = map g (map f l)
+| g, f, nil => idp
+| g, f, a cons l => pmap (g _ cons) (map_comp g f l)
+
+def map_id {A : Type} (l : List A) : map (\x => x) l = l
+| nil => idp
+| a cons l => pmap (a cons) (map_id l)
+
+def headDef {A : Type} (x : A) (xs : List A) : A
+| x, nil => x
+| x, a cons b => a
+
+def curry {A B C : Type} (t : Sig A ** B) (f : A -> B -> C) => f t.1 t.2
+
+def splitAt {A : Type} (n : Nat) (l : List A) : Sig (List A) ** (List A)
+| zero, l => (nil, l)
+| suc n, nil => (nil, nil)
+| suc n, a cons l => curry (splitAt n l) (\l1 l2 => (a cons l1, l2))
+
+def take {A : Type} (n : Nat) (l : List A) => (splitAt n l).1
+
+def drop {A : Type} (n : Nat) (l : List A) => (splitAt n l).2
+
+def replace {A : Type} (l : List A) (i s : Nat) (r : List A) =>
+  curry (splitAt i l) (\l1 l2 => l1 ++ r ++ drop s l2)
+
+def splitAt-appendLem {A : Type} (n : Nat) (l : List A) : take n l ++ drop n l = l
+| zero, l => idp
+| suc n, nil => idp
+| suc n, a cons l => pmap (a cons) (splitAt-appendLem n l)
+
+def slice {A : Type} (l : List A) (i s : Nat) => take s (drop i l)
+
+def slice-appendLem {A : Type} (l : List A) (i s : Nat)
+   : take i l ++ (slice l i s ++ drop s (drop i l)) = l
+| l, zero, s => splitAt-appendLem s l
+| nil, suc i, zero => idp
+| nil, suc i, suc s => idp
+| a cons l, suc i, s => pmap (a cons) (slice-appendLem l i s)
+
+---- Red black trees ----
+
+open data Color | red | black
+open data RBTree (A : Type) : Type
+| rbLeaf
+| rbBranch Color (RBTree A) A (RBTree A)
+
+def rbTreeToList {A : Type} (t : RBTree A) (r : List A) : List A
+| rbLeaf, r => r
+| rbBranch x t1 a t2, r => rbTreeToList t1 (a cons rbTreeToList t2 r)
+
+def repaint {A : Type} (t : RBTree A) : RBTree A
+| rbBranch c l a r => rbBranch black l a r
+| rbLeaf => rbLeaf
+
+def balanceLeft {A : Type} (c : Color) (l : RBTree A) (v : A) (r : RBTree A) : RBTree A
+| black, rbBranch red (rbBranch red a x b) y c, v, r => rbBranch red (rbBranch black a x b) y (rbBranch black c v r)
+| black, rbBranch red a x (rbBranch red b y c), v, r => rbBranch red (rbBranch black a x b) y (rbBranch black c v r)
+| c, a, v, r => rbBranch c a v r
+
+def balanceRight {A : Type} (c : Color) (l : RBTree A) (v : A) (r : RBTree A) : RBTree A
+| black, l, v, rbBranch red (rbBranch red b y c) z d => rbBranch red (rbBranch black l v b) y (rbBranch black c z d)
+| black, l, v, rbBranch red b y (rbBranch red c z d) => rbBranch red (rbBranch black l v b) y (rbBranch black c z d)
+| c, l, v, b => rbBranch c l v b
+
+def Decider (A : Type) => Pi (x y : A) -> Bool
+
+def insert-lemma {A : Type} (dec< : Decider A) (a a1 : A) (c : Color) (l1 l2 : RBTree A) (a1<a : Bool) : RBTree A
+| dec<, a, a1, c, l1, l2, true => balanceRight c l1 a1 (insert a l2 dec<)
+| dec<, a, a1, c, l1, l2, false => balanceLeft c (insert a l1 dec<) a1 l2
+
+def insert {A : Type} (a : A) (t : RBTree A) (dec< : Decider A) : RBTree A
+| a, rbLeaf, dec< => rbBranch red rbLeaf a rbLeaf
+| a, rbBranch c l1 a1 l2, dec< => insert-lemma dec< a a1 c l1 l2 (dec< a1 a)
+
+def aux {A : Type} (l : List A) (r : RBTree A) (dec< : Decider A) : RBTree A
+| nil, r, dec< => r
+| a cons l, r, dec< => aux l (repaint (insert a r dec<)) dec<
+
+def tree-sort {A : Type} (dec< : Decider A) (l : List A) => rbTreeToList (aux l rbLeaf dec<) nil

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
@@ -25,6 +25,8 @@ ULEVEL : 'universe';
 TYPE : 'Type';
 
 // other keywords
+// principal: add `_KW` suffix to avoid conflict with a potential rule name.
+// if it seems impossible, then forget about it.
 AS : 'as';
 OPEN : 'open';
 IMPORT : 'import';
@@ -35,6 +37,7 @@ HIDING : 'hiding';
 COERCE : 'coerce';
 OPAQUE : 'opaque';
 INLINE : 'inline';
+OVERLAP : 'overlap';
 MODULE_KW : 'module';
 BIND_KW : 'bind';
 MATCH : 'match';

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -60,6 +60,7 @@ fnBody : IMPLIES expr
 
 fnModifiers : OPAQUE
             | INLINE
+            | OVERLAP
             | PATTERN_KW
             ;
 


### PR DESCRIPTION
Addresses the problem raised in #98.

Summary:
+ The title.
+ We mean "reduce according to `overlap` modifier" by: if we have that modifier { try to unfold on each clause anyway }, otherwise { try to unfold, if we see a blocked reduction, fail directly }.
+ When checking conditions, we also reduce according to the `overlap` modifier (`orderIndependent` parameter which is passed everywhere).
+ When checking confluence, if we don't have an `overlap` modifier, we still traverse the classification, but we only generate domination warnings in a different way (if any) (see `firstMatchDomination`).
+ A [red-black tree](https://github.com/aya-prover/aya-dev/blob/281670a088f224e1cfe73678254dc91668f5a356/base/src/test/resources/success/redblack.aya) (no deletion, used to sort a list) showcase.
+ Conditions are always required to be confluent to avoid a bug in Arend:

```arend
\data Adams
  | abel Nat
  | cain Nat Nat \with {
    | zero, a => abel a
    | a, zero => abel (suc a)
  }
\func Adams-id (a : Adams) : Adams
  | abel n => abel n
  | cain n m => cain n m
```

I forgot to open an issue about it, and I'm not in the mood of opening issues.

bors d=imkiva