### PR TITLE
Call `needTyck` with current module name

### DIFF
--- a/api/src/main/java/org/aya/api/ref/DefVar.java
+++ b/api/src/main/java/org/aya/api/ref/DefVar.java
@@ -54,4 +54,11 @@ public final class DefVar<Core extends CoreDef, Concrete extends ConcreteDecl> i
   @Override public boolean equals(Object o) {
     return this == o;
   }
+
+  public boolean isInModule(@NotNull ImmutableSeq<String> moduleName) {
+    var maybeSubmodule = module;
+    if (maybeSubmodule == null) return false;
+    if (maybeSubmodule.sizeLessThan(moduleName.size())) return false;
+    return maybeSubmodule.slice(0, moduleName.size()).equals(moduleName);
+  }
 }

--- a/api/src/main/java/org/aya/api/ref/DefVar.java
+++ b/api/src/main/java/org/aya/api/ref/DefVar.java
@@ -59,6 +59,6 @@ public final class DefVar<Core extends CoreDef, Concrete extends ConcreteDecl> i
     var maybeSubmodule = module;
     if (maybeSubmodule == null) return false;
     if (maybeSubmodule.sizeLessThan(moduleName.size())) return false;
-    return maybeSubmodule.slice(0, moduleName.size()).equals(moduleName);
+    return maybeSubmodule.sliceView(0, moduleName.size()).sameElements(moduleName);
   }
 }

--- a/base/src/main/java/org/aya/concrete/remark/Remark.java
+++ b/base/src/main/java/org/aya/concrete/remark/Remark.java
@@ -99,7 +99,7 @@ public final class Remark implements Stmt {
   }
 
   /** It's always downstream (cannot be imported), so always need to be checked. */
-  @Override public boolean needTyck() {
+  @Override public boolean needTyck(@NotNull ImmutableSeq<String> currentMod) {
     return true;
   }
 }

--- a/base/src/main/java/org/aya/concrete/stmt/Command.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Command.java
@@ -8,8 +8,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public sealed interface Command extends Stmt {
-  @Override default boolean needTyck() {
-    return true;
+  @Override default boolean needTyck(@NotNull ImmutableSeq<String> currentMod) {
+    // commands are desugared in the shallow resolver
+    return false;
   }
 
   /**

--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -113,8 +113,8 @@ public sealed abstract class Decl extends Signatured implements Stmt, ConcreteDe
       this.ref = DefVar.concrete(this, name);
     }
 
-    @Override public boolean needTyck() {
-      return ref.concrete.signature == null;
+    @Override public boolean needTyck(@NotNull ImmutableSeq<String> currentMod) {
+      return ref.isInModule(currentMod) && ref.concrete.signature == null;
     }
 
     @Override public @NotNull DefVar<PrimDef, PrimDecl> ref() {

--- a/base/src/main/java/org/aya/concrete/stmt/Generalize.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Generalize.java
@@ -18,7 +18,8 @@ public sealed interface Generalize extends Stmt {
     return Accessibility.Private;
   }
 
-  @Override default boolean needTyck() {
+  @Override default boolean needTyck(@NotNull ImmutableSeq<String> currentMod) {
+    // commands are desugared in the shallow resolver
     return false;
   }
 

--- a/base/src/main/java/org/aya/concrete/stmt/Sample.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Sample.java
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.stmt;
 
+import kala.collection.immutable.ImmutableSeq;
 import org.aya.api.error.BufferReporter;
 import org.aya.core.def.Def;
 import org.aya.core.def.UserDef;
@@ -15,8 +16,8 @@ import org.jetbrains.annotations.Nullable;
 public sealed interface Sample extends Stmt {
   @NotNull Stmt delegate();
 
-  @Override default boolean needTyck() {
-    return delegate().needTyck();
+  @Override default boolean needTyck(@NotNull ImmutableSeq<String> currentMod) {
+    return delegate().needTyck(currentMod);
   }
 
   /** @return <code>null</code> if the delegate is a command (not a definition) */

--- a/base/src/main/java/org/aya/concrete/stmt/Signatured.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Signatured.java
@@ -49,7 +49,7 @@ public sealed abstract class Signatured implements ConcreteDecl, OpDecl, TyckUni
     return opInfo;
   }
 
-  @Override public boolean needTyck() {
-    return ref().core == null;
+  @Override public boolean needTyck(@NotNull ImmutableSeq<String> currentMod) {
+    return ref().isInModule(currentMod) && ref().core == null;
   }
 }

--- a/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
@@ -94,7 +94,7 @@ public interface StmtResolver {
 
   private static void addReferences(@NotNull ResolveInfo info, TyckUnit decl, ExprResolver resolver) {
     info.depGraph().sucMut(decl).appendAll(resolver.reference().view()
-      .filter(TyckUnit::needTyck));
+      .filter(unit -> unit.needTyck(info.thisModule().moduleName())));
   }
 
   private static @NotNull Tuple2<ExprResolver, Context>

--- a/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
@@ -140,7 +140,8 @@ public record AyaSccTycker(
     stmts.forEach(stmt -> {
       var reference = DynamicSeq.<TyckUnit>create();
       SigRefFinder.HEADER_ONLY.visit(stmt, reference);
-      graph.sucMut(stmt).appendAll(reference.view().filter(TyckUnit::needTyck));
+      graph.sucMut(stmt).appendAll(reference.view()
+        .filter(unit -> unit.needTyck(resolveInfo.thisModule().moduleName())));
     });
     var order = graph.topologicalOrder();
     var cycle = order.view().filter(s -> s.sizeGreaterThan(1));

--- a/base/src/main/java/org/aya/tyck/order/TyckUnit.java
+++ b/base/src/main/java/org/aya/tyck/order/TyckUnit.java
@@ -2,12 +2,14 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck.order;
 
+import kala.collection.immutable.ImmutableSeq;
 import org.aya.concrete.stmt.Signatured;
 import org.aya.concrete.stmt.Stmt;
 import org.aya.util.error.SourceNode;
+import org.jetbrains.annotations.NotNull;
 
 public sealed interface TyckUnit
   extends SourceNode
   permits Stmt, Signatured {
-  boolean needTyck();
+  boolean needTyck(@NotNull ImmutableSeq<String> currentMod);
 }

--- a/base/src/test/resources/success/common/src/Refparo/Model.aya
+++ b/base/src/test/resources/success/common/src/Refparo/Model.aya
@@ -2,6 +2,9 @@ open import Paths
 
 public open data Unit | unit
 
+def coe {a b : Type} (eq : a = b) (x : a) (i : I) : eq.at i
+  => arcoe eq.at x i
+
 -- *** Types
 
 universe u
@@ -62,7 +65,7 @@ def mkTheta
   (T-inv : Pi (A : Type u) (T : EventT) -> A = getT (setT A T))
   : Theta setT
   => \{A} => \q => \{T} => \p => \f => q (\x => p (\e =>
-    Sig (get (setT A T) e = transport (\A => A) (T-inv A T) x) ** (f e)))
+    Sig (get (setT A T) e = coe (T-inv A T) x right) ** (f e)))
 
 def agent : Theta setAgentT
   => \{A} => mkTheta getAgentT getAgent setAgentT AgentT-inv {A}


### PR DESCRIPTION
Check `needTyck` with current module name so imported definitions won't pollute `CompiledAya`