### PR TITLE
Enhance error report for rbTree

### DIFF
--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -11,6 +11,7 @@ import org.aya.concrete.Expr;
 import org.aya.concrete.Pattern;
 import org.aya.concrete.resolve.context.Context;
 import org.aya.core.def.*;
+import org.aya.core.term.Term;
 import org.aya.generic.Modifier;
 import org.aya.util.binop.OpDecl;
 import org.aya.util.error.SourcePos;
@@ -125,6 +126,8 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
   public static final class DataCtor extends Signatured implements OpDecl {
     public final @NotNull DefVar<CtorDef, Decl.DataCtor> ref;
     public DefVar<DataDef, DataDecl> dataRef;
+    /** Similar to {@link Signatured#signature}, but stores the bindings in {@link DataCtor#patterns} */
+    public ImmutableSeq<Term.Param> patternTele;
     public @NotNull ImmutableSeq<Pattern.Clause> clauses;
     public @NotNull ImmutableSeq<Pattern> patterns;
     public final @Nullable OpDecl.OpInfo opInfo;

--- a/base/src/main/java/org/aya/core/def/CtorDef.java
+++ b/base/src/main/java/org/aya/core/def/CtorDef.java
@@ -46,12 +46,11 @@ public final class CtorDef extends SubLevelDef {
   telescopes(@NotNull DefVar<CtorDef, Decl.DataCtor> defVar, ImmutableSeq<Sort> sort) {
     var core = defVar.core;
     if (core != null) return new DataDef.CtorTelescopes(core.ownerTele, sort, core.selfTele);
-    // TODO[ice]: put ownerTele into ctor concrete signature and use that instead
-    var dataSignature = defVar.concrete.dataRef.concrete.signature;
+    var dataSignature = defVar.concrete.patternTele;
     assert dataSignature != null;
     var conSignature = defVar.concrete.signature;
     assert conSignature != null;
-    return new DataDef.CtorTelescopes(dataSignature.param(), sort, conSignature.param());
+    return new DataDef.CtorTelescopes(dataSignature, sort, conSignature.param());
   }
 
   @Override public <P, R> R accept(@NotNull Visitor<P, R> visitor, P p) {

--- a/base/src/main/java/org/aya/core/def/CtorDef.java
+++ b/base/src/main/java/org/aya/core/def/CtorDef.java
@@ -45,15 +45,8 @@ public final class CtorDef extends SubLevelDef {
   public static @NotNull DataDef.CtorTelescopes
   telescopes(@NotNull DefVar<CtorDef, Decl.DataCtor> defVar, ImmutableSeq<Sort> sort) {
     var core = defVar.core;
-    if (core != null) {
-      var dataDef = core.dataRef.core;
-      var conTelescope = core.selfTele;
-      if (dataDef != null)
-        return new DataDef.CtorTelescopes(dataDef.telescope, sort, conTelescope);
-      var signature = core.dataRef.concrete.signature;
-      assert signature != null;
-      return new DataDef.CtorTelescopes(signature.param(), sort, conTelescope);
-    }
+    if (core != null) return new DataDef.CtorTelescopes(core.ownerTele, sort, core.selfTele);
+    // TODO[ice]: put ownerTele into ctor concrete signature and use that instead
     var dataSignature = defVar.concrete.dataRef.concrete.signature;
     assert dataSignature != null;
     var conSignature = defVar.concrete.signature;

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -191,10 +191,10 @@ public record StmtTycker(
         .<Var, Term>toImmutableMap();
       dataCall = (CallTerm.Data) dataCall.subst(subst);
     }
+    ctor.patternTele = pat.isEmpty() ? dataParamView.map(Term.Param::implicitify).toImmutableSeq() : Pat.extractTele(pat);
     var elabClauses = patTycker.elabClauses(signature, ctor.clauses);
     var matchings = elabClauses.flatMap(Pat.PrototypeClause::deprototypify);
-    var implicits = pat.isEmpty() ? dataParamView.map(Term.Param::implicitify).toImmutableSeq() : Pat.extractTele(pat);
-    var elaborated = new CtorDef(dataRef, ctor.ref, pat, implicits, tele, matchings, dataCall, ctor.coerce);
+    var elaborated = new CtorDef(dataRef, ctor.ref, pat, ctor.patternTele, tele, matchings, dataCall, ctor.coerce);
     if (patTycker.noError())
       ensureConfluent(tycker, signature, elabClauses, matchings, ctor.sourcePos, false, true);
     return elaborated;

--- a/base/src/main/java/org/aya/tyck/pat/ClausesProblem.java
+++ b/base/src/main/java/org/aya/tyck/pat/ClausesProblem.java
@@ -8,7 +8,9 @@ import kala.collection.immutable.ImmutableSeq;
 import org.aya.api.distill.DistillerOptions;
 import org.aya.api.error.Problem;
 import org.aya.concrete.Pattern;
+import org.aya.core.def.CtorDef;
 import org.aya.core.pat.Pat;
+import org.aya.core.term.CallTerm;
 import org.aya.core.term.Term;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.doc.Style;
@@ -102,6 +104,22 @@ public sealed interface ClausesProblem extends Problem {
       return Doc.sep(
         Doc.english("Cannot perform pattern matching"),
         Doc.styled(Style.code(), pat.toDoc(options))
+      );
+    }
+  }
+
+  record UnsureCase(
+    @Override @NotNull SourcePos sourcePos,
+    @NotNull CtorDef ctor,
+    @NotNull CallTerm.Data dataCall
+  ) implements ClausesProblem {
+    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.vcat(
+        // Use `unsure` instead of `not sure`, which is used in Agda
+        Doc.english("I'm unsure if there should be a case for constructor"),
+        Doc.par(1, ctor.toDoc(options)),
+        Doc.english("because I got stuck on the index unification of type"),
+        Doc.par(1, dataCall.toDoc(options))
       );
     }
   }

--- a/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
@@ -22,7 +22,7 @@ public sealed interface PatternProblem extends Problem {
 
   record BlockedEval(@Override @NotNull Pattern pattern, @NotNull CallTerm.Data dataCall) implements PatternProblem {
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
-      return Doc.sep(
+      return Doc.vcat(
         Doc.english("Unsure if this pattern is actually impossible, as constructor selection is blocked on:"),
         Doc.par(1, dataCall.toDoc(options)));
     }
@@ -51,12 +51,10 @@ public sealed interface PatternProblem extends Problem {
     }
   }
 
-  record UnavailableCtor(@Override @NotNull Pattern pattern,
-                         @NotNull CallTerm.Data dataCall) implements PatternProblem {
-    @Override public @NotNull Severity level() {
-      return Severity.ERROR;
-    }
-
+  record UnavailableCtor(
+    @Override @NotNull Pattern pattern,
+    @NotNull CallTerm.Data dataCall
+  ) implements PatternProblem {
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
       return Doc.vcat(
         Doc.english("Cannot match with"),

--- a/base/src/test/resources/failure/patterns/unsure-missing.aya
+++ b/base/src/test/resources/failure/patterns/unsure-missing.aya
@@ -1,0 +1,17 @@
+open data Nat | zero | suc Nat
+open data Fin+1 (n : Nat) : Type
+ | m => fzero
+ | suc m => fsuc (Fin+1 m)
+
+def overlap addN (a b : Nat) : Nat
+ | zero, a => a
+ | a, zero => a
+ | suc a, b => suc (addN a b)
+ | a, suc b => suc (addN a b)
+
+def finToNat (n : Nat) (att : Fin+1 n) : Nat
+ | n, fzero => zero
+ | suc n, fsuc a => suc (finToNat n a)
+
+def addF (m n : Nat) (a : Fin+1 m) (b : Fin+1 n) : Fin+1 (addN (finToNat m a) n)
+ | m, n, fzero, a => a

--- a/base/src/test/resources/failure/patterns/unsure-missing.aya.txt
+++ b/base/src/test/resources/failure/patterns/unsure-missing.aya.txt
@@ -1,0 +1,14 @@
+In file $FILE:16:4 ->
+
+  14 |  | suc n, fsuc a => suc (finToNat n a)
+  15 | 
+  16 | def addF (m n : Nat) (a : Fin+1 m) (b : Fin+1 n) : Fin+1 (addN (finToNat m a) n)
+           ^--^
+
+Error: I'm unsure if there should be a case for constructor
+         | suc m => fsuc (_ : Fin+1 m)
+       because I got stuck on the index unification of type
+         Fin+1 m
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/success/redblack.aya
+++ b/base/src/test/resources/success/redblack.aya
@@ -118,43 +118,129 @@ def slice-appendLem {A : Type} (l : List A) (i s : Nat)
 | nil, suc i, suc s => idp
 | a cons l, suc i, s => pmap (a cons) (slice-appendLem l i s)
 
----- Red black trees ----
+---- Red black tree, extrinsic ----
 
-open data Color | red | black
-open data RBTree (A : Type) : Type
-| rbLeaf
-| rbBranch Color (RBTree A) A (RBTree A)
+module RedBlackEx {
+  open data Color | red | black
+  open data RBTree (A : Type) : Type
+  | rbLeaf
+  | rbNode Color (RBTree A) A (RBTree A)
 
-def rbTreeToList {A : Type} (t : RBTree A) (r : List A) : List A
-| rbLeaf, r => r
-| rbBranch x t1 a t2, r => rbTreeToList t1 (a cons rbTreeToList t2 r)
+  def rbTreeToList {A : Type} (RBTree A) (List A) : List A
+  | rbLeaf, r => r
+  | rbNode x t1 a t2, r => rbTreeToList t1 (a cons rbTreeToList t2 r)
 
-def repaint {A : Type} (t : RBTree A) : RBTree A
-| rbBranch c l a r => rbBranch black l a r
-| rbLeaf => rbLeaf
+  def repaint {A : Type} (RBTree A) : RBTree A
+  | rbNode c l a r => rbNode black l a r
+  | rbLeaf => rbLeaf
 
-def balanceLeft {A : Type} (c : Color) (l : RBTree A) (v : A) (r : RBTree A) : RBTree A
-| black, rbBranch red (rbBranch red a x b) y c, v, r => rbBranch red (rbBranch black a x b) y (rbBranch black c v r)
-| black, rbBranch red a x (rbBranch red b y c), v, r => rbBranch red (rbBranch black a x b) y (rbBranch black c v r)
-| c, a, v, r => rbBranch c a v r
+  def balanceLeft {A : Type} Color (RBTree A) A (RBTree A) : RBTree A
+  | black, rbNode red (rbNode red a x b) y c, v, r => rbNode red (rbNode black a x b) y (rbNode black c v r)
+  | black, rbNode red a x (rbNode red b y c), v, r => rbNode red (rbNode black a x b) y (rbNode black c v r)
+  | c, a, v, r => rbNode c a v r
 
-def balanceRight {A : Type} (c : Color) (l : RBTree A) (v : A) (r : RBTree A) : RBTree A
-| black, l, v, rbBranch red (rbBranch red b y c) z d => rbBranch red (rbBranch black l v b) y (rbBranch black c z d)
-| black, l, v, rbBranch red b y (rbBranch red c z d) => rbBranch red (rbBranch black l v b) y (rbBranch black c z d)
-| c, l, v, b => rbBranch c l v b
+  def balanceRight {A : Type} Color (RBTree A) A (RBTree A) : RBTree A
+  | black, l, v, rbNode red (rbNode red b y c) z d => rbNode red (rbNode black l v b) y (rbNode black c z d)
+  | black, l, v, rbNode red b y (rbNode red c z d) => rbNode red (rbNode black l v b) y (rbNode black c z d)
+  | c, l, v, b => rbNode c l v b
 
-def Decider (A : Type) => Pi (x y : A) -> Bool
+  def Decider (A : Type) => Pi (x y : A) -> Bool
 
-def insert-lemma {A : Type} (dec< : Decider A) (a a1 : A) (c : Color) (l1 l2 : RBTree A) (a1<a : Bool) : RBTree A
-| dec<, a, a1, c, l1, l2, true => balanceRight c l1 a1 (insert a l2 dec<)
-| dec<, a, a1, c, l1, l2, false => balanceLeft c (insert a l1 dec<) a1 l2
+  def insert-lemma {A : Type} (Decider A) (a a1 : A) Color (l1 l2 : RBTree A) Bool : RBTree A
+  | dec<, a, a1, c, l1, l2, true => balanceRight c l1 a1 (insert a l2 dec<)
+  | dec<, a, a1, c, l1, l2, false => balanceLeft c (insert a l1 dec<) a1 l2
 
-def insert {A : Type} (a : A) (t : RBTree A) (dec< : Decider A) : RBTree A
-| a, rbLeaf, dec< => rbBranch red rbLeaf a rbLeaf
-| a, rbBranch c l1 a1 l2, dec< => insert-lemma dec< a a1 c l1 l2 (dec< a1 a)
+  def insert {A : Type} A (RBTree A) (Decider A) : RBTree A
+  | a, rbLeaf, dec< => rbNode red rbLeaf a rbLeaf
+  | a, rbNode c l1 a1 l2, dec< => insert-lemma dec< a a1 c l1 l2 (dec< a1 a)
 
-def aux {A : Type} (l : List A) (r : RBTree A) (dec< : Decider A) : RBTree A
-| nil, r, dec< => r
-| a cons l, r, dec< => aux l (repaint (insert a r dec<)) dec<
+  def aux {A : Type} (List A) (RBTree A) (Decider A) : RBTree A
+  | nil, r, dec< => r
+  | a cons l, r, dec< => aux l (repaint (insert a r dec<)) dec<
 
-def tree-sort {A : Type} (dec< : Decider A) (l : List A) => rbTreeToList (aux l rbLeaf dec<) nil
+  def tree-sort {A : Type} (dec< : Decider A) (l : List A) => rbTreeToList (aux l rbLeaf dec<) nil
+}
+
+---- Red black tree, intrinsic ----
+
+module RedBlackIn {
+  open RedBlackEx using (Color, Decider)
+  open RedBlackEx::Color using (red, black)
+  open data Tree (A : Type) Color Nat : Type
+  | A, black, zero => rbLeaf
+  | A, red, n => rbRed (Tree A black n) A (Tree A black n)
+  | A, black, suc n => rbBlack {c1 c2 : Color} (Tree A c1 n) A (Tree A c2 n)
+
+  def RBTree (A : Type) : Type => Sig (n : Nat) ** (Tree A black n)
+
+  open data HTree (A : Type) Nat : Type
+  | A, m => hRed (Tree A red m)
+  | A, suc m => hBlack (Tree A black (suc m))
+
+  open data AlmostTreeData (A : Type) Color Nat : Type
+  | A, black, suc n => alBlack {c1 c2 : Color} (Tree A c1 n) A (Tree A c2 n)
+  | A, red, n => alRed {c1 c2 : Color} (Tree A c1 n) A (Tree A c2 n)
+  def AlmostTree (A : Type) (n : Nat) : Type => Sig (c : Color) ** (AlmostTreeData A c n)
+
+  def balanceLeftRed {A : Type} {n : Nat} {c : Color} (HTree A n) A (Tree A c n)
+    : AlmostTree A n
+  | hRed l, x, r => (_, alRed l x r)
+  | {A}, {suc n}, hBlack l, x, r => (_, alRed l x r)
+
+  def balanceRightRed {A : Type} {n : Nat} {c : Color} (Tree A c n) A (HTree A n)
+    : AlmostTree A n
+  | l, x, hRed r => (_, alRed l x r)
+  | {A}, {suc n}, l, x, hBlack r => (_, alRed l x r)
+
+  def balanceLeftBlack {A : Type} {n : Nat} {c : Color} (AlmostTree A n) A (Tree A c n)
+    : HTree A (suc n)
+  -- rotation
+  | (red, alRed {red} (rbRed a x b) y c), z, d => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
+  | (red, alRed {c1} {red} a x (rbRed b y c)), z, d => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
+  -- expand catch-all for different proofs
+  | {A}, {zero}, (red, alRed {black} {black} rbLeaf x rbLeaf), y, r => hBlack (rbBlack (rbRed rbLeaf x rbLeaf) y r)
+  | {A}, {suc n}, (red, alRed {black} {black} l x r), y, c => hBlack (rbBlack (rbRed l x r) y c)
+  | {A}, {suc n}, (black, alBlack a x b), y, r => hBlack (rbBlack (rbBlack a x b) y r)
+
+  def balanceRightBlack {A : Type} {n : Nat} {c : Color} (Tree A c n) A (AlmostTree A n)
+    : HTree A (suc n)
+  -- rotation
+  | a, x, (red, alRed {red} (rbRed b y c) z d) => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
+  | a, x, (red, alRed {c1} {red} b y (rbRed c z d)) => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
+  -- ditto
+  | {A}, {zero}, a, x, (red, alRed {black} {black} rbLeaf y rbLeaf) => hBlack (rbBlack a x (rbRed rbLeaf y rbLeaf))
+  | {A}, {suc n}, a, x, (red, alRed {black} {black} l y r) => hBlack (rbBlack a x (rbRed l y r))
+  | {A}, {suc n}, a, x, (black, alBlack b y c) => hBlack (rbBlack a x (rbBlack b y c))
+
+  def forget {A : Type} {n : Nat} (HTree A n) : AlmostTree A n
+  | hRed (rbRed l x r) => (_, alRed l x r)
+  | {A}, {suc n}, hBlack (rbBlack l x r) => (_, alBlack l x r)
+
+  def insertBlack {A : Type} {n : Nat} (Tree A black n) A (Decider A) : HTree A n
+  | {A}, {zero}, rbLeaf, x, dec< => hRed (rbRed rbLeaf x rbLeaf)
+  | {A}, {suc n}, rbBlack l y r, x, dec< => insertBlack-lemma dec< l y r x (dec< x y)
+
+  def insertBlack-lemma {A : Type} {n : Nat} {c1 c2 : Color}
+      (Decider A) (Tree A c1 n) A (Tree A c2 n) A Bool
+    : HTree A (suc n)
+  | dec<, l, y, r, x, true => balanceLeftBlack (insertRed l x dec<) y r
+  | dec<, l, y, r, x, false => balanceRightBlack l x (insertRed r x dec<)
+
+  def insertRed {A : Type} {n : Nat} {c : Color} (Tree A c n) A (Decider A) : AlmostTree A n
+  | {A}, {zero}, {black}, rbLeaf, x, dec< => forget (insertBlack rbLeaf x dec<)
+  | {A}, {suc n}, {black}, rbBlack l y r, x, dec< => forget (insertBlack (rbBlack l y r) x dec<)
+  | {A}, {n}, {red}, rbRed l y r, x, dec< => insert-lemma dec< l y r x (dec< x y)
+
+  def insert-lemma {A : Type} {n : Nat} (Decider A)
+      (Tree A black n) A (Tree A black n) A Bool
+    : AlmostTree A n
+  | dec<, l, y, r, x, true => balanceLeftRed (insertBlack l x dec<) y r
+  | dec<, l, y, r, x, false => balanceRightRed l y (insertBlack r x dec<)
+
+  def dyeRoot {A : Type} {n : Nat} (HTree A n) : RBTree A
+  | hRed (rbRed l x r) => (_, rbBlack l x r)
+  | {A}, {suc n}, hBlack (rbBlack l x r) => (_, rbBlack l x r)
+
+  def insert {A : Type} {n : Nat} (t : RBTree A) (x : A) (dec< : Decider A)
+      => dyeRoot (insertBlack t.2 x dec<)
+}

--- a/lsp/src/main/java/org/aya/lsp/server/AyaService.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaService.java
@@ -206,7 +206,7 @@ public class AyaService implements WorkspaceService, TextDocumentService {
     }
 
     @Override public @NotNull Severity level() {
-      return owner.level();
+      return Severity.INFO;
     }
 
     @Override public @NotNull Doc brief(@NotNull DistillerOptions options) {

--- a/tools/src/main/java/org/aya/util/ArrayUtil.java
+++ b/tools/src/main/java/org/aya/util/ArrayUtil.java
@@ -1,0 +1,56 @@
+// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.util;
+
+import kala.tuple.Tuple;
+import kala.tuple.Tuple2;
+import kala.tuple.Tuple3;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Array;
+import java.util.function.Function;
+
+@SuppressWarnings("unchecked")
+public interface ArrayUtil {
+  static <A> A @NotNull [] map(A @NotNull [] array, Function<A, A> f) {
+    var a = (A[]) Array.newInstance(array.getClass().componentType(), array.length);
+    for (int i = 0; i < array.length; i++) a[i] = f.apply(array[i]);
+    return a;
+  }
+
+  static <A, B> B @NotNull [] map(A @NotNull [] array, B @NotNull [] outTyper, Function<A, B> f) {
+    var b = (B[]) Array.newInstance(outTyper.getClass().componentType(), array.length);
+    for (int i = 0; i < array.length; i++) b[i] = f.apply(array[i]);
+    return b;
+  }
+
+  static <A> A @NotNull [] map(A @NotNull [] array, Function<A, A> f, int start, int end) {
+    var a = (A[]) Array.newInstance(array.getClass().componentType(), end - start);
+    for (int i = start; i < end; i++) a[i - start] = f.apply(array[i]);
+    return a;
+  }
+
+  static <A> A @NotNull [] map(A @NotNull [] array, Function<A, A> f, int start) {
+    return map(array, f, start, array.length);
+  }
+
+  static <A, B> @NotNull Tuple2<A, B> @NotNull [] zip(A @NotNull [] a, B @NotNull [] b) {
+    var len = Math.min(a.length, b.length);
+    var c = new Tuple2[len];
+    for (int i = 0; i < len; i++) c[i] = Tuple.of(a[i], b[i]);
+    return c;
+  }
+
+  static <A, B, C> @NotNull Tuple3<A, B, C> @NotNull [] zip(A @NotNull [] a, B @NotNull [] b, C @NotNull [] c) {
+    var len = Math.min(a.length, Math.min(b.length, c.length));
+    var d = new Tuple3[len];
+    for (int i = 0; i < len; i++) d[i] = Tuple.of(a[i], b[i], c[i]);
+    return d;
+  }
+
+  static <A> boolean identical(A @NotNull [] a, A @NotNull [] b) {
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) if (a[i] != b[i]) return false;
+    return true;
+  }
+}


### PR DESCRIPTION
Summary:

+ Added `ArrayUtil` 🍒-picked from `arrays` branch (#192)
+ Now index unification failure in constructor selection (in coverage checker) is taken carefully: if the failure is due to a stuck case and there aren't any catch-all patterns, we report an error. (in case there are no patterns, we do not report error, as this will eventually become either an impossible case or a missing case)
+ Added indexed redblack tree (I blame @dramforever for pushing me to do this, it took me the entire afternoon!! But I also appreciate it as this helped me discovering all these bugs)
+ Since `ownerTele` in `CtorDef` isn't equal to the corresponding `DataDef.telescope()` (so in case core of a concall is missing, we can't retrieve `ownerTele`!! This is impossible yet, but may once become possible). To address this problem, we now store `ownerTele` into `CtorDecl.patternTele`.

https://github.com/aya-prover/aya-dev/blob/54c167ba509d63114df816440fb7e70796b13689/base/src/main/java/org/aya/tyck/StmtTycker.java#L194

This line of code constructs `CtorDef.ownerTele`, which is certainly not always the dataParams.