### PR TITLE
Remove reporter from library owner

### DIFF
--- a/cli/src/main/java/org/aya/cli/library/LibraryModuleLoader.java
+++ b/cli/src/main/java/org/aya/cli/library/LibraryModuleLoader.java
@@ -42,13 +42,10 @@ import java.nio.file.Path;
  * @see FileModuleLoader
  */
 record LibraryModuleLoader(
+  @NotNull CountingReporter reporter,
   @NotNull LibraryOwner owner,
   @NotNull LibraryModuleLoader.United states
 ) implements ModuleLoader {
-  @Override public @NotNull CountingReporter reporter() {
-    return owner.reporter();
-  }
-
   private void saveCompiledCore(@NotNull LibrarySource file, @NotNull ResolveInfo resolveInfo, @NotNull ImmutableSeq<Def> defs) {
     try {
       var coreFile = file.coreFile();

--- a/cli/src/main/java/org/aya/cli/library/source/LibraryOwner.java
+++ b/cli/src/main/java/org/aya/cli/library/source/LibraryOwner.java
@@ -4,7 +4,6 @@ package org.aya.cli.library.source;
 
 import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableSeq;
-import org.aya.api.error.CountingReporter;
 import org.aya.api.error.SourceFileLocator;
 import org.aya.cli.library.json.LibraryConfig;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +24,6 @@ public interface LibraryOwner {
   @NotNull SeqView<Path> modulePath();
   @NotNull SeqView<LibrarySource> librarySources();
   @NotNull SeqView<LibraryOwner> libraryDeps();
-  @NotNull CountingReporter reporter();
   @NotNull SourceFileLocator locator();
   @NotNull LibraryConfig underlyingLibrary();
 

--- a/lsp/src/main/java/org/aya/lsp/library/WsLibrary.java
+++ b/lsp/src/main/java/org/aya/lsp/library/WsLibrary.java
@@ -5,8 +5,6 @@ package org.aya.lsp.library;
 import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.DynamicSeq;
-import org.aya.api.error.CountingReporter;
-import org.aya.api.error.Reporter;
 import org.aya.api.error.SourceFileLocator;
 import org.aya.cli.library.json.LibraryConfig;
 import org.aya.cli.library.source.LibraryOwner;
@@ -22,18 +20,16 @@ import java.nio.file.Path;
  * @author kiva
  */
 public record WsLibrary(
-  @NotNull CountingReporter reporter,
   @NotNull SourceFileLocator locator,
   @NotNull DynamicSeq<LibrarySource> sources,
   @NotNull LibraryConfig mockConfig,
   @NotNull Path workspace
 ) implements LibraryOwner {
-  public static @NotNull WsLibrary mock(@NotNull Reporter outReporter, @NotNull Path ayaSource) {
+  public static @NotNull WsLibrary mock(@NotNull Path ayaSource) {
     var parent = ayaSource.getParent();
-    var reporter = CountingReporter.of(outReporter);
     var mockConfig = mockConfig(parent);
     var locator = new SourceFileLocator.Module(SeqView.of(parent));
-    var owner = new WsLibrary(reporter, locator, DynamicSeq.create(), mockConfig, parent);
+    var owner = new WsLibrary(locator, DynamicSeq.create(), mockConfig, parent);
     owner.sources.append(new LibrarySource(owner, ayaSource));
     return owner;
   }

--- a/lsp/src/main/java/org/aya/lsp/server/AyaService.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaService.java
@@ -64,7 +64,7 @@ public class AyaService implements WorkspaceService, TextDocumentService {
     if (!Files.exists(ayaJson)) return tryAyaLibrary(path.getParent());
     try {
       var config = LibraryConfigData.fromLibraryRoot(path);
-      var owner = DiskLibraryOwner.from(reporter, config);
+      var owner = DiskLibraryOwner.from(config);
       libraries.append(owner);
     } catch (IOException e) {
       var s = new StringWriter();
@@ -77,7 +77,7 @@ public class AyaService implements WorkspaceService, TextDocumentService {
 
   private void mockLibraries(@NotNull Path path) {
     libraries.appendAll(FileUtil.collectSource(path, Constants.AYA_POSTFIX, 1).map(
-      aya -> WsLibrary.mock(reporter, FileUtil.canonicalize(aya))));
+      aya -> WsLibrary.mock(FileUtil.canonicalize(aya))));
   }
 
   private @Nullable LibraryOwner findOwner(@Nullable Path path) {
@@ -135,7 +135,7 @@ public class AyaService implements WorkspaceService, TextDocumentService {
       CompilerFlags.Message.EMOJI, false, true, null,
       SeqView.empty(), null);
     try {
-      LibraryCompiler.newCompiler(flags, owner).start();
+      LibraryCompiler.newCompiler(reporter, flags, owner).start();
     } catch (IOException e) {
       var s = new StringWriter();
       e.printStackTrace(new PrintWriter(s));
@@ -221,7 +221,7 @@ public class AyaService implements WorkspaceService, TextDocumentService {
               ownerMut.addLibrarySource(newSrc);
             }
             case null -> {
-              var mock = WsLibrary.mock(reporter, newSrc);
+              var mock = WsLibrary.mock(newSrc);
               Log.d("Created new file: %s, mocked a library %s for it", newSrc, mock.mockConfig().name());
               libraries.append(mock);
             }


### PR DESCRIPTION
When debugging #312 I found the reporter in library owner was not used and caused the compiler to skip writing core files for modules followed. It turns out some changes have been made to make the delayed reporter in the library compiler not working, which is mostly due to my careless reviewing of https://github.com/aya-prover/aya-dev/commit/b10d16ad26d5197836d992af378be0b4bdce2c71 which implicitly breaks the fixture in https://github.com/aya-prover/aya-dev/commit/c7b3ade253bff180ad2daf059e54f6c1a4e65add

hit hit kiva