### PR TITLE
Now I can play with Aya in VSCode happily

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -7,15 +7,18 @@
 
 ## Download
 
-You may download the latest nightly release of Aya from [GitHub Releases].
+You may download the latest build of Aya from [GitHub Releases].
+It's updated for per-commit to the `main` branch,
+but the release date displayed is very old and is an issue of GitHub.
+
 There are prebuilt binaries for Windows, Linux, and macOS that can be used
 in Java-free environments as well as fat-jar files which can be invoked via `java --enable-preview -jar`.
-Note that the nightly release is updated for each commit to the `main` branch,
-but the release date displayed is very old and is an issue of GitHub.
 
 The minimum required version of Java is [Java 17].
 
-Aya is under active development. Nothing guaranteed! However, we can share some cool stuffs here:
+Aya is under active development, so please expect bugs, usability/performance issues
+(please file issues or create threads in discussions!).
+However, we can share some cool stuffs here:
 
 + Dependent types, including pi-types, sigma types, etc.
   You could write a [type-safe interpreter][gadt].

--- a/base/src/main/java/org/aya/distill/BaseDistiller.java
+++ b/base/src/main/java/org/aya/distill/BaseDistiller.java
@@ -137,7 +137,7 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
           var used = telescope.sliceView(i + 1, telescope.size())
             .map(ParamLike::type).appended(body)
             .anyMatch(p -> findUsages.applyAsInt(p, ref) > 0);
-          if (used) buf.append(last.explicit()
+          if (!used) buf.append(last.explicit()
             ? term(Outer.ProjHead, last.type())
             : Doc.braced(last.type().toDoc(options)));
           else buf.append(dynamicSeqNames(names, last));

--- a/base/src/main/java/org/aya/distill/BaseDistiller.java
+++ b/base/src/main/java/org/aya/distill/BaseDistiller.java
@@ -71,6 +71,16 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
     return visitCalls(var, style, args, outer, options.map.get(DistillerOptions.Key.ShowImplicitArgs));
   }
 
+  /**
+   * Pretty-print an application in a smart way.
+   * If an infix operator is applied by two arguments, we use operator syntax.
+   *
+   * @param infix Whether the applied function is an infix operator.
+   * @param fn    The applied function, pretty-printed.
+   * @param fmt   Mostly just {@link #term(Outer, AyaDocile)}, but can be overridden.
+   * @param <T>   Mostly <code>Term</code>.
+   * @see BaseDistiller#prefix(Doc, Fmt, Outer, SeqView)
+   */
   <T extends AyaDocile> @NotNull Doc visitCalls(
     boolean infix, @NotNull Doc fn, @NotNull Fmt<T> fmt, Outer outer,
     @NotNull SeqView<@NotNull Arg<@NotNull T>> args, boolean showImplicits
@@ -91,6 +101,11 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
     return prefix(fn, fmt, outer, visibleArgs.view());
   }
 
