### PR TITLE
Implement "meta patteriables"

### DIFF
--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -237,8 +237,10 @@ public sealed interface Pat extends CorePat {
     @NotNull Option<Term> expr
   ) implements AyaDocile {
     @Override public @NotNull Doc toDoc(@NotNull DistillerOptions options) {
-      var doc = new CoreDistiller(options).visitMaybeCtorPatterns(
-        patterns, BaseDistiller.Outer.Free, Doc.COMMA);
+      var distiller = new CoreDistiller(options);
+      var pats = options.map.get(DistillerOptions.Key.ShowImplicitPats) ? patterns : patterns.view().filter(Pat::explicit);
+      var doc = Doc.emptyIf(pats.isEmpty(), () -> Doc.cat(Doc.ONE_WS, Doc.commaList(
+        pats.view().map(p -> distiller.visitPat(p, BaseDistiller.Outer.Free)))));
       if (expr.isDefined()) return Doc.sep(doc, Doc.symbol("=>"), expr.get().toDoc(options));
       else return doc;
     }

--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -78,6 +78,7 @@ public sealed interface Pat extends CorePat {
   record Meta(
     boolean explicit,
     @NotNull Ref<Pat> solution,
+    @NotNull LocalVar as, // placeholder name
     @NotNull Term type
   ) implements Pat {
     @Override public void storeBindings(@NotNull LocalCtx localCtx) {
@@ -86,12 +87,10 @@ public sealed interface Pat extends CorePat {
       // only used for constructor ownerTele extraction for simpler indexed types
     }
 
-    @Override public @Nullable LocalVar as() {
-      return null;
-    }
-
     @Override public @NotNull Pat zonk(@NotNull Zonker zonker) {
-      return solution.value.zonk(zonker);
+      var value = solution.value;
+      if (value == null) return new Bind(explicit, as, type);
+      return value.zonk(zonker);
     }
 
     @Override public @NotNull Pat rename(Substituter.@NotNull TermSubst subst, boolean explicit) {

--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -5,6 +5,7 @@ package org.aya.core.pat;
 import kala.collection.SeqLike;
 import kala.collection.immutable.ImmutableSeq;
 import kala.control.Option;
+import kala.value.Ref;
 import org.aya.api.core.CorePat;
 import org.aya.api.distill.AyaDocile;
 import org.aya.api.distill.DistillerOptions;
@@ -57,6 +58,22 @@ public sealed interface Pat extends CorePat {
   ) implements Pat {
     @Override public void storeBindings(@NotNull LocalCtx localCtx) {
       localCtx.put(as, type);
+    }
+  }
+
+  record Meta(
+    boolean explicit,
+    @NotNull Ref<Pat> solution,
+    @NotNull Term type
+  ) implements Pat {
+    @Override public void storeBindings(@NotNull LocalCtx localCtx) {
+      // Do nothing
+      // This is safe because storeBindings is called only in extractTele which is
+      // only used for constructor ownerTele extraction for simpler indexed types
+    }
+
+    @Override public @Nullable LocalVar as() {
+      return null;
     }
   }
 

--- a/base/src/main/java/org/aya/core/pat/PatMatcher.java
+++ b/base/src/main/java/org/aya/core/pat/PatMatcher.java
@@ -35,6 +35,7 @@ public record PatMatcher(@NotNull Substituter.TermSubst subst) {
     return tryBuildSubstTerms(pats, terms.view().map(Arg::term));
   }
 
+  /** @see this#tryBuildSubstArgs(ImmutableSeq, SeqLike) */
   public static Result<Substituter.TermSubst, Boolean> tryBuildSubstTerms(
     @NotNull ImmutableSeq<@NotNull Pat> pats,
     @NotNull SeqView<@NotNull Term> terms
@@ -70,6 +71,11 @@ public record PatMatcher(@NotNull Substituter.TermSubst subst) {
         var as = tuple.as();
         if (as != null) subst.addDirectly(as, tup);
         visitList(tuple.pats(), tup.items());
+      }
+      case Pat.Meta meta -> {
+        var sol = meta.solution().value;
+        assert sol != null : "Unsolved pattern " + meta;
+        match(sol, term);
       }
     }
   }

--- a/base/src/main/java/org/aya/core/pat/PatMatcher.java
+++ b/base/src/main/java/org/aya/core/pat/PatMatcher.java
@@ -61,13 +61,7 @@ public record PatMatcher(@NotNull Substituter.TermSubst subst) {
           case CallTerm.Prim primCall -> {
             if (primCall.ref() != prim.ref()) throw new Mismatch(false);
           }
-          case RefTerm.MetaPat metaPat -> {
-            var referee = metaPat.ref();
-            var todo = referee.solution();
-            if (todo.value != null) throw new UnsupportedOperationException(
-              "unsure what to do, please file an issue with reproduction if you see this!");
-            todo.value = pat.rename(subst, referee.explicit());
-          }
+          case RefTerm.MetaPat metaPat -> solve(pat, metaPat);
           default -> throw new Mismatch(true);
         }
       }
@@ -90,6 +84,14 @@ public record PatMatcher(@NotNull Substituter.TermSubst subst) {
         match(sol, term);
       }
     }
+  }
+
+  private void solve(@NotNull Pat pat, @NotNull RefTerm.MetaPat metaPat) {
+    var referee = metaPat.ref();
+    var todo = referee.solution();
+    if (todo.value != null) throw new UnsupportedOperationException(
+      "unsure what to do, please file an issue with reproduction if you see this!");
+    todo.value = pat.rename(subst, referee.explicit());
   }
 
   private void visitList(ImmutableSeq<Pat> lpats, SeqLike<Term> terms) throws Mismatch {

--- a/base/src/main/java/org/aya/core/pat/PatToTerm.java
+++ b/base/src/main/java/org/aya/core/pat/PatToTerm.java
@@ -28,6 +28,7 @@ public class PatToTerm {
       case Pat.Ctor ctor -> visitCtor(ctor);
       case Pat.Bind bind -> new RefTerm(bind.as(), bind.type());
       case Pat.Tuple tuple -> new IntroTerm.Tuple(tuple.pats().map(this::visit));
+      case Pat.Meta meta -> new RefTerm.MetaPat(meta);
     };
   }
 

--- a/base/src/main/java/org/aya/core/pat/PatUnify.java
+++ b/base/src/main/java/org/aya/core/pat/PatUnify.java
@@ -20,13 +20,13 @@ import org.jetbrains.annotations.Nullable;
 public record PatUnify(@NotNull TermSubst lhsSubst, @NotNull TermSubst rhsSubst) {
   private void unify(@NotNull Pat lhs, @NotNull Pat rhs) {
     switch (lhs) {
+      default -> throw new IllegalStateException();
       case Pat.Bind bind -> {
       }
       case Pat.Tuple tuple -> {
         if (rhs instanceof Pat.Tuple tuple1) visitList(tuple.pats(), tuple1.pats());
         else reportError(lhs, rhs);
       }
-      case Pat.Absurd absurd -> throw new IllegalStateException();
       case Pat.Prim prim -> {
         if (!(rhs instanceof Pat.Prim prim1)) reportError(lhs, rhs);
         else assert prim.ref() == prim1.ref();

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -42,6 +42,7 @@ public record Serializer(@NotNull Serializer.State state) implements
       case Pat.Tuple tuple -> new SerPat.Tuple(tuple.explicit(),
         serializePats(tuple.pats()), state.localMaybe(tuple.as()), serialize(tuple.type()));
       case Pat.Bind bind -> new SerPat.Bind(bind.explicit(), state.local(bind.as()), serialize(bind.type()));
+      case Pat.Meta meta -> throw new IllegalArgumentException(meta.toString());
     };
   }
 
@@ -87,6 +88,10 @@ public record Serializer(@NotNull Serializer.State state) implements
 
   @Override public SerTerm visitError(@NotNull ErrorTerm term, Unit unit) {
     throw new AssertionError("Shall not have error term serialized.");
+  }
+
+  @Override public SerTerm visitMetaPat(RefTerm.@NotNull MetaPat metaPat, Unit unit) {
+    throw new AssertionError("Shall not have metaPats serialized.");
   }
 
   @Override public SerTerm visitHole(CallTerm.@NotNull Hole term, Unit unit) {

--- a/base/src/main/java/org/aya/core/term/RefTerm.java
+++ b/base/src/main/java/org/aya/core/term/RefTerm.java
@@ -27,5 +27,10 @@ public record RefTerm(@NotNull LocalVar var, @NotNull Term type) implements Term
     @Override public <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p) {
       return visitor.visitMetaPat(this, p);
     }
+
+    public @NotNull Term inline() {
+      var sol = ref.solution().value;
+      return sol != null ? sol.toTerm() : this;
+    }
   }
 }

--- a/base/src/main/java/org/aya/core/term/RefTerm.java
+++ b/base/src/main/java/org/aya/core/term/RefTerm.java
@@ -6,6 +6,7 @@ import org.aya.api.ref.DefVar;
 import org.aya.api.ref.LocalVar;
 import org.aya.concrete.stmt.Decl;
 import org.aya.core.def.FieldDef;
+import org.aya.core.pat.Pat;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -19,6 +20,12 @@ public record RefTerm(@NotNull LocalVar var, @NotNull Term type) implements Term
   public record Field(@NotNull DefVar<FieldDef, Decl.StructField> ref) implements Term {
     @Override public <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p) {
       return visitor.visitFieldRef(this, p);
+    }
+  }
+
+  public record MetaPat(@NotNull Pat.Meta ref) implements Term {
+    @Override public <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p) {
+      return visitor.visitMetaPat(this, p);
     }
   }
 }

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -71,7 +71,7 @@ public sealed interface Term extends CoreTerm permits
   }
 
   default @NotNull Term zonk(@NotNull ExprTycker tycker, @Nullable SourcePos pos) {
-    return new Zonker(tycker.state, tycker.reporter).zonk(this, pos);
+    return tycker.newZonker().zonk(this, pos);
   }
 
   @Override default @NotNull Term rename() {

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -10,7 +10,6 @@ import kala.tuple.Tuple3;
 import kala.tuple.Unit;
 import org.aya.api.core.CoreTerm;
 import org.aya.api.distill.DistillerOptions;
-import org.aya.util.error.SourcePos;
 import org.aya.api.ref.Bind;
 import org.aya.api.ref.LocalVar;
 import org.aya.api.ref.Var;
@@ -28,6 +27,7 @@ import org.aya.pretty.doc.Doc;
 import org.aya.tyck.ExprTycker;
 import org.aya.tyck.LittleTyper;
 import org.aya.tyck.TyckState;
+import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,7 +38,9 @@ import org.jetbrains.annotations.TestOnly;
  *
  * @author ice1000
  */
-public sealed interface Term extends CoreTerm permits CallTerm, ElimTerm, ErrorTerm, FormTerm, IntroTerm, RefTerm, RefTerm.Field {
+public sealed interface Term extends CoreTerm permits
+  CallTerm, ElimTerm, ErrorTerm, FormTerm, IntroTerm,
+  RefTerm, RefTerm.Field, RefTerm.MetaPat {
   <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p);
 
   default <P, R> R accept(@NotNull Visitor<P, R> visitor, P p) {
@@ -140,6 +142,7 @@ public sealed interface Term extends CoreTerm permits CallTerm, ElimTerm, ErrorT
     R visitHole(@NotNull CallTerm.Hole hole, P p);
     R visitFieldRef(@NotNull RefTerm.Field field, P p);
     R visitError(@NotNull ErrorTerm error, P p);
+    R visitMetaPat(@NotNull RefTerm.MetaPat metaPat, P p);
   }
 
   /**

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -24,10 +24,8 @@ import org.aya.distill.BaseDistiller;
 import org.aya.distill.CoreDistiller;
 import org.aya.generic.ParamLike;
 import org.aya.pretty.doc.Doc;
-import org.aya.tyck.ExprTycker;
 import org.aya.tyck.LittleTyper;
 import org.aya.tyck.TyckState;
-import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -68,10 +66,6 @@ public sealed interface Term extends CoreTerm permits
 
   default @NotNull Term subst(@NotNull Substituter.TermSubst subst, @NotNull LevelSubst levelSubst) {
     return accept(new Substituter(subst, levelSubst), Unit.unit());
-  }
-
-  default @NotNull Term zonk(@NotNull ExprTycker tycker, @Nullable SourcePos pos) {
-    return tycker.newZonker().zonk(this, pos);
   }
 
   @Override default @NotNull Term rename() {

--- a/base/src/main/java/org/aya/core/visitor/Normalizer.java
+++ b/base/src/main/java/org/aya/core/visitor/Normalizer.java
@@ -23,9 +23,13 @@ public record Normalizer(@Nullable TyckState state) implements Unfolder<Normaliz
     return term;
   }
 
-  @Override
-  public @NotNull Term visitFieldRef(@NotNull RefTerm.Field term, NormalizeMode normalizeMode) {
+  @Override public @NotNull Term
+  visitFieldRef(@NotNull RefTerm.Field term, NormalizeMode normalizeMode) {
     return term;
+  }
+
+  @Override public @NotNull Term visitMetaPat(@NotNull RefTerm.MetaPat metaPat, NormalizeMode normalizeMode) {
+    return metaPat.inline();
   }
 
   @Override public @NotNull Term visitLam(@NotNull IntroTerm.Lambda term, NormalizeMode mode) {

--- a/base/src/main/java/org/aya/core/visitor/TermConsumer.java
+++ b/base/src/main/java/org/aya/core/visitor/TermConsumer.java
@@ -112,6 +112,10 @@ public interface TermConsumer<P> extends Term.Visitor<P, Unit> {
     return Unit.unit();
   }
 
+  @Override default Unit visitMetaPat(RefTerm.@NotNull MetaPat metaPat, P p) {
+    return Unit.unit();
+  }
+
   @Override default Unit visitProj(@NotNull ElimTerm.Proj term, P p) {
     return term.of().accept(this, p);
   }

--- a/base/src/main/java/org/aya/core/visitor/TermFixpoint.java
+++ b/base/src/main/java/org/aya/core/visitor/TermFixpoint.java
@@ -42,6 +42,10 @@ public interface TermFixpoint<P> extends Term.Visitor<P, @NotNull Term> {
     return term;
   }
 
+  @Override default @NotNull Term visitMetaPat(RefTerm.@NotNull MetaPat metaPat, P p) {
+    return metaPat;
+  }
+
   @Override default @NotNull Term visitConCall(@NotNull CallTerm.Con conCall, P p) {
     var dataArgs = conCall.head().dataArgs().map(arg -> visitArg(arg, p));
     var conArgs = conCall.conArgs().map(arg -> visitArg(arg, p));

--- a/base/src/main/java/org/aya/core/visitor/Unfolder.java
+++ b/base/src/main/java/org/aya/core/visitor/Unfolder.java
@@ -115,7 +115,7 @@ public interface Unfolder<P> extends TermFixpoint<P> {
     @NotNull ImmutableSeq<Matching> clauses
   ) {
     for (var matchy : clauses) {
-      var termSubst = PatMatcher.tryBuildSubstArgs(matchy.patterns(), args);
+      var termSubst = PatMatcher.tryBuildSubstArgs(null, matchy.patterns(), args);
       if (termSubst.isOk()) {
         subst.add(termSubst.get());
         var newBody = matchy.body().subst(subst, levelSubst).accept(this, p).rename();

--- a/base/src/main/java/org/aya/core/visitor/Zonker.java
+++ b/base/src/main/java/org/aya/core/visitor/Zonker.java
@@ -3,19 +3,19 @@
 package org.aya.core.visitor;
 
 import kala.collection.immutable.ImmutableSeq;
-import kala.collection.mutable.DynamicSeq;
 import kala.collection.mutable.DynamicLinkedSeq;
+import kala.collection.mutable.DynamicSeq;
 import kala.tuple.Unit;
 import org.aya.api.distill.DistillerOptions;
 import org.aya.api.error.Problem;
 import org.aya.api.error.Reporter;
-import org.aya.util.error.SourcePos;
 import org.aya.core.sort.Sort;
 import org.aya.core.term.*;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.doc.Style;
 import org.aya.tyck.TyckState;
 import org.aya.tyck.error.LevelMismatchError;
+import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -70,6 +70,10 @@ public final class Zonker implements TermFixpoint<Unit> {
       return new ErrorTerm(term);
     }
     return metas.get(sol).accept(this, Unit.unit());
+  }
+
+  @Override public @NotNull Term visitMetaPat(@NotNull RefTerm.MetaPat metaPat, Unit unit) {
+    return metaPat.inline();
   }
 
   @Override public @Nullable Sort visitSort(@NotNull Sort sort, Unit unit) {

--- a/base/src/main/java/org/aya/distill/BaseDistiller.java
+++ b/base/src/main/java/org/aya/distill/BaseDistiller.java
@@ -46,9 +46,9 @@ public abstract class BaseDistiller {
 
   <T extends AyaDocile> @NotNull Doc visitCalls(
     boolean infix, @NotNull Doc fn, @NotNull Fmt<T> fmt, Outer outer,
-    @NotNull SeqView<@NotNull Arg<@NotNull T>> args
+    @NotNull SeqView<@NotNull Arg<@NotNull T>> args, boolean showImplicits
   ) {
-    var visibleArgs = (options.map.get(DistillerOptions.Key.ShowImplicitArgs) ? args : args.filter(Arg::explicit)).toImmutableSeq();
+    var visibleArgs = (showImplicits ? args : args.filter(Arg::explicit)).toImmutableSeq();
     if (visibleArgs.isEmpty()) return infix ? Doc.parened(fn) : fn;
     // Print as a binary operator
     if (infix) {

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -152,7 +152,7 @@ public class ConcreteDistiller extends BaseDistiller implements
   }
 
   @Override public Doc visitHole(Expr.@NotNull HoleExpr expr, Outer outer) {
-    if (!expr.explicit()) return Doc.symbol("_");
+    if (!expr.explicit()) return Doc.symbol(Constants.ANONYMOUS_PREFIX);
     var filling = expr.filling();
     if (filling == null) return Doc.symbol("{??}");
     return Doc.sep(Doc.symbol("{?"), filling.accept(this, Outer.Free), Doc.symbol("?}"));

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -120,7 +120,8 @@ public class ConcreteDistiller extends BaseDistiller implements
     var fn = Doc.styled(KEYWORD, "Type");
     if (!options.map.get(DistillerOptions.Key.ShowLevels)) return fn;
     return visitCalls(false, fn, (nc, l) -> l.toDoc(options), outer,
-      SeqView.of(new Arg<>(o -> expr.level().toDoc(), true))
+      SeqView.of(new Arg<>(o -> expr.level().toDoc(), true)),
+      true
     );
   }
 
@@ -133,21 +134,24 @@ public class ConcreteDistiller extends BaseDistiller implements
     return visitCalls(infix,
       head.accept(this, Outer.AppHead),
       (nest, arg) -> arg.accept(this, nest), outer,
-      args.view().map(arg -> new Arg<>(arg.expr(), arg.explicit()))
+      args.view().map(arg -> new Arg<>(arg.expr(), arg.explicit())),
+      options.map.get(DistillerOptions.Key.ShowImplicitArgs)
     );
   }
 
   @Override public Doc visitLsuc(Expr.@NotNull LSucExpr expr, Outer outer) {
     return visitCalls(false,
       Doc.styled(KEYWORD, "lsuc"),
-      (nest, arg) -> arg.accept(this, nest), outer, SeqView.of(new Arg<>(expr.expr(), true))
+      (nest, arg) -> arg.accept(this, nest), outer, SeqView.of(new Arg<>(expr.expr(), true)),
+      true
     );
   }
 
   @Override public Doc visitLmax(Expr.@NotNull LMaxExpr expr, Outer outer) {
     return visitCalls(false,
       Doc.styled(KEYWORD, "lmax"),
-      (nest, arg) -> arg.accept(this, nest), outer, expr.levels().view().map(term -> new Arg<>(term, true))
+      (nest, arg) -> arg.accept(this, nest), outer, expr.levels().view().map(term -> new Arg<>(term, true)),
+      true
     );
   }
 
@@ -197,7 +201,8 @@ public class ConcreteDistiller extends BaseDistiller implements
     if (seq.sizeEquals(1)) return seq.first().expr().accept(this, outer);
     return visitCalls(false,
       seq.first().expr().accept(this, Outer.AppSpine),
-      (nest, arg) -> arg.accept(this, nest), outer, seq.view().drop(1).map(e -> new Arg<>(e.expr(), e.explicit()))
+      (nest, arg) -> arg.accept(this, nest), outer, seq.view().drop(1).map(e -> new Arg<>(e.expr(), e.explicit())),
+      options.map.get(DistillerOptions.Key.ShowImplicitArgs)
     );
   }
 

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -259,12 +259,6 @@ public class CoreDistiller extends BaseDistiller implements
     };
   }
 
-  public Doc visitMaybeCtorPatterns(SeqLike<Pat> patterns, Outer outer, @NotNull Doc delim) {
-    var pats = options.map.get(DistillerOptions.Key.ShowImplicitPats) ? patterns : patterns.view().filter(Pat::explicit);
-    return Doc.emptyIf(pats.isEmpty(), () -> Doc.cat(Doc.ONE_WS, Doc.join(delim,
-      pats.view().map(p -> visitPat(p, outer)))));
-  }
-
   @Override public Doc visitFn(@NotNull FnDef def, Unit unit) {
     var line1 = DynamicSeq.of(Doc.styled(KEYWORD, "def"),
       linkDef(def.ref(), FN_CALL),

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -203,7 +203,9 @@ public class CoreDistiller extends BaseDistiller implements
   }
 
   @Override public Doc visitMetaPat(RefTerm.@NotNull MetaPat metaPat, Outer outer) {
-    return Doc.plain("<metaPat>");
+    var ref = metaPat.ref();
+    if (ref.solution().value == null) return varDoc(ref.as());
+    return visitPat(ref, outer);
   }
 
   private Doc visitCalls(
@@ -223,9 +225,9 @@ public class CoreDistiller extends BaseDistiller implements
 
   public Doc visitPat(@NotNull Pat pat, Outer outer) {
     return switch (pat) {
-      case Pat.Meta meta-> {
+      case Pat.Meta meta -> {
         var sol = meta.solution().value;
-        yield sol != null ? visitPat(sol, outer) : Doc.plain("<meta>");
+        yield sol != null ? visitPat(sol, outer) : Doc.bracedUnless(linkDef(meta.as()), meta.explicit());
       }
       case Pat.Bind bind -> Doc.bracedUnless(linkDef(bind.as()), bind.explicit());
       case Pat.Prim prim -> Doc.bracedUnless(linkRef(prim.ref(), CON_CALL), prim.explicit());

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -202,6 +202,10 @@ public class CoreDistiller extends BaseDistiller implements
     return !term.isReallyError() ? doc : Doc.angled(doc);
   }
 
+  @Override public Doc visitMetaPat(RefTerm.@NotNull MetaPat metaPat, Outer outer) {
+    return Doc.plain("<metaPat>");
+  }
+
   private Doc visitCalls(
     @NotNull DefVar<?, ?> var, @NotNull Style style,
     @NotNull SeqLike<@NotNull Arg<@NotNull Term>> args, Outer outer
@@ -219,6 +223,10 @@ public class CoreDistiller extends BaseDistiller implements
 
   public Doc visitPat(@NotNull Pat pat, Outer outer) {
     return switch (pat) {
+      case Pat.Meta meta-> {
+        var sol = meta.solution().value;
+        yield sol != null ? visitPat(sol, outer) : Doc.plain("<meta>");
+      }
       case Pat.Bind bind -> Doc.bracedUnless(linkDef(bind.as()), bind.explicit());
       case Pat.Prim prim -> Doc.bracedUnless(linkRef(prim.ref(), CON_CALL), prim.explicit());
       case Pat.Ctor ctor -> {

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -434,7 +434,8 @@ public final class ExprTycker {
   public @NotNull Result zonk(@NotNull Expr expr, @NotNull Result result) {
     solveMetas();
     var pos = expr.sourcePos();
-    return new Result(result.wellTyped.zonk(this, pos), result.type.zonk(this, pos));
+    var zonker = newZonker();
+    return new Result(zonker.zonk(result.wellTyped, pos), zonker.zonk(result.type, pos));
   }
 
   private @NotNull Term generatePi(Expr.@NotNull LamExpr expr) {

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -30,6 +30,7 @@ import org.aya.core.sort.Sort;
 import org.aya.core.term.*;
 import org.aya.core.visitor.Substituter;
 import org.aya.core.visitor.Unfolder;
+import org.aya.core.visitor.Zonker;
 import org.aya.generic.Constants;
 import org.aya.generic.Level;
 import org.aya.generic.Modifier;
@@ -61,6 +62,10 @@ public final class ExprTycker {
 
   private void tracing(@NotNull Consumer<Trace.@NotNull Builder> consumer) {
     if (traceBuilder != null) consumer.accept(traceBuilder);
+  }
+
+  public @NotNull Zonker newZonker() {
+    return new Zonker(state, reporter);
   }
 
   private @NotNull Result doSynthesize(@NotNull Expr expr) {

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -42,6 +42,10 @@ public record LittleTyper(@Nullable TyckState state) implements Term.Visitor<Uni
     return ErrorTerm.typeOf(term);
   }
 
+  @Override public Term visitMetaPat(RefTerm.@NotNull MetaPat metaPat, Unit unit) {
+    return metaPat.ref().type();
+  }
+
   @Override public Term visitSigma(FormTerm.@NotNull Sigma term, Unit unit) {
     var univ = term.params().view()
       .map(param -> param.type()

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -192,7 +192,7 @@ public record StmtTycker(
       dataCall = (CallTerm.Data) dataCall.subst(subst);
     }
     ctor.patternTele = pat.isEmpty() ? dataParamView.map(Term.Param::implicitify).toImmutableSeq() : Pat.extractTele(pat);
-    var elabClauses = patTycker.elabClauses(signature, ctor.clauses);
+    var elabClauses = patTycker.elabClauses(ctor.clauses, signature)._2;
     var matchings = elabClauses.flatMap(Pat.PrototypeClause::deprototypify);
     var elaborated = new CtorDef(dataRef, ctor.ref, pat, ctor.patternTele, tele, matchings, dataCall, ctor.coerce);
     if (patTycker.noError())
@@ -225,7 +225,7 @@ public record StmtTycker(
     assert structSig != null;
     field.signature = new Def.Signature(structSig.sortParam(), tele, result);
     var patTycker = new PatTycker(tycker);
-    var elabClauses = patTycker.elabClauses(field.signature, field.clauses);
+    var elabClauses = patTycker.elabClauses(field.clauses, field.signature)._2;
     var matchings = elabClauses.flatMap(Pat.PrototypeClause::deprototypify);
     var body = field.body.map(e -> tycker.inherit(e, result).wellTyped());
     var elaborated = new FieldDef(structRef, field.ref, structSig.param(), tele, result, matchings, body, field.coerce);

--- a/base/src/main/java/org/aya/tyck/pat/Conquer.java
+++ b/base/src/main/java/org/aya/tyck/pat/Conquer.java
@@ -58,7 +58,7 @@ public record Conquer(
         var conditions = ctor.ref().core.clauses;
         for (int i = 0, size = conditions.size(); i < size; i++) {
           var condition = conditions.get(i);
-          var matchy = PatMatcher.tryBuildSubstTerms(params, condition.patterns().view().map(Pat::toTerm));
+          var matchy = PatMatcher.tryBuildSubstTerms(null, params, condition.patterns().view().map(Pat::toTerm));
           if (matchy.isOk()) checkConditions(ctor, nth, i + 1, condition.body(), matchy.get(), condition.sourcePos());
         }
       }

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -226,7 +226,7 @@ public record PatClassifier(
           var conTele = ctor.selfTele;
           // Check if this constructor is available by doing the obvious thing
           if (ctor.pats.isNotEmpty()) {
-            var matchy = PatMatcher.tryBuildSubstArgs(ctor.pats, dataCall.args());
+            var matchy = PatMatcher.tryBuildSubstArgs(null, ctor.pats, dataCall.args());
             // If not, check the reason why: it may fail negatively or positively
             if (matchy.isErr()) {
               // Index unification fails negatively

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -85,7 +85,7 @@ public final class PatTycker {
     });
     exprTycker.solveMetas();
     var zonker = exprTycker.newZonker();
-    return Tuple.of(signature.result().zonk(exprTycker, resultPos),
+    return Tuple.of(zonker.zonk(signature.result(), resultPos),
       res.map(c -> new Pat.PrototypeClause(
         c.sourcePos(), c.patterns().map(p -> p.zonk(zonker)),
         c.expr().map(e -> zonker.zonk(e, c.sourcePos())))));

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -29,12 +29,12 @@ import org.aya.core.term.FormTerm;
 import org.aya.core.term.Term;
 import org.aya.core.visitor.Substituter;
 import org.aya.core.visitor.Unfolder;
-import org.aya.core.visitor.Zonker;
 import org.aya.pretty.doc.Doc;
 import org.aya.tyck.ExprTycker;
 import org.aya.tyck.error.NotYetTyckedError;
 import org.aya.tyck.trace.Trace;
 import org.aya.util.TreeBuilder;
+import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -75,7 +75,7 @@ public final class PatTycker {
   public @NotNull Tuple2<@NotNull Term, @NotNull ImmutableSeq<Pat.PrototypeClause>>
   elabClauses(
     @NotNull ImmutableSeq<Pattern.@NotNull Clause> clauses,
-    @NotNull Def.Signature signature
+    @NotNull Def.Signature signature, @Nullable SourcePos resultPos
   ) {
     var res = clauses.mapIndexed((index, clause) -> {
       tracing(builder -> builder.shift(new Trace.LabelT(clause.sourcePos, "clause " + (1 + index))));
@@ -83,7 +83,12 @@ public final class PatTycker {
       tracing(TreeBuilder::reduce);
       return elabClause;
     });
-    return Tuple.of(signature.result(), res);
+    exprTycker.solveMetas();
+    var zonker = exprTycker.newZonker();
+    return Tuple.of(signature.result().zonk(exprTycker, resultPos),
+      res.map(c -> new Pat.PrototypeClause(
+        c.sourcePos(), c.patterns().map(p -> p.zonk(zonker)),
+        c.expr().map(e -> zonker.zonk(e, c.sourcePos())))));
   }
 
   @SuppressWarnings("unchecked") private @NotNull Pat doTyck(@NotNull Pattern pattern, @NotNull Term term) {
@@ -137,9 +142,6 @@ public final class PatTycker {
     };
   }
 
-  /**
-   * @return already zonked
-   */
   private Pat.PrototypeClause visitMatch(Pattern.@NotNull Clause match, Def.@NotNull Signature signature) {
     exprTycker.localCtx = exprTycker.localCtx.derive();
     currentClause = match;
@@ -152,15 +154,11 @@ public final class PatTycker {
       // not be added to the localCtx of tycker, causing assertion errors
       ? match.expr.<Term>map(e -> new ErrorTerm(e, false))
       : match.expr.map(e -> exprTycker.inherit(e, type).wellTyped().subst(termSubst));
-    var zonker = new Zonker(exprTycker.state, exprTycker.reporter);
-    exprTycker.solveMetas();
-    result = result.map(e -> zonker.zonk(e, match.expr.get().sourcePos()));
     termSubst.clear();
     var parent = exprTycker.localCtx.parent();
     assert parent != null;
     exprTycker.localCtx = parent;
-    var zonkPats = patterns._1.map(pat -> pat.zonk(zonker));
-    return new Pat.PrototypeClause(match.sourcePos, zonkPats, result);
+    return new Pat.PrototypeClause(match.sourcePos, patterns._1, result);
   }
 
   public @NotNull Tuple2<ImmutableSeq<Pat>, Term>

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -287,7 +287,7 @@ public final class PatTycker {
   }
 
   private Result<Substituter.TermSubst, Boolean> mischa(CallTerm.Data dataCall, DataDef core, CtorDef ctor) {
-    if (ctor.pats.isNotEmpty()) return PatMatcher.tryBuildSubstArgs(ctor.pats, dataCall.args());
+    if (ctor.pats.isNotEmpty()) return PatMatcher.tryBuildSubstArgs( ctor.pats, dataCall.args());
     else return Result.ok(Unfolder.buildSubst(core.telescope(), dataCall.args()));
   }
 }

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -146,7 +146,7 @@ public final class PatTycker {
     exprTycker.localCtx = exprTycker.localCtx.derive();
     currentClause = match;
     var patResult = visitPatterns(signature, match.patterns.view());
-    var patterns = patResult._1.map(p -> p.zonk(null));
+    var patterns = patResult._1.map(Pat::inline);
     var type = patResult._2.accept(new TermFixpoint<>() {
       @Override public @NotNull Term visitMetaPat(@NotNull RefTerm.MetaPat metaPat, Unit unit) {
         return metaPat.inline();

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -29,6 +29,7 @@ import org.aya.core.term.*;
 import org.aya.core.visitor.Substituter;
 import org.aya.core.visitor.TermFixpoint;
 import org.aya.core.visitor.Unfolder;
+import org.aya.generic.Constants;
 import org.aya.pretty.doc.Doc;
 import org.aya.tyck.ExprTycker;
 import org.aya.tyck.error.NotYetTyckedError;
@@ -138,7 +139,9 @@ public final class PatTycker {
         exprTycker.localCtx.put(v, term);
         yield new Pat.Bind(bind.explicit(), v, term);
       }
-      case default -> throw new UnsupportedOperationException("Number and underscore patterns are unsupported yet");
+      case Pattern.CalmFace face -> new Pat.Meta(face.explicit(), new Ref<>(),
+        new LocalVar(Constants.ANONYMOUS_PREFIX, face.sourcePos()), term);
+      case default -> throw new UnsupportedOperationException("Number patterns are unsupported yet");
     };
   }
 

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -10,6 +10,7 @@ import kala.control.Result;
 import kala.tuple.Tuple;
 import kala.tuple.Tuple2;
 import kala.tuple.Tuple3;
+import kala.value.Ref;
 import org.aya.api.error.Problem;
 import org.aya.api.ref.DefVar;
 import org.aya.api.ref.LocalVar;
@@ -219,8 +220,11 @@ public final class PatTycker {
 
   private @NotNull Def.Signature generatePat(PatData data) {
     var ref = data.param.ref();
-    // TODO: implicitly generated patterns might be inferred to something else?
-    var bind = new Pat.Bind(false, new LocalVar(ref.name(), ref.definition()), data.param.type());
+    Pat bind;
+    var freshVar = new LocalVar(ref.name(), ref.definition());
+    if (data.param.type().normalize(exprTycker.state, NormalizeMode.WHNF) instanceof CallTerm.Data dataCall)
+      bind = new Pat.Meta(false, new Ref<>(), freshVar, data.param.type());
+    else bind = new Pat.Bind(false, freshVar, data.param.type());
     data.results.append(bind);
     exprTycker.localCtx.put(bind.as(), data.param.type());
     termSubst.add(ref, bind.toTerm());

--- a/base/src/main/java/org/aya/tyck/unify/DefEq.java
+++ b/base/src/main/java/org/aya/tyck/unify/DefEq.java
@@ -260,6 +260,11 @@ public final class DefEq {
       preRhs.freezeHoles(state), this.pos));
     var ret = switch (type) {
       default -> throw new IllegalStateException();
+      case RefTerm.MetaPat metaPat -> {
+        var lhsRef = metaPat.ref();
+        if (preRhs instanceof RefTerm.MetaPat rPat && lhsRef == rPat.ref()) yield lhsRef.type();
+        else yield null;
+      }
       case RefTerm lhs -> {
         if (preRhs instanceof RefTerm rhs
           && varSubst.getOrDefault(rhs.var(), rhs).var() == lhs.var()) {

--- a/base/src/test/resources/failure/patterns/selection-failure.aya
+++ b/base/src/test/resources/failure/patterns/selection-failure.aya
@@ -5,5 +5,5 @@ open data Vect (A : Type) (n : Nat) : Type
  | A, zero => vnil
  | A, suc m => vcons A (Vect A m)
 def mapImpl {A B : Type} {n : Nat} (f : Pi A -> B) (xs : Vect A n) : Vect B n
- | f, vnil => vnil
- | f, vcons x xs => _
+ | {A}, {B}, {n}, f, vnil => vnil
+ | {A}, {B}, {n}, f, vcons x xs => _

--- a/base/src/test/resources/failure/patterns/selection-failure.aya.txt
+++ b/base/src/test/resources/failure/patterns/selection-failure.aya.txt
@@ -1,21 +1,21 @@
-In file $FILE:8:6 ->
+In file $FILE:8:21 ->
 
   6 |  | A, suc m => vcons A (Vect A m)
   7 | def mapImpl {A B : Type} {n : Nat} (f : Pi A -> B) (xs : Vect A n) : Vect B n
-  8 |  | f, vnil => vnil
-            ^--^
+  8 |  | {A}, {B}, {n}, f, vnil => vnil
+                           ^--^
 
 Error: Cannot match with
          vnil
        as index unification is blocked for type
          Vect A n
 
-In file $FILE:9:6 ->
+In file $FILE:9:21 ->
 
   7 | def mapImpl {A B : Type} {n : Nat} (f : Pi A -> B) (xs : Vect A n) : Vect B n
-  8 |  | f, vnil => vnil
-  9 |  | f, vcons x xs => _
-            ^--------^
+  8 |  | {A}, {B}, {n}, f, vnil => vnil
+  9 |  | {A}, {B}, {n}, f, vcons x xs => _
+                           ^--------^
 
 Error: Cannot match with
          vcons x xs

--- a/base/src/test/resources/success/curry.aya
+++ b/base/src/test/resources/success/curry.aya
@@ -7,3 +7,13 @@ def curry3 (A B C D : Type)
             (f : (Sig A B ** C) -> D)
             (a : A) (b : B) (c : C) : D
   => f (a, b, c)
+
+def uncurry (A : Type) (B : Type) (C : Type)
+             (f : Pi A B -> C)
+             (p : Sig A ** B) : C
+  => f (p.1) (p.2)
+
+def uncurry3 (A : Type) (B : Type) (C : Type) (D : Type)
+              (f : Pi A B C -> D)
+              (p : Sig A B ** C) : D
+  => f (p.1) (p.2) (p.3)

--- a/base/src/test/resources/success/lambda-tuple-infer.aya
+++ b/base/src/test/resources/success/lambda-tuple-infer.aya
@@ -1,4 +1,4 @@
-open data ℕ : Type
+open data ℕ
   | zero
   | suc ℕ
 
@@ -11,3 +11,14 @@ def overlap infix + (a b : ℕ) : ℕ
 example def test => \ x => x + zero
 
 example def test2 => (zero, suc zero)
+
+def addTup (Sig ℕ ** ℕ) : ℕ
+ | (zero, a) => a
+ | (a, zero) => a
+ | (suc a, b) => suc (a + b)
+ | (a, suc b) => suc (a + b)
+
+open data Wow (n : ℕ)
+ | suc zero => wow
+
+example def test3 : Wow (addTup test2) => wow

--- a/base/src/test/resources/success/omit-data-univ.aya
+++ b/base/src/test/resources/success/omit-data-univ.aya
@@ -1,2 +1,0 @@
-open data Bool | true | false
-open data Nat | zero | succ Nat

--- a/base/src/test/resources/success/redblack.aya
+++ b/base/src/test/resources/success/redblack.aya
@@ -185,40 +185,40 @@ module RedBlackIn {
   def balanceLeftRed {A : Type} {n : Nat} {c : Color} (HTree A n) A (Tree A c n)
     : AlmostTree A n
   | hRed l, x, r => (_, alRed l x r)
-  | {A}, {suc n}, hBlack l, x, r => (_, alRed l x r)
+  | hBlack l, x, r => (_, alRed l x r)
 
   def balanceRightRed {A : Type} {n : Nat} {c : Color} (Tree A c n) A (HTree A n)
     : AlmostTree A n
   | l, x, hRed r => (_, alRed l x r)
-  | {A}, {suc n}, l, x, hBlack r => (_, alRed l x r)
+  | l, x, hBlack r => (_, alRed l x r)
 
   def balanceLeftBlack {A : Type} {n : Nat} {c : Color} (AlmostTree A n) A (Tree A c n)
     : HTree A (suc n)
   -- rotation
-  | (red, alRed {red} (rbRed a x b) y c), z, d => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
-  | (red, alRed {c1} {red} a x (rbRed b y c)), z, d => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
+  | (red, alRed (rbRed a x b) y c), z, d => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
+  | (red, alRed a x (rbRed b y c)), z, d => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
   -- expand catch-all for different proofs
-  | {A}, {zero}, (red, alRed {black} {black} rbLeaf x rbLeaf), y, r => hBlack (rbBlack (rbRed rbLeaf x rbLeaf) y r)
-  | {A}, {suc n}, (red, alRed {black} {black} l x r), y, c => hBlack (rbBlack (rbRed l x r) y c)
-  | {A}, {suc n}, (black, alBlack a x b), y, r => hBlack (rbBlack (rbBlack a x b) y r)
+  | (red, alRed rbLeaf x rbLeaf), y, r => hBlack (rbBlack (rbRed rbLeaf x rbLeaf) y r)
+  | (red, alRed {black} {black} l x r), y, c => hBlack (rbBlack (rbRed l x r) y c)
+  | (black, alBlack a x b), y, r => hBlack (rbBlack (rbBlack a x b) y r)
 
   def balanceRightBlack {A : Type} {n : Nat} {c : Color} (Tree A c n) A (AlmostTree A n)
     : HTree A (suc n)
   -- rotation
-  | a, x, (red, alRed {red} (rbRed b y c) z d) => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
-  | a, x, (red, alRed {c1} {red} b y (rbRed c z d)) => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
+  | a, x, (red, alRed (rbRed b y c) z d) => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
+  | a, x, (red, alRed b y (rbRed c z d)) => hRed (rbRed (rbBlack a x b) y (rbBlack c z d))
   -- ditto
-  | {A}, {zero}, a, x, (red, alRed {black} {black} rbLeaf y rbLeaf) => hBlack (rbBlack a x (rbRed rbLeaf y rbLeaf))
-  | {A}, {suc n}, a, x, (red, alRed {black} {black} l y r) => hBlack (rbBlack a x (rbRed l y r))
-  | {A}, {suc n}, a, x, (black, alBlack b y c) => hBlack (rbBlack a x (rbBlack b y c))
+  | a, x, (red, alRed rbLeaf y rbLeaf) => hBlack (rbBlack a x (rbRed rbLeaf y rbLeaf))
+  | a, x, (red, alRed {black} {black} l y r) => hBlack (rbBlack a x (rbRed l y r))
+  | a, x, (black, alBlack b y c) => hBlack (rbBlack a x (rbBlack b y c))
 
   def forget {A : Type} {n : Nat} (HTree A n) : AlmostTree A n
   | hRed (rbRed l x r) => (_, alRed l x r)
-  | {A}, {suc n}, hBlack (rbBlack l x r) => (_, alBlack l x r)
+  | hBlack (rbBlack l x r) => (_, alBlack l x r)
 
   def insertBlack {A : Type} {n : Nat} (Tree A black n) A (Decider A) : HTree A n
-  | {A}, {zero}, rbLeaf, x, dec< => hRed (rbRed rbLeaf x rbLeaf)
-  | {A}, {suc n}, rbBlack l y r, x, dec< => insertBlack-lemma dec< l y r x (dec< x y)
+  | rbLeaf, x, dec< => hRed (rbRed rbLeaf x rbLeaf)
+  | rbBlack l y r, x, dec< => insertBlack-lemma dec< l y r x (dec< x y)
 
   def insertBlack-lemma {A : Type} {n : Nat} {c1 c2 : Color}
       (Decider A) (Tree A c1 n) A (Tree A c2 n) A Bool
@@ -227,9 +227,9 @@ module RedBlackIn {
   | dec<, l, y, r, x, false => balanceRightBlack l x (insertRed r x dec<)
 
   def insertRed {A : Type} {n : Nat} {c : Color} (Tree A c n) A (Decider A) : AlmostTree A n
-  | {A}, {zero}, {black}, rbLeaf, x, dec< => forget (insertBlack rbLeaf x dec<)
-  | {A}, {suc n}, {black}, rbBlack l y r, x, dec< => forget (insertBlack (rbBlack l y r) x dec<)
-  | {A}, {n}, {red}, rbRed l y r, x, dec< => insert-lemma dec< l y r x (dec< x y)
+  | rbLeaf, x, dec< => forget (insertBlack rbLeaf x dec<)
+  | rbBlack l y r, x, dec< => forget (insertBlack (rbBlack l y r) x dec<)
+  | rbRed l y r, x, dec< => insert-lemma dec< l y r x (dec< x y)
 
   def insert-lemma {A : Type} {n : Nat} (Decider A)
       (Tree A black n) A (Tree A black n) A Bool
@@ -239,7 +239,7 @@ module RedBlackIn {
 
   def dyeRoot {A : Type} {n : Nat} (HTree A n) : RBTree A
   | hRed (rbRed l x r) => (_, rbBlack l x r)
-  | {A}, {suc n}, hBlack (rbBlack l x r) => (_, rbBlack l x r)
+  | hBlack (rbBlack l x r) => (_, rbBlack l x r)
 
   def insert {A : Type} {n : Nat} (t : RBTree A) (x : A) (dec< : Decider A)
       => dyeRoot (insertBlack t.2 x dec<)

--- a/base/src/test/resources/success/type-safe-norm.aya
+++ b/base/src/test/resources/success/type-safe-norm.aya
@@ -1,12 +1,12 @@
-open data Nat : Type 0 | zero | suc Nat
-open data Bool : Type 0 | true | false
+open data Nat | zero | suc Nat
+open data Bool | true | false
 def not (b : Bool) : Bool
  | true => false
  | false => true
 def ifElse (A : Type) (b : Bool) (x y : A) : A
  | A, true, x, y => x
  | A, false, x, y => y
-open data TermTy : Type 0 | natT | boolT
+open data TermTy | natT | boolT
 def termTy (t : TermTy) : Type 0
  | natT => Nat
  | boolT => Bool
@@ -17,8 +17,8 @@ open data Term (n : TermTy) : Type 0
  | boolT => inv (Term boolT)
  | A => case (Term boolT) (Term A) (Term A)
 def normalize (t : TermTy) (x : Term t) : termTy t
- | natT, nat n => n
- | natT, succ n => suc (normalize natT n)
- | boolT, bool b => b
- | boolT, inv b => not (normalize boolT b)
+ | _, nat n => n
+ | _, succ n => suc (normalize natT n)
+ | _, bool b => b
+ | _, inv b => not (normalize boolT b)
  | t, case b x y => ifElse (termTy t) (normalize boolT b) (normalize t x) (normalize t y)

--- a/base/src/test/resources/success/uncurry.aya
+++ b/base/src/test/resources/success/uncurry.aya
@@ -1,9 +1,0 @@
-def uncurry (A : Type) (B : Type) (C : Type)
-             (f : Pi A B -> C)
-             (p : Sig A ** B) : C
-  => f (p.1) (p.2)
-
-def uncurry3 (A : Type) (B : Type) (C : Type) (D : Type)
-              (f : Pi A B C -> D)
-              (p : Sig A B ** C) : D
-  => f (p.1) (p.2) (p.3)

--- a/base/src/test/resources/success/vect-map.aya
+++ b/base/src/test/resources/success/vect-map.aya
@@ -4,6 +4,6 @@ open data Nat : Type
 open data Vect (A : Type) (n : Nat) : Type
  | A, zero => vnil
  | A, suc m => vcons A (Vect A m)
-def map {A B : Type} (n : Nat) (f : Pi A -> B) (xs : Vect A n) : Vect B n
- | zero, f, vnil => vnil {_}
- | suc n, f, vcons x xs => vcons (f x) (map n f xs)
+def map {A B : Type} {n : Nat} (f : Pi A -> B) (xs : Vect A n) : Vect B n
+ | f, vnil => vnil {_}
+ | f, vcons x xs => vcons (f x) (map f xs)


### PR DESCRIPTION
Fix #81, oh my glob.

## Summary

Split into five sections.

### Refactorings
+ Inlined some functions, like `CoreDistiller::visitMaybeCtorPatterns`. There are some others, I can't remember.
+ For `BaseDistiller::visitCalls`, added a new boolean parameter for implicitness option. This is because sometimes it's `ShowImplicitArgs`, sometimes it's `ShowImplicitPats`.
+ I replaced  all visitors of `Pat` with pattern matching (JEP 406) and deleted `Pat.Visitor` the abstract visitor along with all the `doAccept` methods.

### Behavioural improvements
Now we also `zonk` the types of the patterns after `elabClauses`. We didn't do this before, but it so far didn't cause any problem. I conjecture that patterns' types are never used after their type checking, but I'm not exactly sure (I'm 95% sure). If they really aren't used, we probably don't have to zonk them, and we probably want to remove them for spatial efficiency. /cc @imkiva 

### New features
+ Added new `Pat.Meta` for "unknown patterns", which are translated into `RefTerm.MetaPat` (also new) in `PatToTerm`. The idea behind these two structures are similar to "meta variables" but for patterns.
  + The `zonk` for meta patteriables is `Pat::inline` -- they inline the solutions of meta patteriables. When no solution, we turn them into bind patterns. So, `Pat::inline` is total, thus no need to have an error reporter.
  + In `PatMatcher`, we may encounter problems like "matching a pattern `p` with an instance of `RefTerm.MetaPat`". In this case, we "solve" the meta patteriable as a renamed version of `p`. Yes, the renamer for patterns is also added.
  + After all these, we `inline` the patterns, which is like freezing the meta patteriables. Solved meta patteriables are inlined as their solutions.
+ `CalmFace` patterns are now tycked as meta patterns. They will cause `UnsupportedOperationException` before.
+ Implicitly-generated patterns are now tycked as meta patterns if their types are data types (to avoid `MetaPat` appearing in the types of unifications). They were generated as bind patterns before.

### Assumptions
+ We will only see `RefTerm.MetaPat` in `PatMatcher` in `PatTycker`. Other invocations to `PatMatcher` will not. Therefore, we made the new `LocalCtx` parameter of `PatMatcher` nullable, because we need to modify the `localCtx` in the type checking of patterns.
+ Meta patteriables will only be solved once. Unsure what to do when they are solved more than once. Maybe unify the patterns to refine them further? 🤔

### Tests
Modified the redblack tree showcase with all manual implicit refinement removed. It works perfectly. Now the exact Agda code can be translated to Aya, with every omittable pattern omitted. One exception is that I discovered a case when you match on two `{black}` patterns, you don't need to split a `rbBlack a x b` pattern. I decided to keep this code to make the code shorter afterall.

Sorry for my English.