### PR TITLE
Allow empty `new` block

### DIFF
--- a/base/src/test/resources/success/src/Structs.aya
+++ b/base/src/test/resources/success/src/Structs.aya
@@ -18,3 +18,7 @@ struct Pos1 (A : Type) : Type
 struct Pos2 (B : Nat -> Type) : Type
   | x : Nat
   | y : B zero
+
+struct EmptyRecord : Type
+def new-empty1 => new EmptyRecord
+def new-empty2 => new EmptyRecord {}

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -84,18 +84,19 @@ dataCtor : COERCE? declNameOrInfix tele* clauses? bindBlock?;
 dataCtorClause : BAR patterns IMPLIES dataCtor;
 
 // expressions
-expr : atom                            # single
-     | expr argument+                  # app
-     | NEW_KW expr LBRACE newArg* RBRACE # new
-     | <assoc=right> expr TO expr      # arr
-     | expr projFix                    # proj
-     | LSUC_KW atom                    # lsuc
-     | LMAX_KW atom+                   # lmax
-     | PI tele+ TO expr                # pi
-     | FORALL tele+ TO expr            # forall
-     | SIGMA tele+ SUCHTHAT expr       # sigma
-     | LAMBDA tele+ (IMPLIES expr?)?   # lam
-     | MATCH exprList clauses          # match
+expr : atom                                 # single
+     | expr argument+                       # app
+     | NEW_KW expr LBRACE newArg* RBRACE    # new
+     | NEW_KW expr                          # newEmpty
+     | <assoc=right> expr TO expr           # arr
+     | expr projFix                         # proj
+     | LSUC_KW atom                         # lsuc
+     | LMAX_KW atom+                        # lmax
+     | PI tele+ TO expr                     # pi
+     | FORALL tele+ TO expr                 # forall
+     | SIGMA tele+ SUCHTHAT expr            # sigma
+     | LAMBDA tele+ (IMPLIES expr?)?        # lam
+     | MATCH exprList clauses               # match
      ;
 
 newArg : BAR ID ids IMPLIES expr;

--- a/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
@@ -333,6 +333,7 @@ public record AyaProducer(
       case AyaParser.LamContext lam -> visitLam(lam);
       case AyaParser.ArrContext arr -> visitArr(arr);
       case AyaParser.NewContext n -> visitNew(n);
+      case AyaParser.NewEmptyContext n -> visitNewEmpty(n);
       case AyaParser.LsucContext lsuc -> visitLsuc(lsuc);
       case AyaParser.LmaxContext lmax -> visitLmax(lmax);
       case AyaParser.ForallContext forall -> visitForall(forall);
@@ -358,6 +359,13 @@ public record AyaProducer(
           .map(t -> new WithPos<>(t.sourcePos(), LocalVar.from(t)))
           .collect(ImmutableSeq.factory()), visitExpr(na.expr())))
     );
+  }
+
+  public @NotNull Expr visitNewEmpty(AyaParser.NewEmptyContext ctx) {
+    return new Expr.NewExpr(
+      sourcePosOf(ctx),
+      visitExpr(ctx.expr()),
+      ImmutableSeq.empty());
   }
 
   public @NotNull Expr visitArr(AyaParser.ArrContext ctx) {


### PR DESCRIPTION
This PR fixes #168 

### Details
Added a new rule of expr
```diff
 expr : atom                                 # single
      | expr argument+                       # app
      | NEW_KW expr LBRACE newArg* RBRACE    # new
+     | NEW_KW expr                          # newEmpty
```

rather than simply make the block part optional like this

```diff
 expr : atom                                 # single
      | expr argument+                       # app
-     | NEW_KW expr LBRACE newArg* RBRACE    # new
+     | NEW_KW expr (LBRACE newArg* RBRACE)? # new

```

This is because in the latter change for given code `new T {}` the antlr always matches the `{}` with the `expr` and treats the following as optional because there's a `{ exprList }` in `argument`. 

And we should allow both `new T` and `new T {}` for empty records for better error messages for the same reason (which is mostly due to antlr's lack of ability to pass parameters to subrules).