+  /**
+   * Pretty-print an application in a dumb (but conservative) way, using prefix syntax.
+   *
+   * @see BaseDistiller#visitCalls(boolean, Doc, Fmt, Outer, SeqView, boolean)
+   */
   private <T extends AyaDocile> @NotNull Doc
   prefix(@NotNull Doc fn, @NotNull Fmt<T> fmt, Outer outer, SeqView<Arg<T>> args) {
     var call = Doc.sep(fn, Doc.sep(args.map(arg ->
@@ -108,7 +123,17 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
     return outer.ordinal() >= binOp.ordinal() ? Doc.parened(binApp) : binApp;
   }
 
-  @NotNull Doc ctorDoc(@NotNull Outer outer, boolean ex, Doc ctorDoc, LocalVar ctorAs, boolean noParams) {
+  /**
+   * This function does the following if necessary:
+   * <ul>
+   *   <li>Wrap the constructor with parentheses or braces</li>
+   *   <li>Append an 'as' at the end</li>
+   * </ul>
+   *
+   * @param ctorDoc  The constructor pretty-printed doc, without the 'as' or parentheses.
+   * @param noParams Whether the constructor has no parameters or not.
+   */
+  @NotNull Doc ctorDoc(@NotNull Outer outer, boolean ex, Doc ctorDoc, @Nullable LocalVar ctorAs, boolean noParams) {
     boolean as = ctorAs != null;
     var withEx = Doc.bracedUnless(ctorDoc, ex);
     var withAs = !as ? withEx :
@@ -116,14 +141,29 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
     return !ex && !as ? withAs : outer != Outer.Free && !noParams ? Doc.parened(withAs) : withAs;
   }
 
+  /**
+   * Pretty-print a telescope in a dumb (but conservative) way.
+   *
+   * @see BaseDistiller#visitTele(Seq, AyaDocile, ToIntBiFunction)
+   */
   public @NotNull Doc visitTele(@NotNull Seq<? extends ParamLike<Term>> telescope) {
     return visitTele(telescope, null, (t, v) -> 1);
   }
 
+  /**
+   * Pretty-print a telescope in a smart way.
+   * The bindings that are not used in the telescope/body are omitted.
+   * Bindings of the same type (by 'same' I mean <code>Objects.equals</code> returns true)
+   * are merged together.
+   *
+   * @param body  the body of the telescope (like the return type in a pi type),
+   *              only used for finding usages (of the variables in the telescope).
+   * @param altF7 a function for finding usages.
+   * @see BaseDistiller#visitTele(Seq)
+   */
   public @NotNull Doc visitTele(
     @NotNull Seq<? extends ParamLike<Term>> telescope,
-    @Nullable Term body,
-    @NotNull ToIntBiFunction<Term, Var> findUsages
+    @Nullable Term body, @NotNull ToIntBiFunction<Term, Var> altF7
   ) {
     if (telescope.isEmpty()) return Doc.empty();
     var last = telescope.first();
@@ -136,10 +176,8 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
           var ref = names.first();
           var used = telescope.sliceView(i + 1, telescope.size())
             .map(ParamLike::type).appended(body)
-            .anyMatch(p -> findUsages.applyAsInt(p, ref) > 0);
-          if (!used) buf.append(last.explicit()
-            ? term(Outer.ProjHead, last.type())
-            : Doc.braced(last.type().toDoc(options)));
+            .anyMatch(p -> altF7.applyAsInt(p, ref) > 0);
+          if (!used) buf.append(justType(last));
           else buf.append(dynamicSeqNames(names, last));
         } else buf.append(dynamicSeqNames(names, last));
         names.clear();
@@ -147,8 +185,16 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
       }
       names.append(param.ref());
     }
-    buf.append(dynamicSeqNames(names, last));
+    if (body != null && names.sizeEquals(1)
+      && altF7.applyAsInt(body, names.first()) == 0) {
+      buf.append(justType(last));
+    } else buf.append(dynamicSeqNames(names, last));
     return Doc.sep(buf);
+  }
+
+  private @NotNull Doc justType(@NotNull ParamLike<Term> monika) {
+    return monika.explicit() ? term(Outer.ProjHead, monika.type())
+      : Doc.braced(monika.type().toDoc(options));
   }
 
   private Doc dynamicSeqNames(DynamicSeq<LocalVar> names, ParamLike<?> param) {

--- a/base/src/main/java/org/aya/distill/BaseDistiller.java
+++ b/base/src/main/java/org/aya/distill/BaseDistiller.java
@@ -177,7 +177,7 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
           var used = telescope.sliceView(i + 1, telescope.size())
             .map(ParamLike::type).appended(body)
             .anyMatch(p -> altF7.applyAsInt(p, ref) > 0);
-          if (!used) buf.append(justType(last));
+          if (!used) buf.append(justType(last, Outer.ProjHead));
           else buf.append(dynamicSeqNames(names, last));
         } else buf.append(dynamicSeqNames(names, last));
         names.clear();
@@ -187,13 +187,13 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
     }
     if (body != null && names.sizeEquals(1)
       && altF7.applyAsInt(body, names.first()) == 0) {
-      buf.append(justType(last));
+      buf.append(justType(last, Outer.ProjHead));
     } else buf.append(dynamicSeqNames(names, last));
     return Doc.sep(buf);
   }
 
