### PR TITLE
Pretty printing enhancements

### DIFF
--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -157,6 +157,15 @@ public sealed interface Expr extends ConcreteExpr {
     }
   }
 
+  static @NotNull Expr unapp(@NotNull Expr expr, @NotNull DynamicSeq<NamedArg> args) {
+    while (expr instanceof AppExpr app) {
+      args.append(app.argument);
+      expr = app.function;
+    }
+    args.reverse();
+    return expr;
+  }
+
   /**
    * @author AustinZhu
    */

--- a/base/src/main/java/org/aya/core/term/ElimTerm.java
+++ b/base/src/main/java/org/aya/core/term/ElimTerm.java
@@ -41,11 +41,12 @@ public sealed interface ElimTerm extends Term {
     }
   }
 
-  static @NotNull Term underlyingHead(@NotNull Term term, DynamicSeq<Arg<@NotNull Term>> args) {
+  static @NotNull Term unapp(@NotNull Term term, DynamicSeq<Arg<@NotNull Term>> args) {
     while (term instanceof ElimTerm.App app) {
       args.append(app.arg);
       term = app.of;
     }
+    args.reverse();
     return term;
   }
 }

--- a/base/src/main/java/org/aya/core/term/FormTerm.java
+++ b/base/src/main/java/org/aya/core/term/FormTerm.java
@@ -45,7 +45,7 @@ public sealed interface FormTerm extends Term {
   }
 
   static @NotNull Term unpi(@NotNull Term term, @NotNull DynamicSeq<Term.Param> params) {
-    if (term instanceof Pi pi) {
+    while (term instanceof Pi pi) {
       params.append(pi.param);
       term = pi.body;
     }

--- a/base/src/main/java/org/aya/core/term/FormTerm.java
+++ b/base/src/main/java/org/aya/core/term/FormTerm.java
@@ -44,6 +44,15 @@ public sealed interface FormTerm extends Term {
     }
   }
 
+  static @NotNull Term unpi(@NotNull Term term, @NotNull DynamicSeq<Term.Param> params) {
+    if (term instanceof Pi pi) {
+      params.append(pi.param);
+      term = pi.body;
+    }
+    params.reverse();
+    return term;
+  }
+
   /**
    * @author re-xyr
    */

--- a/base/src/main/java/org/aya/distill/BaseDistiller.java
+++ b/base/src/main/java/org/aya/distill/BaseDistiller.java
@@ -89,7 +89,7 @@ public abstract class BaseDistiller {
     return !ex && !as ? withAs : outer != Outer.Free && !noParams ? Doc.parened(withAs) : withAs;
   }
 
-  Doc visitTele(@NotNull SeqLike<? extends ParamLike<?>> telescope) {
+  @NotNull Doc visitTele(@NotNull SeqLike<? extends ParamLike<?>> telescope) {
     if (telescope.isEmpty()) return Doc.empty();
     var last = telescope.first();
     var buf = DynamicSeq.<Doc>create();

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -129,7 +129,7 @@ public class CoreDistiller extends BaseDistiller implements
 
   @Override public Doc visitApp(@NotNull ElimTerm.App term, Outer outer) {
     var args = DynamicSeq.of(term.arg());
-    var head = ElimTerm.underlyingHead(term.of(), args);
+    var head = ElimTerm.unapp(term.of(), args);
     if (head instanceof RefTerm.Field fieldRef) return visitCalls(fieldRef.ref(), FIELD_CALL, args, outer);
     return visitCalls(false, head.accept(this, Outer.AppHead), args.view(), outer);
   }
@@ -221,7 +221,7 @@ public class CoreDistiller extends BaseDistiller implements
       case Pat.Prim prim -> Doc.bracedUnless(linkRef(prim.ref(), CON_CALL), prim.explicit());
       case Pat.Ctor ctor -> {
         var pats = options.map.get(DistillerOptions.Key.ShowImplicitPats) ? ctor.params().view() : ctor.params().view().filter(Pat::explicit);
-        var ctorDoc = visitCalls(ctor.ref(), CON_CALL, pats.map(p -> new Arg<>(p.toTerm(), p.explicit())), outer);
+        var ctorDoc = visitCalls(ctor.ref(), CON_CALL, pats.map(Pat::toArg), outer);
         yield ctorDoc(outer, ctor.explicit(), ctorDoc, ctor.as(), ctor.params().isEmpty());
       }
       case Pat.Absurd absurd -> Doc.bracedUnless(Doc.styled(KEYWORD, "impossible"), absurd.explicit());

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -98,11 +98,13 @@ public class CoreDistiller extends BaseDistiller implements
     if (!options.map.get(DistillerOptions.Key.ShowImplicitPats) && !term.param().explicit()) {
       return term.body().accept(this, outer);
     }
+    var params = DynamicSeq.of(term.param());
+    var body = FormTerm.unpi(term.body(), params);
     var doc = Doc.sep(
       Doc.styled(KEYWORD, Doc.symbol("Pi")),
-      term.param().toDoc(options),
+      visitTele(params),
       Doc.symbol("->"),
-      term.body().accept(this, Outer.Codomain)
+      body.accept(this, Outer.Codomain)
     );
     // Add paren when it's not free or a codomain
     return checkParen(outer, doc, Outer.BinOp);

--- a/base/src/test/java/org/aya/concrete/ParseTest.java
+++ b/base/src/test/java/org/aya/concrete/ParseTest.java
@@ -274,8 +274,10 @@ public class ParseTest {
         """,
       """
         struct Path (A : I -> Type) (a : A left) (b : A right) : Type
-          | at (i : I) : A i {| left => a
-          | right => b}
+          | at (i : I) : A i {
+            | left => a
+            | right => b
+          }
         """
     );
     parseAndPretty(

--- a/base/src/test/resources/failure/patterns/issues/issue681.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues/issue681.aya.txt
@@ -8,8 +8,7 @@ In file $FILE:29:4 ->
 Error: There is no parameter for the pattern
          zero
        to match against, given the return type
-         Pi (x : Nat) -> Pi (y : Nat) -> Pi (z : Nat) -> (=) {Nat} (x + (y + z))
-        ((x + y) + z)
+         Pi (z y x : Nat) -> (=) {Nat} (x + (y + z)) ((x + y) + z)
        (and in case it's a function type, you may want to move its parameters before
        the `:` in the signature)
 
@@ -23,8 +22,7 @@ In file $FILE:30:4 ->
 Error: There is no parameter for the pattern
          suc x
        to match against, given the return type
-         Pi (x : Nat) -> Pi (y : Nat) -> Pi (z : Nat) -> (=) {Nat} (x + (y + z))
-        ((x + y) + z)
+         Pi (z y x : Nat) -> (=) {Nat} (x + (y + z)) ((x + y) + z)
        (and in case it's a function type, you may want to move its parameters before
        the `:` in the signature)
 


### PR DESCRIPTION
Fix #195.

Summary:
+ Blocks (conditions and `new` expression body) in concrete are now pretty printed with alignment and indentation
+ Pi type in core is now pretty printed in the beautiful way (nested pi will be shortened)
+ `AppTerm` and `AppExpr` has `unapp` implemented totally wrongly and are now fixed

bors r+