### PR TITLE
Resolve prim in shallow resolver

### DIFF
--- a/base/src/main/java/org/aya/concrete/resolve/ResolveInfo.java
+++ b/base/src/main/java/org/aya/concrete/resolve/ResolveInfo.java
@@ -13,12 +13,11 @@ import org.jetbrains.annotations.Debug;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * @param opSet       binary operators
- * @param imports     modules imported using `import` command
- * @param reExports   modules re-exported using `public open` command
- * @param declGraph   dependency graph of decls. for each (v, successors) in the graph,
- *                    `successors` should be tycked first.
- * @param sampleGraph dependency graph of samples and remarks.
+ * @param opSet     binary operators
+ * @param imports   modules imported using `import` command
+ * @param reExports modules re-exported using `public open` command
+ * @param depGraph  dependency graph of definitions. for each (v, successors) in the graph,
+ *                  `successors` should be tycked first.
  */
 @Debug.Renderer(text = "thisModule.moduleName().joinToString(\"::\")")
 public record ResolveInfo(
@@ -27,10 +26,9 @@ public record ResolveInfo(
   @NotNull AyaBinOpSet opSet,
   @NotNull DynamicSeq<ResolveInfo> imports,
   @NotNull DynamicSeq<ImmutableSeq<String>> reExports,
-  @NotNull MutableGraph<TyckUnit> declGraph,
-  @NotNull MutableGraph<TyckUnit> sampleGraph
+  @NotNull MutableGraph<TyckUnit> depGraph
 ) {
   public ResolveInfo(@NotNull ModuleContext thisModule, @NotNull ImmutableSeq<Stmt> thisProgram, @NotNull AyaBinOpSet opSet) {
-    this(thisModule, thisProgram, opSet, DynamicSeq.create(), DynamicSeq.create(), MutableGraph.create(), MutableGraph.create());
+    this(thisModule, thisProgram, opSet, DynamicSeq.create(), DynamicSeq.create(), MutableGraph.create());
   }
 }

--- a/base/src/main/java/org/aya/concrete/resolve/error/PrimDependencyError.java
+++ b/base/src/main/java/org/aya/concrete/resolve/error/PrimDependencyError.java
@@ -1,10 +1,9 @@
 // Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
-package org.aya.concrete.error;
+package org.aya.concrete.resolve.error;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.api.distill.DistillerOptions;
-import org.aya.concrete.resolve.error.ResolveProblem;
 import org.aya.core.def.PrimDef;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.doc.Style;

--- a/base/src/main/java/org/aya/concrete/resolve/error/RedefinitionPrimError.java
+++ b/base/src/main/java/org/aya/concrete/resolve/error/RedefinitionPrimError.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
-package org.aya.concrete.error;
+package org.aya.concrete.resolve.error;
 
 import org.aya.api.distill.DistillerOptions;
 import org.aya.api.error.Problem;
@@ -9,21 +9,20 @@ import org.aya.pretty.doc.Style;
 import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 
-public record UnknownPrimError(
-  @Override @NotNull SourcePos sourcePos,
-  @NotNull String name
+public record RedefinitionPrimError(
+  @NotNull String name,
+  @Override @NotNull SourcePos sourcePos
 ) implements Problem {
   @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
-    return Doc.sep(
-      Doc.plain("Unknown primitive"),
+    return Doc.sep(Doc.plain("Redefinition of primitive"),
       Doc.styled(Style.code(), Doc.plain(name)));
-  }
-
-  @Override public @NotNull Stage stage() {
-    return Stage.PARSE;
   }
 
   @Override public @NotNull Severity level() {
     return Severity.ERROR;
+  }
+
+  @Override public @NotNull Stage stage() {
+    return Stage.PARSE;
   }
 }

--- a/base/src/main/java/org/aya/concrete/resolve/error/RedefinitionPrimError.java
+++ b/base/src/main/java/org/aya/concrete/resolve/error/RedefinitionPrimError.java
@@ -14,7 +14,7 @@ public record RedefinitionPrimError(
   @Override @NotNull SourcePos sourcePos
 ) implements Problem {
   @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
-    return Doc.sep(Doc.plain("Redefinition of primitive"),
+    return Doc.sep(Doc.english("Redefinition of primitive"),
       Doc.styled(Style.code(), Doc.plain(name)));
   }
 

--- a/base/src/main/java/org/aya/concrete/resolve/error/UnknownPrimError.java
+++ b/base/src/main/java/org/aya/concrete/resolve/error/UnknownPrimError.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
-package org.aya.concrete.error;
+package org.aya.concrete.resolve.error;
 
 import org.aya.api.distill.DistillerOptions;
 import org.aya.api.error.Problem;
@@ -9,33 +9,21 @@ import org.aya.pretty.doc.Style;
 import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 
-public record RedefinitionError(
-  @NotNull Kind kind,
-  @NotNull String name,
-  @Override @NotNull SourcePos sourcePos
+public record UnknownPrimError(
+  @Override @NotNull SourcePos sourcePos,
+  @NotNull String name
 ) implements Problem {
   @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
-    return Doc.sep(Doc.plain("Redefinition of"), Doc.plain(kind.prettyName),
+    return Doc.sep(
+      Doc.plain("Unknown primitive"),
       Doc.styled(Style.code(), Doc.plain(name)));
-  }
-
-  @Override public @NotNull Severity level() {
-    return Severity.ERROR;
   }
 
   @Override public @NotNull Stage stage() {
     return Stage.PARSE;
   }
 
-  public enum Kind {
-    Prim("primitive"),
-    Ctor("constructor"),
-    Field("field");
-
-    final @NotNull String prettyName;
-
-    Kind(@NotNull String name) {
-      prettyName = name;
-    }
+  @Override public @NotNull Severity level() {
+    return Severity.ERROR;
   }
 }

--- a/base/src/main/java/org/aya/concrete/resolve/module/ModuleLoader.java
+++ b/base/src/main/java/org/aya/concrete/resolve/module/ModuleLoader.java
@@ -35,9 +35,7 @@ public interface ModuleLoader {
     var sccTycker = new AyaOrgaTycker(new AyaSccTycker(resolveInfo, builder, delayedReporter), resolveInfo);
     // in case we have un-messaged TyckException
     try (delayedReporter) {
-      var SCCs = resolveInfo.declGraph().topologicalOrder()
-        .view().appendedAll(resolveInfo.sampleGraph().topologicalOrder())
-        .toImmutableSeq();
+      var SCCs = resolveInfo.depGraph().topologicalOrder();
       SCCs.forEach(sccTycker::tyckSCC);
     } finally {
       if (onTycked != null) onTycked.onModuleTycked(

--- a/base/src/main/java/org/aya/concrete/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/concrete/resolve/visitor/StmtResolver.java
@@ -79,9 +79,9 @@ public interface StmtResolver {
         var delegateInfo = new ResolveInfo(info.thisModule(), info.program(), info.opSet());
         resolveStmt(delegate, delegateInfo);
         // little hacky: transfer dependencies from `delegate` to `sample`
-        info.sampleGraph().sucMut(sample).appendAll(delegateInfo.declGraph().suc(delegate));
+        info.depGraph().sucMut(sample).appendAll(delegateInfo.depGraph().suc(delegate));
       }
-      case Remark remark -> info.sampleGraph().sucMut(remark).appendAll(remark.doResolve(info));
+      case Remark remark -> info.depGraph().sucMut(remark).appendAll(remark.doResolve(info));
       case Command cmd -> {}
       case Generalize.Levels levels -> {}
       case Generalize.Variables variables -> {
@@ -93,7 +93,7 @@ public interface StmtResolver {
   }
 
   private static void addReferences(@NotNull ResolveInfo info, TyckUnit decl, ExprResolver resolver) {
-    info.declGraph().sucMut(decl).appendAll(resolver.reference().view()
+    info.depGraph().sucMut(decl).appendAll(resolver.reference().view()
       .filter(TyckUnit::needTyck));
   }
 

--- a/base/src/main/java/org/aya/concrete/resolve/visitor/StmtShallowResolver.java
+++ b/base/src/main/java/org/aya/concrete/resolve/visitor/StmtShallowResolver.java
@@ -6,9 +6,6 @@ import kala.collection.SeqLike;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableHashMap;
 import kala.tuple.Tuple2;
-import org.aya.concrete.error.PrimDependencyError;
-import org.aya.concrete.error.RedefinitionError;
-import org.aya.concrete.error.UnknownPrimError;
 import org.aya.concrete.remark.Remark;
 import org.aya.concrete.resolve.ResolveInfo;
 import org.aya.concrete.resolve.context.Context;
@@ -16,6 +13,9 @@ import org.aya.concrete.resolve.context.ModuleContext;
 import org.aya.concrete.resolve.context.NoExportContext;
 import org.aya.concrete.resolve.context.PhysicalModuleContext;
 import org.aya.concrete.resolve.error.ModNotFoundError;
+import org.aya.concrete.resolve.error.PrimDependencyError;
+import org.aya.concrete.resolve.error.RedefinitionPrimError;
+import org.aya.concrete.resolve.error.UnknownPrimError;
 import org.aya.concrete.resolve.module.ModuleLoader;
 import org.aya.concrete.stmt.*;
 import org.aya.core.def.PrimDef;
@@ -126,7 +126,7 @@ public record StmtShallowResolver(
         if (lack.isNotEmpty() && lack.get().isNotEmpty())
           context.reportAndThrow(new PrimDependencyError(name, lack.get(), sourcePos));
         else if (PrimDef.Factory.INSTANCE.have(primID))
-          context.reportAndThrow(new RedefinitionError(RedefinitionError.Kind.Prim, name, sourcePos));
+          context.reportAndThrow(new RedefinitionPrimError(name, sourcePos));
         PrimDef.Factory.INSTANCE.factory(primID, decl.ref);
         resolveDecl(decl, context);
       }

--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -100,19 +100,17 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
    * which means it's unspecified in the concrete syntax.
    * @see PrimDef
    */
-  public static final class PrimDecl extends Decl implements OpDecl {
+  public static final class PrimDecl extends Decl {
     public final @NotNull DefVar<PrimDef, PrimDecl> ref;
 
     public PrimDecl(
       @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
-      @Nullable OpDecl.OpInfo opInfo,
-      @NotNull DefVar<PrimDef, PrimDecl> ref,
+      @NotNull String name,
       @NotNull ImmutableSeq<Expr.Param> telescope,
       @NotNull Expr result
     ) {
-      super(sourcePos, entireSourcePos, Accessibility.Public, opInfo, BindBlock.EMPTY, telescope, result);
-      ref.concrete = this;
-      this.ref = ref;
+      super(sourcePos, entireSourcePos, Accessibility.Public, null, BindBlock.EMPTY, telescope, result);
+      this.ref = DefVar.concrete(this, name);
     }
 
     @Override public boolean needTyck() {
@@ -128,7 +126,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
     }
   }
 
-  public static final class DataCtor extends Signatured implements OpDecl {
+  public static final class DataCtor extends Signatured {
     public final @NotNull DefVar<CtorDef, Decl.DataCtor> ref;
     public DefVar<DataDef, DataDecl> dataRef;
     /** Similar to {@link Signatured#signature}, but stores the bindings in {@link DataCtor#patterns} */
@@ -165,7 +163,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
    * @author kiva
    * @see DataDef
    */
-  public static final class DataDecl extends Decl implements OpDecl {
+  public static final class DataDecl extends Decl {
     public final @NotNull DefVar<DataDef, DataDecl> ref;
     public final @NotNull ImmutableSeq<DataCtor> body;
     /** Yet type-checked constructors */
@@ -202,7 +200,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
    *
    * @author vont
    */
-  public static final class StructDecl extends Decl implements OpDecl {
+  public static final class StructDecl extends Decl {
     public final @NotNull DefVar<StructDef, StructDecl> ref;
     public @NotNull
     final ImmutableSeq<StructField> fields;
@@ -234,7 +232,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
     }
   }
 
-  public static final class StructField extends Signatured implements OpDecl {
+  public static final class StructField extends Signatured {
     public final @NotNull DefVar<FieldDef, Decl.StructField> ref;
     public DefVar<StructDef, StructDecl> structRef;
     public @NotNull ImmutableSeq<Pattern.Clause> clauses;
@@ -265,10 +263,6 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
     @Override public @NotNull DefVar<FieldDef, StructField> ref() {
       return ref;
     }
-
-    @Override public @Nullable OpDecl.OpInfo opInfo() {
-      return opInfo;
-    }
   }
 
   /**
@@ -277,7 +271,7 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
    * @author re-xyr
    * @see FnDef
    */
-  public static final class FnDecl extends Decl implements OpDecl {
+  public static final class FnDecl extends Decl {
     public final @NotNull EnumSet<Modifier> modifiers;
     public final @NotNull DefVar<FnDef, FnDecl> ref;
     public @NotNull Either<Expr, ImmutableSeq<Pattern.Clause>> body;

--- a/base/src/main/java/org/aya/core/serde/SerDef.java
+++ b/base/src/main/java/org/aya/core/serde/SerDef.java
@@ -5,7 +5,9 @@ package org.aya.core.serde;
 import kala.collection.immutable.ImmutableSeq;
 import kala.control.Either;
 import kala.control.Option;
+import org.aya.api.ref.DefVar;
 import org.aya.api.util.InternalException;
+import org.aya.concrete.stmt.Decl;
 import org.aya.core.def.*;
 import org.aya.generic.Constants;
 import org.aya.generic.Modifier;
@@ -126,7 +128,8 @@ public sealed interface SerDef extends Serializable {
   ) implements SerDef {
     @Override
     public @NotNull Def de(SerTerm.@NotNull DeState state) {
-      var def = PrimDef.Factory.INSTANCE.getOrCreate(name);
+      var defVar = DefVar.<PrimDef, Decl.PrimDecl>empty(name.id);
+      var def = PrimDef.Factory.INSTANCE.getOrCreate(name, defVar);
       state.putPrim(module, name, def.ref);
       return def;
     }

--- a/base/src/main/java/org/aya/tyck/order/AyaOrgaTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaOrgaTycker.java
@@ -4,7 +4,6 @@ package org.aya.tyck.order;
 
 import kala.collection.mutable.MutableSet;
 import org.aya.concrete.resolve.ResolveInfo;
-import org.aya.concrete.stmt.Decl;
 import org.aya.util.MutableGraph;
 import org.aya.util.tyck.OrgaTycker;
 import org.jetbrains.annotations.NotNull;
@@ -12,23 +11,20 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Incremental and non-stopping compiler for SCCs.
  *
- * @param declUsage   usage graph of decls (usually the transpose of {@link ResolveInfo#declGraph()}).
- *                    for each (vertex, w) in the graph, the vertex should be tycked first.
- * @param sampleUsage transpose of {@link ResolveInfo#sampleGraph()}
+ * @param usageGraph usage graph of decls (usually the transpose of {@link ResolveInfo#depGraph()}).
+ *                   for each (vertex, w) in the graph, the vertex should be tycked first.
  * @author kiva
  */
 public record AyaOrgaTycker(
   @NotNull AyaSccTycker sccTycker,
-  @NotNull MutableGraph<TyckUnit> declUsage,
-  @NotNull MutableGraph<TyckUnit> sampleUsage,
+  @NotNull MutableGraph<TyckUnit> usageGraph,
   @NotNull MutableSet<TyckUnit> skippedSet
 ) implements OrgaTycker<TyckUnit, AyaSccTycker.SCCTyckingFailed> {
   public AyaOrgaTycker(@NotNull AyaSccTycker sccTycker, @NotNull ResolveInfo resolveInfo) {
-    this(sccTycker, resolveInfo.declGraph().transpose(), resolveInfo.sampleGraph().transpose(), MutableSet.of());
+    this(sccTycker, resolveInfo.depGraph().transpose(), MutableSet.of());
   }
 
   @Override public @NotNull Iterable<TyckUnit> collectUsageOf(@NotNull TyckUnit failed) {
-    var graph = failed instanceof Decl ? declUsage : sampleUsage;
-    return graph.suc(failed);
+    return usageGraph.suc(failed);
   }
 }

--- a/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
@@ -61,7 +61,7 @@ public record AyaSccTycker(
   }
 
   private boolean isRecursive(@NotNull Decl unit) {
-    return resolveInfo.declGraph().hasSuc(unit, unit);
+    return resolveInfo.depGraph().hasSuc(unit, unit);
   }
 
   private void checkHeader(@NotNull TyckUnit stmt) {

--- a/base/src/test/resources/failure/scope/issue274.aya.txt
+++ b/base/src/test/resources/failure/scope/issue274.aya.txt
@@ -5,8 +5,8 @@ In file $FILE:3:4 ->
   3 |   | zero
           ^--^
 
-Error: Redefinition of constructor `zero`
+Error: The name zero (`zero`) is already defined elsewhere
 
-Parsing interrupted due to:
+Resolving interrupted due to:
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/scope/prim-dependency.aya.txt
+++ b/base/src/test/resources/failure/scope/prim-dependency.aya.txt
@@ -6,6 +6,6 @@ In file $FILE:1:5 ->
 
 Error: The prim `left` depends on undeclared prims: `I`
 
-Parsing interrupted due to:
+Resolving interrupted due to:
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/scope/re-prim.aya.txt
+++ b/base/src/test/resources/failure/scope/re-prim.aya.txt
@@ -6,6 +6,6 @@ In file $FILE:2:5 ->
 
 Error: Redefinition of primitive `I`
 
-Parsing interrupted due to:
+Resolving interrupted due to:
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/scope/unknown-prim.aya.txt
+++ b/base/src/test/resources/failure/scope/unknown-prim.aya.txt
@@ -5,6 +5,6 @@ In file $FILE:1:5 ->
 
 Error: Unknown primitive `YYUT`
 
-Parsing interrupted due to:
+Resolving interrupted due to:
 1 error(s), 0 warning(s).
 What are you doing?

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -63,7 +63,7 @@ fnModifiers : OPAQUE
 
 structDecl : STRUCT declNameOrInfix tele* type? (EXTENDS idsComma)? (BAR field)* bindBlock?;
 
-primDecl : PRIM assoc? ID tele* type? ;
+primDecl : PRIM ID tele* type? ;
 
 field : COERCE? declNameOrInfix tele* type clauses? bindBlock? # fieldDecl
       | declNameOrInfix tele* type? IMPLIES expr    bindBlock? # fieldImpl


### PR DESCRIPTION
Summary
- remove `OpInfo` from `PrimDecl` because we don't have a proper way of using prims as operators #289 .
- resolve `PrimDecl` in the shallow resolver, which creates `PrimDef` instances from concretes' `DefVar`.
- set all dependencies of prims in `PrimDef` because we need `DefVar` to create it which is only accessible by declaring prim names explicitly.
- other refactorings related to resolving and parsing