-  private @NotNull Doc justType(@NotNull ParamLike<Term> monika) {
-    return monika.explicit() ? term(Outer.ProjHead, monika.type())
+  @NotNull Doc justType(@NotNull ParamLike<Term> monika, Outer outer) {
+    return monika.explicit() ? term(outer, monika.type())
       : Doc.braced(monika.type().toDoc(options));
   }
 

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -126,7 +126,7 @@ public class CoreDistiller extends BaseDistiller<Term> implements
       Doc.styled(KEYWORD, Doc.symbol("Sig")),
       visitTele(term.params().dropLast(1), last.type(), Term::findUsages),
       Doc.symbol("**"),
-      last.toDoc(options)
+      justType(last, Outer.Codomain)
     );
     // Same as Pi
     return checkParen(outer, doc, Outer.BinOp);

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -121,11 +121,12 @@ public class CoreDistiller extends BaseDistiller<Term> implements
   }
 
   @Override public Doc visitSigma(@NotNull FormTerm.Sigma term, Outer outer) {
+    var last = term.params().last();
     var doc = Doc.sep(
       Doc.styled(KEYWORD, Doc.symbol("Sig")),
-      visitTele(term.params().dropLast(1)),
+      visitTele(term.params().dropLast(1), last.type(), Term::findUsages),
       Doc.symbol("**"),
-      term.params().last().toDoc(options)
+      last.toDoc(options)
     );
     // Same as Pi
     return checkParen(outer, doc, Outer.BinOp);

--- a/cli/src/main/java/org/aya/cli/library/source/LibrarySource.java
+++ b/cli/src/main/java/org/aya/cli/library/source/LibrarySource.java
@@ -10,6 +10,7 @@ import org.aya.core.def.Def;
 import org.aya.generic.Constants;
 import org.aya.resolve.ResolveInfo;
 import org.aya.util.FileUtil;
+import org.aya.util.error.SourceFile;
 import org.jetbrains.annotations.Debug;
 import org.jetbrains.annotations.NotNull;
 
@@ -48,6 +49,10 @@ public record LibrarySource(
 
   public @NotNull Path displayPath() {
     return owner.locator().displayName(file);
+  }
+
+  public @NotNull SourceFile toSourceFile(@NotNull String sourceCode) {
+    return new SourceFile(displayPath().toString(), file, sourceCode);
   }
 
   public @NotNull Path coreFile() {

--- a/lsp/src/main/java/org/aya/lsp/actions/ComputeSignature.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/ComputeSignature.java
@@ -18,10 +18,10 @@ import org.jetbrains.annotations.NotNull;
 
 public interface ComputeSignature {
   static @NotNull Doc invokeHover(
-    @NotNull LibrarySource loadedFile,
+    @NotNull LibrarySource source,
     @NotNull Position position
   ) {
-    var target = Resolver.resolveVar(loadedFile, position).firstOrNull();
+    var target = Resolver.resolveVar(source, position).firstOrNull();
     if (target == null) return Doc.empty();
     return computeSignature(target.data(), true);
   }

--- a/lsp/src/main/java/org/aya/lsp/actions/ComputeTerm.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/ComputeTerm.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
 
 public final class ComputeTerm implements SyntaxNodeAction {
   private @Nullable WithPos<Term> result = null;
-  private final @NotNull LibrarySource loadedFile;
+  private final @NotNull LibrarySource source;
   private final @NotNull Kind kind;
 
   public enum Kind {
@@ -34,13 +34,13 @@ public final class ComputeTerm implements SyntaxNodeAction {
     }
   }
 
-  public ComputeTerm(@NotNull LibrarySource loadedFile, @NotNull Kind kind) {
-    this.loadedFile = loadedFile;
+  public ComputeTerm(@NotNull LibrarySource source, @NotNull Kind kind) {
+    this.source = source;
     this.kind = kind;
   }
 
   public @NotNull ComputeTermResult invoke(ComputeTermResult.Params params) {
-    var program = loadedFile.program().value;
+    var program = source.program().value;
     if (program == null) return ComputeTermResult.bad(params);
     visitAll(program, new XY(params.position));
     return result == null ? ComputeTermResult.bad(params) : ComputeTermResult.good(params, result);

--- a/lsp/src/main/java/org/aya/lsp/actions/FindReferences.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/FindReferences.java
@@ -26,12 +26,20 @@ public interface FindReferences {
     @NotNull Position position,
     @NotNull SeqView<LibraryOwner> libraries
   ) {
+    return findRefs(source, position, libraries)
+      .map(ref -> LspRange.toLoc(ref.sourcePos()))
+      .collect(Collectors.toList());
+  }
+
+  static @NotNull SeqView<Expr.RefExpr> findRefs(
+    @NotNull LibrarySource source,
+    @NotNull Position position,
+    @NotNull SeqView<LibraryOwner> libraries
+  ) {
     var vars = Resolver.resolveVar(source, position);
     var resolver = new ReferenceResolver(DynamicSeq.create());
     vars.forEach(var -> libraries.forEach(lib -> resolve(resolver, lib, var.data())));
-    return resolver.refs.view()
-      .map(ref -> LspRange.toLoc(ref.sourcePos()))
-      .collect(Collectors.toList());
+    return resolver.refs.view();
   }
 
   private static void resolve(@NotNull ReferenceResolver resolver, @NotNull LibraryOwner owner, @NotNull Var var) {

--- a/lsp/src/main/java/org/aya/lsp/actions/FindReferences.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/FindReferences.java
@@ -9,6 +9,7 @@ import org.aya.cli.library.source.LibrarySource;
 import org.aya.lsp.utils.LspRange;
 import org.aya.lsp.utils.Resolver;
 import org.aya.util.error.SourcePos;
+import org.aya.util.error.WithPos;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.jetbrains.annotations.NotNull;
@@ -36,6 +37,16 @@ public interface FindReferences {
     var resolver = new Resolver.UsageResolver();
     vars.forEach(var -> libraries.forEach(lib -> resolve(resolver, lib, var.data())));
     return resolver.refs.view();
+  }
+
+  static @NotNull SeqView<SourcePos> findOccurrences(
+    @NotNull LibrarySource source,
+    @NotNull Position position,
+    @NotNull SeqView<LibraryOwner> libraries
+  ) {
+    var defs = GotoDefinition.findDefs(source, position, libraries).map(WithPos::data);
+    var refs = FindReferences.findRefs(source, position, libraries);
+    return defs.concat(refs);
   }
 
   private static void resolve(@NotNull Resolver.UsageResolver resolver, @NotNull LibraryOwner owner, @NotNull Var var) {

--- a/lsp/src/main/java/org/aya/lsp/actions/FindReferences.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/FindReferences.java
@@ -22,11 +22,11 @@ import java.util.stream.Collectors;
 
 public interface FindReferences {
   static @NotNull List<Location> invoke(
-    @NotNull LibrarySource loadedFile,
+    @NotNull LibrarySource source,
     @NotNull Position position,
     @NotNull SeqView<LibraryOwner> libraries
   ) {
-    var vars = Resolver.resolveVar(loadedFile, position);
+    var vars = Resolver.resolveVar(source, position);
     var resolver = new ReferenceResolver(DynamicSeq.create());
     vars.forEach(var -> libraries.forEach(lib -> resolve(resolver, lib, var.data())));
     return resolver.refs.view()

--- a/lsp/src/main/java/org/aya/lsp/actions/GotoDefinition.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/GotoDefinition.java
@@ -11,7 +11,6 @@ import org.aya.lsp.utils.Log;
 import org.aya.lsp.utils.LspRange;
 import org.aya.lsp.utils.ModuleVar;
 import org.aya.lsp.utils.Resolver;
-import org.aya.util.error.SourceFile;
 import org.aya.util.error.SourcePos;
 import org.aya.util.error.WithPos;
 import org.eclipse.lsp4j.LocationLink;
@@ -59,9 +58,9 @@ public interface GotoDefinition {
   }
 
   private static @Nullable SourcePos mockSourcePos(@NotNull SeqView<LibraryOwner> libraries, @NotNull ModuleVar moduleVar) {
-    var src = Resolver.resolveModule(libraries, moduleVar.path().ids()).getOrNull();
-    if (src == null) return null;
-    return new SourcePos(new SourceFile(src.displayPath().toString(), src.file(), ""),
-      0, 0, 1, 0, 1, 0);
+    return Resolver.resolveModule(libraries, moduleVar.path().ids())
+      .map(src -> src.toSourceFile(""))
+      .map(src -> new SourcePos(src, 0, 0, 1, 0, 1, 0))
+      .getOrNull();
   }
 }

--- a/lsp/src/main/java/org/aya/lsp/actions/GotoDefinition.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/GotoDefinition.java
@@ -13,6 +13,7 @@ import org.aya.lsp.utils.ModuleVar;
 import org.aya.lsp.utils.Resolver;
 import org.aya.util.error.SourceFile;
 import org.aya.util.error.SourcePos;
+import org.aya.util.error.WithPos;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
 import org.jetbrains.annotations.NotNull;
@@ -30,6 +31,20 @@ public interface GotoDefinition {
     @NotNull Position position,
     @NotNull SeqView<LibraryOwner> libraries
   ) {
+    return findDefs(source, position, libraries).mapNotNull(pos -> {
+      var from = pos.sourcePos();
+      var to = pos.data();
+      var res = LspRange.toLoc(from, to);
+      if (res != null) Log.d("Resolved: %s in %s", to, res.getTargetUri());
+      return res;
+    }).collect(Collectors.toList());
+  }
+
+  static @NotNull SeqView<WithPos<SourcePos>> findDefs(
+    @NotNull LibrarySource source,
+    @NotNull Position position,
+    @NotNull SeqView<LibraryOwner> libraries
+  ) {
     return Resolver.resolveVar(source, position).mapNotNull(pos -> {
       var from = pos.sourcePos();
       var target = switch (pos.data()) {
@@ -39,10 +54,8 @@ public interface GotoDefinition {
         case default -> null;
       };
       if (target == null) return null;
-      var res = LspRange.toLoc(from, target);
-      if (res != null) Log.d("Resolved: %s in %s", target, res.getTargetUri());
-      return res;
-    }).collect(Collectors.toList());
+      return new WithPos<>(from, target);
+    });
   }
 
   private static @Nullable SourcePos mockSourcePos(@NotNull SeqView<LibraryOwner> libraries, @NotNull ModuleVar moduleVar) {

--- a/lsp/src/main/java/org/aya/lsp/actions/GotoDefinition.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/GotoDefinition.java
@@ -26,11 +26,11 @@ import java.util.stream.Collectors;
  */
 public interface GotoDefinition {
   static @NotNull List<LocationLink> invoke(
-    @NotNull LibrarySource loadedFile,
+    @NotNull LibrarySource source,
     @NotNull Position position,
     @NotNull SeqView<LibraryOwner> libraries
   ) {
-    return Resolver.resolveVar(loadedFile, position).mapNotNull(pos -> {
+    return Resolver.resolveVar(source, position).mapNotNull(pos -> {
       var from = pos.sourcePos();
       var target = switch (pos.data()) {
         case DefVar<?, ?> defVar -> defVar.concrete.sourcePos();

--- a/lsp/src/main/java/org/aya/lsp/actions/GotoDefinition.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/GotoDefinition.java
@@ -2,15 +2,21 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.lsp.actions;
 
+import kala.collection.SeqView;
 import org.aya.api.ref.DefVar;
 import org.aya.api.ref.LocalVar;
+import org.aya.cli.library.source.LibraryOwner;
 import org.aya.cli.library.source.LibrarySource;
 import org.aya.lsp.utils.Log;
 import org.aya.lsp.utils.LspRange;
+import org.aya.lsp.utils.ModuleVar;
 import org.aya.lsp.utils.Resolver;
+import org.aya.util.error.SourceFile;
+import org.aya.util.error.SourcePos;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,12 +25,17 @@ import java.util.stream.Collectors;
  * @author ice1000, kiva
  */
 public interface GotoDefinition {
-  static @NotNull List<LocationLink> invoke(@NotNull LibrarySource loadedFile, @NotNull Position position) {
+  static @NotNull List<LocationLink> invoke(
+    @NotNull LibrarySource loadedFile,
+    @NotNull Position position,
+    @NotNull SeqView<LibraryOwner> libraries
+  ) {
     return Resolver.resolveVar(loadedFile, position).mapNotNull(pos -> {
       var from = pos.sourcePos();
       var target = switch (pos.data()) {
         case DefVar<?, ?> defVar -> defVar.concrete.sourcePos();
         case LocalVar localVar -> localVar.definition();
+        case ModuleVar moduleVar -> mockSourcePos(libraries, moduleVar);
         case default -> null;
       };
       if (target == null) return null;
@@ -32,5 +43,12 @@ public interface GotoDefinition {
       if (res != null) Log.d("Resolved: %s in %s", target, res.getTargetUri());
       return res;
     }).collect(Collectors.toList());
+  }
+
+  private static @Nullable SourcePos mockSourcePos(@NotNull SeqView<LibraryOwner> libraries, @NotNull ModuleVar moduleVar) {
+    var src = Resolver.resolveModule(libraries, moduleVar.path().ids()).getOrNull();
+    if (src == null) return null;
+    return new SourcePos(new SourceFile(src.displayPath().toString(), src.file(), ""),
+      0, 0, 1, 0, 1, 0);
   }
 }

--- a/lsp/src/main/java/org/aya/lsp/actions/Rename.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/Rename.java
@@ -35,7 +35,7 @@ public interface Rename {
   ) {
     var defs = GotoDefinition.findDefs(source, position, libraries);
     var refs = FindReferences.findRefs(source, position, libraries)
-      .map(ref -> new WithPos<>(SourcePos.NONE, ref.sourcePos()));
+      .map(ref -> new WithPos<>(SourcePos.NONE, ref));
 
     return defs.concat(refs)
       .flatMap(pos -> {

--- a/lsp/src/main/java/org/aya/lsp/actions/Rename.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/Rename.java
@@ -1,0 +1,50 @@
+// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.lsp.actions;
+
+import kala.collection.SeqView;
+import kala.tuple.Tuple;
+import org.aya.api.ref.Var;
+import org.aya.cli.library.source.LibraryOwner;
+import org.aya.cli.library.source.LibrarySource;
+import org.aya.lsp.utils.LspRange;
+import org.aya.lsp.utils.Resolver;
+import org.aya.util.error.SourcePos;
+import org.aya.util.error.WithPos;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextEdit;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public interface Rename {
+  static @Nullable WithPos<String> prepare(@NotNull LibrarySource source, @NotNull Position position) {
+    var vars = Resolver.resolveVar(source, position);
+    if (vars.isEmpty()) return null;
+    return vars.first().map(Var::name);
+  }
+
+  static Map<String, List<TextEdit>> rename(
+    @NotNull LibrarySource source,
+    @NotNull Position position,
+    @NotNull String newName,
+    @NotNull SeqView<LibraryOwner> libraries
+  ) {
+    var defs = GotoDefinition.findDefs(source, position, libraries);
+    var refs = FindReferences.findRefs(source, position, libraries)
+      .map(ref -> new WithPos<>(SourcePos.NONE, ref.sourcePos()));
+
+    return defs.concat(refs)
+      .flatMap(pos -> {
+        var to = pos.data();
+        var edit = new TextEdit(LspRange.toRange(to), newName);
+        return to.file().underlying().map(uri -> Tuple.of(uri, edit));
+      }).collect(Collectors.groupingBy(tup -> tup._1.toUri().toString(), Collectors.mapping(
+        tup -> tup._2,
+        Collectors.toList()
+      )));
+  }
+}

--- a/lsp/src/main/java/org/aya/lsp/actions/SyntaxHighlight.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/SyntaxHighlight.java
@@ -129,12 +129,12 @@ public final class SyntaxHighlight implements StmtConsumer<@NotNull DynamicSeq<H
   // region import, open, module
 
   @Override public Unit visitImport(Command.@NotNull Import cmd, @NotNull DynamicSeq<HighlightResult.Symbol> buffer) {
-    buffer.append(new HighlightResult.Symbol(LspRange.toRange(cmd.sourcePos()), HighlightResult.Symbol.Kind.ModuleDef));
+    buffer.append(new HighlightResult.Symbol(LspRange.toRange(cmd.path().sourcePos()), HighlightResult.Symbol.Kind.ModuleDef));
     return StmtConsumer.super.visitImport(cmd, buffer);
   }
 
   @Override public Unit visitOpen(Command.@NotNull Open cmd, @NotNull DynamicSeq<HighlightResult.Symbol> buffer) {
-    buffer.append(new HighlightResult.Symbol(LspRange.toRange(cmd.sourcePos()), HighlightResult.Symbol.Kind.ModuleDef));
+    buffer.append(new HighlightResult.Symbol(LspRange.toRange(cmd.path().sourcePos()), HighlightResult.Symbol.Kind.ModuleDef));
     return StmtConsumer.super.visitOpen(cmd, buffer);
   }
 

--- a/lsp/src/main/java/org/aya/lsp/server/AyaServer.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaServer.java
@@ -56,6 +56,7 @@ public class AyaServer implements LanguageClientAware, LanguageServer {
       cap.setWorkspace(workCap);
       cap.setHoverProvider(true);
       cap.setReferencesProvider(true);
+      cap.setRenameProvider(new RenameOptions(true));
 
       var folders = params.getWorkspaceFolders();
       // In case we open a single file, this value will be null, so be careful.

--- a/lsp/src/main/java/org/aya/lsp/server/AyaServer.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaServer.java
@@ -57,6 +57,7 @@ public class AyaServer implements LanguageClientAware, LanguageServer {
       cap.setHoverProvider(true);
       cap.setReferencesProvider(true);
       cap.setRenameProvider(new RenameOptions(true));
+      cap.setDocumentHighlightProvider(true);
 
       var folders = params.getWorkspaceFolders();
       // In case we open a single file, this value will be null, so be careful.

--- a/lsp/src/main/java/org/aya/lsp/server/AyaService.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaService.java
@@ -289,6 +289,25 @@ public class AyaService implements WorkspaceService, TextDocumentService {
     });
   }
 
+  @Override public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
+    return CompletableFuture.supplyAsync(() -> {
+      var source = find(params.getTextDocument().getUri());
+      if (source == null) return null;
+      var renames = Rename.rename(source, params.getPosition(), params.getNewName(), libraries.view());
+      return new WorkspaceEdit(renames);
+    });
+  }
+
+  @Override public CompletableFuture<Either<Range, PrepareRenameResult>> prepareRename(PrepareRenameParams params) {
+    return CompletableFuture.supplyAsync(() -> {
+      var source = find(params.getTextDocument().getUri());
+      if (source == null) return null;
+      var begin = Rename.prepare(source, params.getPosition());
+      if (begin == null) return null;
+      return Either.forRight(new PrepareRenameResult(LspRange.toRange(begin.sourcePos()), begin.data()));
+    });
+  }
+
   public ComputeTermResult computeTerm(@NotNull ComputeTermResult.Params input, ComputeTerm.Kind type) {
     var source = find(input.uri);
     if (source == null) return ComputeTermResult.bad(input);

--- a/lsp/src/main/java/org/aya/lsp/server/AyaService.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaService.java
@@ -264,17 +264,17 @@ public class AyaService implements WorkspaceService, TextDocumentService {
   @Override
   public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> definition(DefinitionParams params) {
     return CompletableFuture.supplyAsync(() -> {
-      var loadedFile = find(params.getTextDocument().getUri());
-      if (loadedFile == null) return Either.forLeft(Collections.emptyList());
-      return Either.forRight(GotoDefinition.invoke(loadedFile, params.getPosition(), libraries.view()));
+      var source = find(params.getTextDocument().getUri());
+      if (source == null) return Either.forLeft(Collections.emptyList());
+      return Either.forRight(GotoDefinition.invoke(source, params.getPosition(), libraries.view()));
     });
   }
 
   @Override public CompletableFuture<Hover> hover(HoverParams params) {
     return CompletableFuture.supplyAsync(() -> {
-      var loadedFile = find(params.getTextDocument().getUri());
-      if (loadedFile == null) return null;
-      var doc = ComputeSignature.invokeHover(loadedFile, params.getPosition());
+      var source = find(params.getTextDocument().getUri());
+      if (source == null) return null;
+      var doc = ComputeSignature.invokeHover(source, params.getPosition());
       if (doc.isEmpty()) return null;
       return new Hover(new MarkupContent(MarkupKind.PLAINTEXT, doc.debugRender()));
     });
@@ -283,16 +283,16 @@ public class AyaService implements WorkspaceService, TextDocumentService {
   @Override
   public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
     return CompletableFuture.supplyAsync(() -> {
-      var loadedFile = find(params.getTextDocument().getUri());
-      if (loadedFile == null) return Collections.emptyList();
-      return FindReferences.invoke(loadedFile, params.getPosition(), libraries.view());
+      var source = find(params.getTextDocument().getUri());
+      if (source == null) return Collections.emptyList();
+      return FindReferences.invoke(source, params.getPosition(), libraries.view());
     });
   }
 
   public ComputeTermResult computeTerm(@NotNull ComputeTermResult.Params input, ComputeTerm.Kind type) {
-    var loadedFile = find(input.uri);
-    if (loadedFile == null) return ComputeTermResult.bad(input);
-    return new ComputeTerm(loadedFile, type).invoke(input);
+    var source = find(input.uri);
+    if (source == null) return ComputeTermResult.bad(input);
+    return new ComputeTerm(source, type).invoke(input);
   }
 
   public record InlineHintProblem(@NotNull Problem owner, WithPos<Doc> docWithPos) implements Problem {

--- a/lsp/src/main/java/org/aya/lsp/server/AyaService.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaService.java
@@ -266,7 +266,7 @@ public class AyaService implements WorkspaceService, TextDocumentService {
     return CompletableFuture.supplyAsync(() -> {
       var loadedFile = find(params.getTextDocument().getUri());
       if (loadedFile == null) return Either.forLeft(Collections.emptyList());
-      return Either.forRight(GotoDefinition.invoke(loadedFile, params.getPosition()));
+      return Either.forRight(GotoDefinition.invoke(loadedFile, params.getPosition(), libraries.view()));
     });
   }
 

--- a/lsp/src/main/java/org/aya/lsp/utils/ModuleVar.java
+++ b/lsp/src/main/java/org/aya/lsp/utils/ModuleVar.java
@@ -1,0 +1,14 @@
+// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.lsp.utils;
+
+import org.aya.api.ref.Var;
+import org.aya.concrete.stmt.QualifiedID;
+import org.jetbrains.annotations.NotNull;
+
+/** Modules are not variables. This is only used in LSP for convenience */
+public record ModuleVar(@NotNull QualifiedID path) implements Var {
+  @Override public @NotNull String name() {
+    return path.join();
+  }
+}

--- a/lsp/src/main/java/org/aya/lsp/utils/Resolver.java
+++ b/lsp/src/main/java/org/aya/lsp/utils/Resolver.java
@@ -112,6 +112,16 @@ public interface Resolver {
       StmtConsumer.super.visitDecl(decl, xy);
     }
 
+    @Override public Unit visitCtor(@NotNull Decl.DataCtor ctor, XY xy) {
+      check(xy, ctor.sourcePos(), ctor.ref());
+      return StmtConsumer.super.visitCtor(ctor, xy);
+    }
+
+    @Override public Unit visitField(@NotNull Decl.StructField field, XY xy) {
+      check(xy, field.sourcePos(), field.ref());
+      return StmtConsumer.super.visitField(field, xy);
+    }
+
     @Override public @NotNull Unit visitRef(@NotNull Expr.RefExpr expr, XY xy) {
       check(xy, expr.sourcePos(), expr.resolvedVar());
       return Unit.unit();
@@ -133,6 +143,7 @@ public interface Resolver {
         }
         case Pattern.Tuple tup -> tup.patterns().forEach(p -> visitPattern(p, xy));
         case Pattern.BinOpSeq seq -> seq.seq().forEach(p -> visitPattern(p, xy));
+        case Pattern.Bind bind -> check(xy, bind.sourcePos(), bind.bind());
         default -> {}
       }
     }


### PR DESCRIPTION
This PR improved existing features:
- Binding emission logic for better hover messages
- Find references in pattern matchings and projections
- Position resolver now correctly finds all `Var`s (we cannot resolve ctors, fields and local telescopes if the cursor was placed at the name part of their definitions before)

and introduced new features:
- Rename a symbol
- Highlight all occurrences of a text by scoping rule (instead of string comparison!!)
- Goto definition for import commands (close #291)

and generalized some tools for future IDE development:
- The `Resolver` class which handles concrete term interactions (all features mentioned above heavily depend on this _busybox_)
- The `ModuleVar` for expanding the definition-based mechanism to modules (like goto module, rename module, etc.)