### PR TITLE
Fix a critical bug of SccTycker

### DIFF
--- a/api/src/main/java/org/aya/api/error/CollectingReporter.java
+++ b/api/src/main/java/org/aya/api/error/CollectingReporter.java
@@ -15,12 +15,4 @@ public interface CollectingReporter extends CountingReporter {
   @Override default void clear() {
     problems().clear();
   }
-
-  default boolean anyError() {
-    return errorSize() > 0;
-  }
-
-  default boolean anyProblem() {
-    return problems().isNotEmpty();
-  }
 }

--- a/api/src/main/java/org/aya/api/error/CountingReporter.java
+++ b/api/src/main/java/org/aya/api/error/CountingReporter.java
@@ -23,6 +23,10 @@ public interface CountingReporter extends Reporter {
     return errorSize() == 0;
   }
 
+  default boolean anyError() {
+    return !noError();
+  }
+
   default @NotNull String countToString() {
     return String.format("%d error(s), %d warning(s).", errorSize(), warningSize());
   }

--- a/api/src/main/java/org/aya/api/ref/DefVar.java
+++ b/api/src/main/java/org/aya/api/ref/DefVar.java
@@ -8,6 +8,7 @@ import org.aya.api.core.CoreDef;
 import org.aya.util.binop.OpDecl;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 
 /**
@@ -19,9 +20,10 @@ public final class DefVar<Core extends CoreDef, Concrete extends ConcreteDecl> i
   /** Initialized in type checking or core deserialization, so it might be null for unchecked user definitions. */
   public @UnknownNullability Core core;
   /** Initialized in the resolver or core deserialization */
-  public @UnknownNullability ImmutableSeq<String> module;
+  public @Nullable ImmutableSeq<String> module;
+  /** Initialized in the resolver or core deserialization */
+  public @Nullable OpDecl opDecl;
   private final @NotNull String name;
-  public @UnknownNullability OpDecl opDecl;
 
   @Contract(pure = true) public boolean isInfix() {
     return opDecl != null && opDecl.opInfo() != null;

--- a/base/src/main/java/org/aya/core/serde/CompiledAya.java
+++ b/base/src/main/java/org/aya/core/serde/CompiledAya.java
@@ -153,6 +153,7 @@ public record CompiledAya(
     serOps.view().forEach(serOp -> {
       var defVar = state.resolve(serOp.name());
       var opDecl = defVar.opDecl;
+      assert opDecl != null; // just initialized above
       var bind = serOp.bind();
       opSet.ensureHasElem(opDecl);
       bind.loosers().forEach(looser -> {

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -247,6 +247,7 @@ public record Serializer(@NotNull Serializer.State state) implements
   }
 
   @Override public SerDef visitPrim(@NotNull PrimDef def, Unit unit) {
+    assert def.ref.module != null;
     return new SerDef.Prim(def.ref.module, def.id);
   }
 }

--- a/base/src/main/java/org/aya/resolve/module/ModuleLoader.java
+++ b/base/src/main/java/org/aya/resolve/module/ModuleLoader.java
@@ -31,11 +31,11 @@ public interface ModuleLoader {
 
   default <E extends Exception> @NotNull ResolveInfo
   tyckModule(Trace.Builder builder, ResolveInfo resolveInfo, ModuleCallback<E> onTycked) throws E {
+    var SCCs = resolveInfo.depGraph().topologicalOrder();
     var delayedReporter = new DelayedReporter(reporter());
-    var sccTycker = new AyaOrgaTycker(new AyaSccTycker(resolveInfo, builder, delayedReporter), resolveInfo);
+    var sccTycker = new AyaOrgaTycker(AyaSccTycker.create(resolveInfo, builder, delayedReporter), resolveInfo);
     // in case we have un-messaged TyckException
     try (delayedReporter) {
-      var SCCs = resolveInfo.depGraph().topologicalOrder();
       SCCs.forEach(sccTycker::tyckSCC);
     } finally {
       if (onTycked != null) onTycked.onModuleTycked(

--- a/cli/src/main/java/org/aya/cli/library/LibraryCompiler.java
+++ b/cli/src/main/java/org/aya/cli/library/LibraryCompiler.java
@@ -210,13 +210,13 @@ public class LibraryCompiler {
       var reporter = CountingReporter.delegate(outerReporter);
       for (var f : order) Files.deleteIfExists(f.coreFile());
       for (var f : order) {
-        tyckOne(reporter, f);
-        if (!reporter.noError()) return ImmutableSeq.of(f);
+        tyckOne(f);
+        if (reporter.anyError()) return ImmutableSeq.of(f);
       }
       return ImmutableSeq.empty();
     }
 
-    private void tyckOne(CountingReporter reporter, LibrarySource file) {
+    private void tyckOne(@NotNull LibrarySource file) {
       var moduleName = file.moduleName();
       var mod = moduleLoader.load(moduleName);
       if (mod == null || file.resolveInfo().value == null)

--- a/lsp/src/main/java/org/aya/lsp/actions/SyntaxHighlight.java
+++ b/lsp/src/main/java/org/aya/lsp/actions/SyntaxHighlight.java
@@ -96,18 +96,8 @@ public final class SyntaxHighlight implements StmtConsumer<@NotNull DynamicSeq<H
   }
 
   private void visitCall(@NotNull DefVar<?, ?> ref, @NotNull SourcePos headPos, @NotNull DynamicSeq<HighlightResult.Symbol> buffer) {
-    if (ref.core instanceof FnDef || ref.concrete instanceof Decl.FnDecl)
-      buffer.append(new HighlightResult.Symbol(LspRange.toRange(headPos), HighlightResult.Symbol.Kind.FnCall));
-    else if (ref.core instanceof PrimDef || ref.concrete instanceof Decl.PrimDecl)
-      buffer.append(new HighlightResult.Symbol(LspRange.toRange(headPos), HighlightResult.Symbol.Kind.PrimCall));
-    else if (ref.core instanceof DataDef || ref.concrete instanceof Decl.DataDecl)
-      buffer.append(new HighlightResult.Symbol(LspRange.toRange(headPos), HighlightResult.Symbol.Kind.DataCall));
-    else if (ref.core instanceof CtorDef || ref.concrete instanceof Decl.DataCtor)
-      buffer.append(new HighlightResult.Symbol(LspRange.toRange(headPos), HighlightResult.Symbol.Kind.ConCall));
-    else if (ref.core instanceof StructDef || ref.concrete instanceof Decl.StructDecl)
-      buffer.append(new HighlightResult.Symbol(LspRange.toRange(headPos), HighlightResult.Symbol.Kind.StructCall));
-    else if (ref.core instanceof FieldDef || ref.concrete instanceof Decl.StructField)
-      buffer.append(new HighlightResult.Symbol(LspRange.toRange(headPos), HighlightResult.Symbol.Kind.FieldCall));
+    var kind = kindOf(ref);
+    if (kind != null) buffer.append(new HighlightResult.Symbol(LspRange.toRange(headPos), kind));
   }
 
   // endregion


### PR DESCRIPTION
- Fixed not clearing reporter countings when one definition failed to tyck (which causes all coming definitions to be treated as failed)
- Search both core and concrete term when highlighting
- Skip `DefVar`s from skipped modules and libraries