### PR TITLE
Reuse parsed tree instead of import only

### DIFF
--- a/base/src/main/java/org/aya/concrete/parse/AyaParsing.java
+++ b/base/src/main/java/org/aya/concrete/parse/AyaParsing.java
@@ -63,21 +63,13 @@ public interface AyaParsing {
     @NotNull SourceFileLocator locator,
     @NotNull Reporter reporter, @NotNull Path path
   ) throws IOException {
-    return program(locator, reporter, path, false);
-  }
-
-  static @NotNull ImmutableSeq<Stmt> program(
-    @NotNull SourceFileLocator locator,
-    @NotNull Reporter reporter, @NotNull Path path,
-    boolean importOnly
-  ) throws IOException {
     return program(reporter, new SourceFile(locator.displayName(path),
-      Files.readString(path)), importOnly);
+      Files.readString(path)));
   }
 
-  static @NotNull ImmutableSeq<Stmt> program(@NotNull Reporter reporter, SourceFile sourceFile, boolean importOnly) {
+  static @NotNull ImmutableSeq<Stmt> program(@NotNull Reporter reporter, SourceFile sourceFile) {
     return new AyaProducer(sourceFile, reporter).visitProgram(
-      parser(sourceFile, reporter).program(), importOnly);
+      parser(sourceFile, reporter).program());
   }
 
   private static @NotNull <T> T replParser(

--- a/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
+++ b/base/src/main/java/org/aya/concrete/parse/AyaProducer.java
@@ -61,11 +61,11 @@ public final class AyaProducer {
   public Either<ImmutableSeq<Stmt>, Expr> visitRepl(AyaParser.ReplContext ctx) {
     var expr = ctx.expr();
     if (expr != null) return Either.right(visitExpr(expr));
-    return Either.left(ImmutableSeq.from(ctx.stmt()).flatMap(s -> visitStmt(s, false)));
+    return Either.left(ImmutableSeq.from(ctx.stmt()).flatMap(this::visitStmt));
   }
 
-  public ImmutableSeq<Stmt> visitProgram(AyaParser.ProgramContext ctx, boolean importOnly) {
-    return ImmutableSeq.from(ctx.stmt()).flatMap(s -> visitStmt(s, importOnly));
+  public ImmutableSeq<Stmt> visitProgram(AyaParser.ProgramContext ctx) {
+    return ImmutableSeq.from(ctx.stmt()).flatMap(this::visitStmt);
   }
 
   public Decl.PrimDecl visitPrimDecl(AyaParser.PrimDeclContext ctx) {
@@ -98,15 +98,13 @@ public final class AyaProducer {
     );
   }
 
-  public @NotNull SeqLike<Stmt> visitStmt(AyaParser.StmtContext ctx, boolean importOnly) {
+  public @NotNull SeqLike<Stmt> visitStmt(AyaParser.StmtContext ctx) {
     var importCmd = ctx.importCmd();
     if (importCmd != null) return ImmutableSeq.of(visitImportCmd(importCmd));
     var mod = ctx.module();
-    if (mod != null) return ImmutableSeq.of(visitModule(mod, importOnly));
+    if (mod != null) return ImmutableSeq.of(visitModule(mod));
     var openCmd = ctx.openCmd();
     if (openCmd != null) return visitOpenCmd(openCmd);
-    if (importOnly) return ImmutableSeq.empty();
-
     var decl = ctx.decl();
     if (decl != null) {
       var result = visitDecl(decl);
@@ -825,11 +823,11 @@ public final class AyaProducer {
       ? Command.Open.UseHide.Strategy.Using : Command.Open.UseHide.Strategy.Hiding);
   }
 
-  public @NotNull Command.Module visitModule(AyaParser.ModuleContext ctx, boolean importOnly) {
+  public @NotNull Command.Module visitModule(AyaParser.ModuleContext ctx) {
     var id = ctx.ID();
     return new Command.Module(
       sourcePosOf(id), id.getText(),
-      ImmutableSeq.from(ctx.stmt()).flatMap(s -> visitStmt(s, importOnly))
+      ImmutableSeq.from(ctx.stmt()).flatMap(this::visitStmt)
     );
   }
 

--- a/base/src/main/java/org/aya/concrete/resolve/module/CachedModuleLoader.java
+++ b/base/src/main/java/org/aya/concrete/resolve/module/CachedModuleLoader.java
@@ -7,8 +7,11 @@ import kala.collection.mutable.MutableHashMap;
 import kala.collection.mutable.MutableMap;
 import org.aya.concrete.resolve.ResolveInfo;
 import org.aya.concrete.stmt.QualifiedID;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Supplier;
 
 /**
  * @author re-xyr
@@ -23,11 +26,12 @@ public final class CachedModuleLoader implements ModuleLoader {
 
   @Override
   public @Nullable ResolveInfo load(@NotNull ImmutableSeq<String> path, @NotNull ModuleLoader recurseLoader) {
-    var stringifiedPath = QualifiedID.join(path);
-    return cache.getOrElse(stringifiedPath, () -> {
-      var ctx = loader.load(path, recurseLoader);
-      cache.put(stringifiedPath, ctx);
-      return ctx;
-    });
+    return cachedOrLoad(path, () -> loader.load(path, recurseLoader));
+  }
+
+  @ApiStatus.Internal
+  public @Nullable ResolveInfo cachedOrLoad(@NotNull ImmutableSeq<String> path, @NotNull Supplier<ResolveInfo> supplier) {
+    var qualified = QualifiedID.join(path);
+    return cache.getOrPut(qualified, supplier);
   }
 }

--- a/base/src/test/java/org/aya/concrete/ParseTest.java
+++ b/base/src/test/java/org/aya/concrete/ParseTest.java
@@ -46,11 +46,11 @@ public class ParseTest {
   }
 
   public static @NotNull ImmutableSeq<Stmt> parseStmt(@NotNull @NonNls @Language("TEXT") String code) {
-    return INSTANCE.visitStmt(AyaParsing.parser(code).stmt(), false).toImmutableSeq();
+    return INSTANCE.visitStmt(AyaParsing.parser(code).stmt()).toImmutableSeq();
   }
 
   public static @NotNull ImmutableSeq<Stmt> parseManyStmt(@NotNull @NonNls @Language("TEXT") String code) {
-    return INSTANCE.visitProgram(AyaParsing.parser(code).program(), false);
+    return INSTANCE.visitProgram(AyaParsing.parser(code).program());
   }
 
   public static @NotNull Tuple2<Decl, ImmutableSeq<Stmt>> parseDecl(@NotNull @NonNls @Language("TEXT") String code) {

--- a/base/src/test/java/org/aya/test/LibraryTest.java
+++ b/base/src/test/java/org/aya/test/LibraryTest.java
@@ -9,16 +9,18 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class LibraryTest {
   @Test public void test() throws IOException {
     FileUtil.deleteRecursively(DIR.resolve("build"));
     // Full rebuild
-    compile();
+    assertEquals(0, compile());
     FileUtil.deleteRecursively(DIR.resolve("build").resolve("out"));
     // The second time should load the cache of 'common'.
-    compile();
+    assertEquals(0, compile());
     // The third time should do nothing.
-    compile();
+    assertEquals(0, compile());
   }
 
   public static final Path DIR = TestRunner.DEFAULT_TEST_DIR.resolve("success");
@@ -28,7 +30,7 @@ public class LibraryTest {
     compile();
   }
 
-  private static void compile() throws IOException {
-    LibraryCompiler.compile(ThrowingReporter.INSTANCE, TestRunner.flags(), DIR);
+  private static int compile() throws IOException {
+    return LibraryCompiler.compile(ThrowingReporter.INSTANCE, TestRunner.flags(), DIR);
   }
 }

--- a/base/src/test/java/org/aya/tyck/TyckDeclTest.java
+++ b/base/src/test/java/org/aya/tyck/TyckDeclTest.java
@@ -46,7 +46,7 @@ public class TyckDeclTest {
   }
 
   public static @NotNull ImmutableSeq<Stmt> successDesugarDecls(@Language("TEXT") @NonNls @NotNull String text) {
-    var decls = AyaParsing.program(ThrowingReporter.INSTANCE, new SourceFile(Path.of("114514"), text), false);
+    var decls = AyaParsing.program(ThrowingReporter.INSTANCE, new SourceFile(Path.of("114514"), text));
     var ctx = new EmptyContext(ThrowingReporter.INSTANCE, Path.of("TestSource")).derive("decl");
     resolve(decls, ctx, new EmptyModuleLoader());
     return decls;

--- a/cli/src/main/java/org/aya/cli/library/LibraryModuleLoader.java
+++ b/cli/src/main/java/org/aya/cli/library/LibraryModuleLoader.java
@@ -71,6 +71,15 @@ public record LibraryModuleLoader(
     return null;
   }
 
+  @Nullable ResolveInfo loadLibrarySource(@NotNull LibrarySource source) {
+    var mod = source.moduleName();
+    var cached = cachedSelf.value;
+    return cached.cachedOrLoad(mod, () -> {
+      var context = new EmptyContext(reporter, source.file()).derive(mod);
+      return FileModuleLoader.resolveModule(context, cached, source.program().value, reporter);
+    });
+  }
+
   @Override
   public @Nullable ResolveInfo load(@NotNull ImmutableSeq<@NotNull String> mod, @NotNull ModuleLoader recurseLoader) {
     var sourcePath = resolveFile(thisModulePath, mod);

--- a/cli/src/main/java/org/aya/cli/library/LibrarySource.java
+++ b/cli/src/main/java/org/aya/cli/library/LibrarySource.java
@@ -4,6 +4,9 @@ package org.aya.cli.library;
 
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.DynamicSeq;
+import kala.value.Ref;
+import org.aya.concrete.resolve.ResolveInfo;
+import org.aya.concrete.stmt.Stmt;
 import org.jetbrains.annotations.Debug;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,14 +15,22 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.stream.IntStream;
 
+/**
+ * A source file may or may not be tycked.
+ *
+ * @param program     initialized after parse
+ * @param resolveInfo initialized after resolve
+ */
 @Debug.Renderer(text = "file")
 public record LibrarySource(
   @NotNull LibraryCompiler owner,
   @NotNull Path file,
-  @NotNull DynamicSeq<LibrarySource> imports
+  @NotNull DynamicSeq<LibrarySource> imports,
+  @NotNull Ref<ImmutableSeq<Stmt>> program,
+  @NotNull Ref<ResolveInfo> resolveInfo
 ) {
   public LibrarySource(@NotNull LibraryCompiler owner, @NotNull Path file) {
-    this(owner, canonicalize(file), DynamicSeq.create());
+    this(owner, canonicalize(file), DynamicSeq.create(), new Ref<>(), new Ref<>());
   }
 
   public @NotNull ImmutableSeq<String> moduleName() {


### PR DESCRIPTION
A simple fix of #228 

This PR adds two field to `LibrarySource`
- `Ref<ImmutableSeq<Stmt>>` as concrete trees which is initialized after resolving library imports
- `Ref<ResolveInfo>` which I don't know whether can be reused by LSP (if not, we remove it then)

