### PR TITLE
TACTIC: phase 1 plan complete

### DIFF
--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -82,6 +82,7 @@ public sealed interface Expr extends AyaDocile, SourceNode {
     R visitBinOpSeq(@NotNull BinOpSeq binOpSeq, P p);
     R visitError(@NotNull ErrorExpr error, P p);
     R visitMetaPat(@NotNull MetaPat metaPat, P p);
+    R visitTac(@NotNull TacExpr tactic, P p);
   }
 
   sealed interface WithTerm extends Expr {
@@ -337,6 +338,19 @@ public sealed interface Expr extends AyaDocile, SourceNode {
       return visitor.visitMetaPat(this, p);
     }
   }
+
+  record TacExpr(@NotNull SourcePos sourcePos, @NotNull TacNode tacNode) implements Expr {
+    @Override public <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p) {
+      return visitor.visitTac(this, p);
+    }
+  }
+
+  sealed interface TacNode {}
+
+  record ExprTac(@NotNull SourcePos sourcePos, @NotNull Expr expr) implements TacNode {}
+
+  record ListExprTac(@NotNull SourcePos sourcePos, @NotNull ImmutableSeq<TacNode> tacNodes) implements TacNode {}
+
 
   /**
    * @author kiva

--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -345,7 +345,11 @@ public sealed interface Expr extends AyaDocile, SourceNode {
     }
   }
 
-  sealed interface TacNode {}
+  sealed interface TacNode extends AyaDocile {
+    @Override default @NotNull Doc toDoc(@NotNull DistillerOptions options) {
+      return new ConcreteDistiller(options).tacNode(this);
+    }
+  }
 
   record ExprTac(@NotNull SourcePos sourcePos, @NotNull Expr expr) implements TacNode {}
 

--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -349,11 +349,11 @@ public sealed interface Expr extends AyaDocile, SourceNode {
     @Override default @NotNull Doc toDoc(@NotNull DistillerOptions options) {
       return new ConcreteDistiller(options).tacNode(this);
     }
+
+    record ExprTac(@NotNull SourcePos sourcePos, @NotNull Expr expr) implements TacNode {}
+
+    record ListExprTac(@NotNull SourcePos sourcePos, @NotNull ImmutableSeq<TacNode> tacNodes) implements TacNode {}
   }
-
-  record ExprTac(@NotNull SourcePos sourcePos, @NotNull Expr expr) implements TacNode {}
-
-  record ListExprTac(@NotNull SourcePos sourcePos, @NotNull ImmutableSeq<TacNode> tacNodes) implements TacNode {}
 
 
   /**

--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -345,17 +345,6 @@ public sealed interface Expr extends AyaDocile, SourceNode {
     }
   }
 
-  sealed interface TacNode extends AyaDocile {
-    @Override default @NotNull Doc toDoc(@NotNull DistillerOptions options) {
-      return new ConcreteDistiller(options).tacNode(this);
-    }
-
-    record ExprTac(@NotNull SourcePos sourcePos, @NotNull Expr expr) implements TacNode {}
-
-    record ListExprTac(@NotNull SourcePos sourcePos, @NotNull ImmutableSeq<TacNode> tacNodes) implements TacNode {}
-  }
-
-
   /**
    * @author kiva
    */

--- a/base/src/main/java/org/aya/concrete/TacNode.java
+++ b/base/src/main/java/org/aya/concrete/TacNode.java
@@ -10,13 +10,16 @@ import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 
 sealed public interface TacNode extends AyaDocile {
-  record ExprTac(@NotNull SourcePos sourcePos, @NotNull Expr expr) implements TacNode {
+
+  @NotNull SourcePos sourcePos();
+
+  record ExprTac(@Override @NotNull SourcePos sourcePos, @NotNull Expr expr) implements TacNode {
     @Override public @NotNull Doc toDoc(@NotNull DistillerOptions options) {
       return Doc.sep(Doc.symbol("|"), expr.toDoc(options));
     }
   }
 
-  record ListExprTac(@NotNull SourcePos sourcePos, @NotNull ImmutableSeq<TacNode> tacNodes) implements TacNode {
+  record ListExprTac(@Override @NotNull SourcePos sourcePos, @NotNull ImmutableSeq<TacNode> tacNodes) implements TacNode {
     @Override public @NotNull Doc toDoc(@NotNull DistillerOptions options) {
       return Doc.cblock(Doc.empty(), 2, Doc.emptyIf(tacNodes.isEmpty(), () ->
         Doc.vcat(tacNodes.view().map(tacNode -> tacNode.toDoc(options)))));

--- a/base/src/main/java/org/aya/concrete/visitor/ExprConsumer.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprConsumer.java
@@ -5,6 +5,7 @@ package org.aya.concrete.visitor;
 import kala.collection.immutable.ImmutableSeq;
 import kala.tuple.Unit;
 import org.aya.concrete.Expr;
+import org.aya.concrete.TacNode;
 import org.jetbrains.annotations.NotNull;
 
 public interface ExprConsumer<P> extends Expr.Visitor<P, Unit> {
@@ -89,10 +90,10 @@ public interface ExprConsumer<P> extends Expr.Visitor<P, Unit> {
     return Unit.unit();
   }
 
-  default void visitTacNode(@NotNull Expr.TacNode node, P p) {
+  default void visitTacNode(@NotNull TacNode node, P p) {
     switch (node) {
-      case Expr.TacNode.ExprTac expr -> expr.expr().accept(this, p);
-      case Expr.TacNode.ListExprTac list -> list.tacNodes().forEach(n -> visitTacNode(n, p));
+      case TacNode.ExprTac expr -> expr.expr().accept(this, p);
+      case TacNode.ListExprTac list -> list.tacNodes().forEach(n -> visitTacNode(n, p));
     }
   }
 

--- a/base/src/main/java/org/aya/concrete/visitor/ExprConsumer.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprConsumer.java
@@ -91,8 +91,8 @@ public interface ExprConsumer<P> extends Expr.Visitor<P, Unit> {
 
   default void visitTacNode(@NotNull Expr.TacNode node, P p) {
     switch (node) {
-      case Expr.ExprTac expr -> expr.expr().accept(this, p);
-      case Expr.ListExprTac list -> list.tacNodes().forEach(n -> visitTacNode(n, p));
+      case Expr.TacNode.ExprTac expr -> expr.expr().accept(this, p);
+      case Expr.TacNode.ListExprTac list -> list.tacNodes().forEach(n -> visitTacNode(n, p));
     }
   }
 

--- a/base/src/main/java/org/aya/concrete/visitor/ExprConsumer.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprConsumer.java
@@ -89,6 +89,18 @@ public interface ExprConsumer<P> extends Expr.Visitor<P, Unit> {
     return Unit.unit();
   }
 
+  default void visitTacNode(@NotNull Expr.TacNode node, P p) {
+    switch (node) {
+      case Expr.ExprTac expr -> expr.expr().accept(this, p);
+      case Expr.ListExprTac list -> list.tacNodes().forEach(n -> visitTacNode(n, p));
+    }
+  }
+
+  @Override default Unit visitTac(Expr.@NotNull TacExpr tactic, P p) {
+    visitTacNode(tactic.tacNode(), p);
+    return Unit.unit();
+  }
+
   @Override default Unit visitLitString(Expr.@NotNull LitStringExpr expr, P p) {
     return Unit.unit();
   }

--- a/base/src/main/java/org/aya/concrete/visitor/ExprOps.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprOps.java
@@ -3,6 +3,9 @@
 package org.aya.concrete.visitor;
 
 import org.aya.concrete.Expr;
+import org.aya.generic.util.InternalException;
+import org.aya.pretty.doc.Doc;
+import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 
 public interface ExprOps extends ExprView {
@@ -17,5 +20,38 @@ public interface ExprOps extends ExprView {
 
   @Override default @NotNull Expr post(@NotNull Expr expr) {
     return view().post(expr);
+  }
+
+  class HoleFiller implements ExprOps {
+    final Expr placeHolder = new Expr.ErrorExpr(SourcePos.NONE, Doc.english("Internal Error for expr hole filler"));
+    boolean filled = false;
+    Expr filling = placeHolder;
+    Expr exprWithHole = placeHolder;
+
+    @Override public @NotNull ExprView view() {
+      return exprWithHole.view();
+    }
+
+    @Override public @NotNull Expr pre(@NotNull Expr expr) {
+      return switch (expr) {
+        case Expr.HoleExpr hole -> {
+          if (!filled) {
+            filled = true;
+            yield filling;
+          } else yield hole;
+        }
+        case Expr misc -> misc;
+      };
+    }
+
+    public @NotNull Expr fill(Expr exprWithHole, Expr filling) {
+      filled = false;
+      this.exprWithHole = exprWithHole;
+      this.filling = filling;
+      var filledExpr = commit();
+      if (!filled) throw new InternalException("Tactic elaborator cannot fill the hole of " + exprWithHole);
+
+      return filledExpr;
+    }
   }
 }

--- a/base/src/main/java/org/aya/concrete/visitor/ExprOps.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprOps.java
@@ -49,7 +49,7 @@ public interface ExprOps extends ExprView {
       this.exprWithHole = exprWithHole;
       this.filling = filling;
       var filledExpr = commit();
-      if (!filled) throw new InternalException("Tactic elaborator cannot fill the hole of " + exprWithHole);
+      if (!filled) throw new InternalException("No hole has been found in " + exprWithHole);
 
       return filledExpr;
     }

--- a/base/src/main/java/org/aya/concrete/visitor/ExprView.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprView.java
@@ -32,7 +32,7 @@ public interface ExprView {
   private Expr.@NotNull NamedArg commit(Expr.@NotNull NamedArg arg) {
     var expr = commit(arg.expr());
     if (expr == arg.expr()) return arg;
-    return new Expr.NamedArg(arg.explicit(), expr);
+    return new Expr.NamedArg(arg.explicit(), arg.name(), expr);
   }
 
   private @NotNull TacNode commit(@NotNull TacNode node) {

--- a/base/src/main/java/org/aya/concrete/visitor/ExprView.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprView.java
@@ -3,6 +3,7 @@
 package org.aya.concrete.visitor;
 
 import org.aya.concrete.Expr;
+import org.aya.concrete.TacNode;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -34,17 +35,17 @@ public interface ExprView {
     return new Expr.NamedArg(arg.explicit(), expr);
   }
 
-  private Expr.TacNode commit(Expr.TacNode node) {
+  private TacNode commit(TacNode node) {
     return switch (node) {
-      case Expr.TacNode.ExprTac exprTac -> {
+      case TacNode.ExprTac exprTac -> {
         var expr = commit(exprTac.expr());
         if (expr == exprTac.expr()) yield exprTac;
-        yield new Expr.TacNode.ExprTac(exprTac.sourcePos(), expr);
+        yield new TacNode.ExprTac(exprTac.sourcePos(), expr);
       }
-      case Expr.TacNode.ListExprTac listExprTac -> {
+      case TacNode.ListExprTac listExprTac -> {
         var tacNodes = listExprTac.tacNodes().map(this::commit);
         if (tacNodes.sameElements(listExprTac.tacNodes(), true)) yield listExprTac;
-        yield new Expr.TacNode.ListExprTac(listExprTac.sourcePos(), tacNodes);
+        yield new TacNode.ListExprTac(listExprTac.sourcePos(), tacNodes);
       }
     };
   }

--- a/base/src/main/java/org/aya/concrete/visitor/ExprView.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprView.java
@@ -36,15 +36,15 @@ public interface ExprView {
 
   private Expr.TacNode commit(Expr.TacNode node) {
     return switch (node) {
-      case Expr.ExprTac exprTac -> {
+      case Expr.TacNode.ExprTac exprTac -> {
         var expr = commit(exprTac.expr());
         if (expr == exprTac.expr()) yield exprTac;
-        yield new Expr.ExprTac(exprTac.sourcePos(), expr);
+        yield new Expr.TacNode.ExprTac(exprTac.sourcePos(), expr);
       }
-      case Expr.ListExprTac listExprTac -> {
+      case Expr.TacNode.ListExprTac listExprTac -> {
         var tacNodes = listExprTac.tacNodes().map(this::commit);
         if (tacNodes.sameElements(listExprTac.tacNodes(), true)) yield listExprTac;
-        yield new Expr.ListExprTac(listExprTac.sourcePos(), tacNodes);
+        yield new Expr.TacNode.ListExprTac(listExprTac.sourcePos(), tacNodes);
       }
     };
   }

--- a/base/src/main/java/org/aya/concrete/visitor/ExprView.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprView.java
@@ -110,6 +110,7 @@ public interface ExprView {
         if (node == tac.tacNode()) yield tac;
         yield new Expr.TacExpr(tac.sourcePos(), node);
       }
+      case null -> null;
     };
   }
 

--- a/base/src/main/java/org/aya/concrete/visitor/ExprView.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprView.java
@@ -35,7 +35,7 @@ public interface ExprView {
     return new Expr.NamedArg(arg.explicit(), expr);
   }
 
-  private TacNode commit(TacNode node) {
+  private @NotNull TacNode commit(@NotNull TacNode node) {
     return switch (node) {
       case TacNode.ExprTac exprTac -> {
         var expr = commit(exprTac.expr());
@@ -117,9 +117,8 @@ public interface ExprView {
         if (node == tac.tacNode()) yield tac;
         yield new Expr.TacExpr(tac.sourcePos(), node);
       }
-      case null -> null;
     };
   }
 
-  default @NotNull Expr commit() {return lastly(commit(initial()));}
+  default @NotNull Expr commit() { return lastly(commit(initial())); }
 }

--- a/base/src/main/java/org/aya/concrete/visitor/ExprView.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprView.java
@@ -18,7 +18,9 @@ public interface ExprView {
 
   default @NotNull Expr post(@NotNull Expr expr) { return expr; }
 
-  private @NotNull Expr commit(@NotNull Expr expr) { return post(traverse(pre(expr))); }
+  default @NotNull Expr lastly(Expr expr) {return expr;}
+
+  private @NotNull Expr commit(Expr expr) {return post(traverse(pre(expr)));}
 
   private Expr.@NotNull Param commit(Expr.@NotNull Param param) {
     var type = commit(param.type());
@@ -34,7 +36,11 @@ public interface ExprView {
 
   private Expr.TacNode commit(Expr.TacNode node) {
     return switch (node) {
-      case Expr.ExprTac exprTac -> commit(exprTac);
+      case Expr.ExprTac exprTac -> {
+        var expr = commit(exprTac.expr());
+        if (expr == exprTac.expr()) yield exprTac;
+        yield new Expr.ExprTac(exprTac.sourcePos(), expr);
+      }
       case Expr.ListExprTac listExprTac -> {
         var tacNodes = listExprTac.tacNodes().map(this::commit);
         if (tacNodes.sameElements(listExprTac.tacNodes(), true)) yield listExprTac;
@@ -114,7 +120,5 @@ public interface ExprView {
     };
   }
 
-  default @NotNull Expr commit() {
-    return commit(initial());
-  }
+  default @NotNull Expr commit() {return lastly(commit(initial()));}
 }

--- a/base/src/main/java/org/aya/concrete/visitor/ExprView.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprView.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * A generic view for traversing Expr
  *
- * @author luna
+ * @author Luna
  */
 
 public interface ExprView {
@@ -51,7 +51,7 @@ public interface ExprView {
 
   private @NotNull Expr traverse(@NotNull Expr expr) {
     return switch (expr) {
-      case Expr.RefExpr ref -> ref; // I don't know
+      case Expr.RefExpr ref -> ref;
       case Expr.UnresolvedExpr unresolved -> unresolved;
       case Expr.LamExpr lam -> {
         var param = commit(lam.param());

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -9,6 +9,7 @@ import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableMap;
 import kala.tuple.Tuple3;
 import kala.tuple.Unit;
+import org.aya.core.Meta;
 import org.aya.core.pat.Pat;
 import org.aya.core.visitor.*;
 import org.aya.distill.BaseDistiller;
@@ -220,5 +221,30 @@ public sealed interface Term extends AyaDocile permits
 
   default TermView view() {
     return () -> this;
+  }
+
+  default @NotNull ImmutableSeq<Meta> allMetas() {
+    record MetaCollector(@Override @NotNull TermView view, MutableList<Meta> metas) implements TermOps {
+      @Contract("_ -> new") public static @NotNull MetaCollector from(@NotNull Term term) {
+        return new MetaCollector(term.view(), MutableList.create());
+      }
+
+      @Override public Term pre(Term term) {
+        return switch (term) {
+          case CallTerm.Hole hole -> {
+            metas.append(hole.ref());
+            yield hole;
+          }
+          case Term misc -> misc;
+        };
+      }
+
+      public @NotNull ImmutableSeq<Meta> collect() {
+        commit();
+        return metas.toImmutableSeq();
+      }
+    }
+
+    return MetaCollector.from(this).collect();
   }
 }

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -224,9 +224,11 @@ public sealed interface Term extends AyaDocile permits
   }
 
   default @NotNull ImmutableSeq<Meta> allMetas() {
-    record MetaCollector(@Override @NotNull TermView view, MutableList<Meta> metas) implements TermOps {
-      @Contract("_ -> new") public static @NotNull MetaCollector from(@NotNull Term term) {
-        return new MetaCollector(term.view(), MutableList.create());
+    return new TermOps() {
+      final MutableList<Meta> metas = MutableList.create();
+
+      @Override public @NotNull TermView view() {
+        return Term.this.view();
       }
 
       @Override public Term pre(Term term) {
@@ -243,8 +245,6 @@ public sealed interface Term extends AyaDocile permits
         commit();
         return metas.toImmutableSeq();
       }
-    }
-
-    return MetaCollector.from(this).collect();
+    }.collect();
   }
 }

--- a/base/src/main/java/org/aya/core/visitor/TermView.java
+++ b/base/src/main/java/org/aya/core/visitor/TermView.java
@@ -27,6 +27,10 @@ public interface TermView {
     return term;
   }
 
+  default @NotNull Term lastly(Term term) {
+    return term;
+  }
+
   private @NotNull Term commit(@NotNull Term term) {
     return post(traverse(pre(term)));
   }
@@ -141,7 +145,7 @@ public interface TermView {
   }
 
   default @NotNull Term commit() {
-    return commit(initial());
+    return lastly(commit(initial()));
   }
 
   default @NotNull TermView lift(int shift) {

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -312,13 +312,12 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
 
   public @NotNull Doc tacNode(@NotNull Expr.TacNode tacNode) {
     return switch (tacNode) {
-      case Expr.ExprTac exprTac -> Doc.sep(Doc.symbol("|"), exprTac.expr().toDoc(options));
-      case Expr.ListExprTac listExprTac -> tacList(listExprTac);
+      case Expr.TacNode.ExprTac exprTac -> Doc.sep(Doc.symbol("|"), exprTac.expr().toDoc(options));
+      case Expr.TacNode.ListExprTac listExprTac -> tacList(listExprTac);
     };
   }
 
-  // TODO: don't know if this is correct
-  public @NotNull Doc tacList(@NotNull Expr.ListExprTac tacList) {
+  public @NotNull Doc tacList(@NotNull Expr.TacNode.ListExprTac tacList) {
     return Doc.cat(
       Doc.symbol("{"),
       Doc.emptyIf(tacList.tacNodes().isEmpty(), () -> Doc.cat(Doc.line(), Doc.nest(2, Doc.vcat(

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -137,6 +137,8 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
         .map($ -> Doc.styled(KEYWORD, Doc.symbol("ulift")))
         .appended(term(Outer.Lifted, expr.expr())));
       case Expr.MetaPat metaPat -> metaPat.meta().toDoc(options);
+      // TODO: add tactic
+      default -> throw new UnsupportedOperationException();
     };
   }
 

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -137,8 +137,7 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
         .map($ -> Doc.styled(KEYWORD, Doc.symbol("ulift")))
         .appended(term(Outer.Lifted, expr.expr())));
       case Expr.MetaPat metaPat -> metaPat.meta().toDoc(options);
-      case Expr.TacExpr expr -> Doc.sep(Doc.styled(KEYWORD, "tactic"),
-        tacNode(expr.tacNode()));
+      case Expr.TacExpr expr -> Doc.sep(Doc.styled(KEYWORD, "tactic"), expr.tacNode().toDoc(options));
     };
   }
 
@@ -308,23 +307,6 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
         } else yield Doc.sep(Doc.symbol("|"), doc);
       }
     };
-  }
-
-  public @NotNull Doc tacNode(@NotNull Expr.TacNode tacNode) {
-    return switch (tacNode) {
-      case Expr.TacNode.ExprTac exprTac -> Doc.sep(Doc.symbol("|"), exprTac.expr().toDoc(options));
-      case Expr.TacNode.ListExprTac listExprTac -> tacList(listExprTac);
-    };
-  }
-
-  public @NotNull Doc tacList(@NotNull Expr.TacNode.ListExprTac tacList) {
-    return Doc.cat(
-      Doc.symbol("{"),
-      Doc.emptyIf(tacList.tacNodes().isEmpty(), () -> Doc.cat(Doc.line(), Doc.nest(2, Doc.vcat(
-        tacList.tacNodes().view().map(this::tacNode))))),
-      Doc.emptyIf(tacList.tacNodes().isEmpty(), Doc::line),
-      Doc.symbol("}")
-    );
   }
 
   private Doc visitClauses(@NotNull ImmutableSeq<Pattern.Clause> clauses) {

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -137,9 +137,8 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
         .map($ -> Doc.styled(KEYWORD, Doc.symbol("ulift")))
         .appended(term(Outer.Lifted, expr.expr())));
       case Expr.MetaPat metaPat -> metaPat.meta().toDoc(options);
-      // TODO: add tactic
-      //default -> throw new UnsupportedOperationException();
-      case Expr.TacExpr expr -> throw new UnsupportedOperationException();
+      case Expr.TacExpr expr -> Doc.cat(Doc.styled(KEYWORD, "tactic"),
+        tacNode(expr.tacNode()));
     };
   }
 
@@ -309,6 +308,24 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
         } else yield Doc.sep(Doc.symbol("|"), doc);
       }
     };
+  }
+
+  public @NotNull Doc tacNode(@NotNull Expr.TacNode tacNode) {
+    return switch (tacNode) {
+      case Expr.ExprTac exprTac -> Doc.sep(Doc.symbol("|"), exprTac.expr().toDoc(options));
+      case Expr.ListExprTac listExprTac -> tacList(listExprTac);
+    };
+  }
+
+  // TODO: don't know if this is correct
+  public @NotNull Doc tacList(@NotNull Expr.ListExprTac tacList) {
+    return Doc.cat(
+      Doc.symbol("{"),
+      Doc.emptyIf(tacList.tacNodes().isEmpty(), () -> Doc.cat(Doc.line(), Doc.nest(2, Doc.vcat(
+        tacList.tacNodes().view().map(this::tacNode))))),
+      Doc.emptyIf(tacList.tacNodes().isEmpty(), Doc::line),
+      Doc.symbol("}")
+    );
   }
 
   private Doc visitClauses(@NotNull ImmutableSeq<Pattern.Clause> clauses) {

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -137,7 +137,7 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
         .map($ -> Doc.styled(KEYWORD, Doc.symbol("ulift")))
         .appended(term(Outer.Lifted, expr.expr())));
       case Expr.MetaPat metaPat -> metaPat.meta().toDoc(options);
-      case Expr.TacExpr expr -> Doc.cat(Doc.styled(KEYWORD, "tactic"),
+      case Expr.TacExpr expr -> Doc.sep(Doc.styled(KEYWORD, "tactic"),
         tacNode(expr.tacNode()));
     };
   }

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -138,7 +138,8 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
         .appended(term(Outer.Lifted, expr.expr())));
       case Expr.MetaPat metaPat -> metaPat.meta().toDoc(options);
       // TODO: add tactic
-      default -> throw new UnsupportedOperationException();
+      //default -> throw new UnsupportedOperationException();
+      case Expr.TacExpr expr -> throw new UnsupportedOperationException();
     };
   }
 

--- a/base/src/main/java/org/aya/tactic/TacTycker.java
+++ b/base/src/main/java/org/aya/tactic/TacTycker.java
@@ -1,0 +1,195 @@
+// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.tactic;
+
+import kala.tuple.Unit;
+import org.aya.concrete.Expr;
+import org.aya.concrete.TacNode;
+import org.aya.concrete.visitor.ExprConsumer;
+import org.aya.concrete.visitor.ExprOps;
+import org.aya.core.term.ErrorTerm;
+import org.aya.core.term.Term;
+import org.aya.generic.util.InternalException;
+import org.aya.tyck.ExprTycker;
+import org.aya.tyck.error.TacticProblem.HoleFillerCannotHaveHole;
+import org.aya.tyck.error.TacticProblem.HoleFillerNumberMismatch;
+import org.aya.tyck.error.TacticProblem.NestedTactic;
+import org.aya.tyck.error.TacticProblem.TacHeadCannotBeList;
+import org.aya.util.distill.AyaDocile;
+import org.aya.util.error.SourcePos;
+import org.aya.util.reporter.Problem;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class TacTycker {
+  private final ExprTycker exprTycker;
+  private final ExprOps.HoleFiller holeFiller = new ExprOps.HoleFiller();
+
+  public TacTycker(@NotNull ExprTycker exprTycker) {
+    this.exprTycker = exprTycker;
+  }
+
+  public @NotNull ExprTycker.Result synthesizeTactic(Expr.@NotNull TacExpr tac) {
+    return switch (tac.tacNode()) {
+      case TacNode.ExprTac exprTac -> exprTycker.synthesize(exprTac.expr());
+      case TacNode.ListExprTac listExprTac -> {
+        var tacNodes = listExprTac.tacNodes();
+        var headTac = tacNodes.first();
+
+        if (headTac instanceof TacNode.ExprTac exprHead) {
+          var inferredResult = exprTycker.synthesize(exprHead.expr());
+          yield inferredResult.isError() ? inferredResult : exprTycker.inherit(tac, inferredResult.type());
+        } else
+          yield tacFail(headTac, new TacHeadCannotBeList(listExprTac.sourcePos(), listExprTac)).result;
+      }
+    };
+  }
+
+  public @NotNull ExprTycker.Result inheritTactic(Expr.@NotNull TacExpr tac, @NotNull Term term) {
+    var theNested = nestedTacBlock(tac);
+
+    if (theNested != null)
+      return tacFail(tac, new NestedTactic(tac.sourcePos(), tac, theNested)).result;
+
+    return inheritTacNode(tac.tacNode(), term).result;
+  }
+
+  private @NotNull TacElabResult inheritTacNode(@NotNull TacNode node, Term term) {
+    return switch (node) {
+      case TacNode.ExprTac exprTac -> inheritExprTac(exprTac, term);
+      case TacNode.ListExprTac listExprTac -> inheritListExprTac(listExprTac, term);
+    };
+  }
+
+  private @NotNull TacElabResult inheritListExprTac(TacNode.@NotNull ListExprTac listExprTac, Term term) {
+    TacElabResult result = null;
+
+    var tacNodes = listExprTac.tacNodes();
+    var headNode = tacNodes.first();
+    var tailNodes = tacNodes.drop(1);
+
+    // enter into a local state
+    var parentCtx = exprTycker.localCtx;
+    exprTycker.localCtx.deriveMap();
+
+    if (headNode instanceof TacNode.ExprTac headTac) {
+      var exprToElab = headTac.expr();
+      var tacHeadResult = exprTycker.inherit(exprToElab, term); // tyck this expr to insert all metas
+      var headTerm = tacHeadResult.wellTyped();
+
+      if (headTerm instanceof ErrorTerm errorTerm)
+        return tacPropagateError(headTac, errorTerm, tacHeadResult);
+
+      var metas = headTerm.allMetas();
+
+      // We can check the remaining nodes against the meta type, but the problem is that the later expected types might change,
+      // so we need to instantiate the meta and tyck again.
+      // We should refill the final, filled concrete expr and type check it against the goal type.
+      while (metas.isNotEmpty()) {
+        var metaSize = metas.size();
+        if (tailNodes.size() == metaSize) {
+          var firstMeta = metas.first();
+          var firstNode = tailNodes.first();
+
+          if (firstMeta.result == null) throw new InternalException("Meta " + firstMeta + " has unknown type");
+          var fillingElabResult = inheritTacNode(firstNode, firstMeta.result);
+          var filling = fillingElabResult.elaborated;
+
+          // propagate error immediately
+          if (filling instanceof Expr.ErrorExpr) return fillingElabResult;
+
+          tailNodes = tailNodes.drop(1);
+          exprToElab = holeFiller.fill(exprToElab, filling);
+          headTerm = exprTycker.inherit(exprToElab, term).wellTyped();
+          metas = headTerm.allMetas();
+
+          if (metas.size() >= metaSize) throw new InternalException("Meta is not solved after elaborating tactic");
+        } else {
+          result = tacFail(exprToElab,
+            new HoleFillerNumberMismatch(listExprTac.sourcePos(), metaSize, tailNodes.size()));
+          break;
+        }
+      }
+
+      // null means that there is no meta to solve
+      if (result == null) result = new TacElabResult(exprToElab,
+        new ExprTycker.Result(exprTycker.inherit(exprToElab, term).wellTyped(), term));
+
+    } else {
+      result = tacFail(headNode, new TacHeadCannotBeList(listExprTac.sourcePos(), listExprTac));
+    }
+
+    exprTycker.localCtx = parentCtx; // revert to the original state
+    return result;
+  }
+
+  private @NotNull TacElabResult inheritExprTac(TacNode.@NotNull ExprTac exprTac, @NotNull Term term) {
+    var result = exprTycker.inherit(exprTac.expr(), term);
+    var metaSize = result.wellTyped().allMetas().size();
+
+    if (result.wellTyped() instanceof ErrorTerm errorTerm)
+      return tacPropagateError(exprTac, errorTerm, result);
+    else if (metaSize != 0)
+      return tacFail(exprTac.expr(), new HoleFillerCannotHaveHole(exprTac.sourcePos(), exprTac));
+
+    return new TacElabResult(exprTac.expr(), result);
+  }
+
+  /**
+   * Fail and report error
+   *
+   * @param tacNode the {@link TacNode} that fails to be elaborated
+   * @param problem the {@link Problem} that occurred
+   * @return a {@link TacElabResult} that represents error
+   */
+  private @NotNull TacElabResult tacFail(@NotNull TacNode tacNode, @NotNull Problem problem) {
+    var errorTyckResult = exprTycker.fail(tacNode, problem);
+    return TacElabResult.error(tacNode.sourcePos(), tacNode, errorTyckResult);
+  }
+
+  private @NotNull TacElabResult tacFail(@NotNull Expr exprToElab, @NotNull Problem problem) {
+    var errorTyckResult = exprTycker.fail(exprToElab, problem);
+    return TacElabResult.error(exprToElab.sourcePos(), exprToElab, errorTyckResult);
+  }
+
+  private @NotNull TacElabResult tacPropagateError(@NotNull TacNode tacNode,
+                                                   @NotNull ErrorTerm errorTerm,
+                                                   @NotNull ExprTycker.Result errorResult) {
+    return TacElabResult.error(tacNode.sourcePos(), errorTerm.description(), errorResult);
+  }
+
+  private @Nullable Expr.TacExpr nestedTacBlock(@NotNull Expr.TacExpr tac) {
+    var nestChecker = new ExprConsumer<Unit>() {
+      Expr.TacExpr theNested = null;
+
+      @Override public Unit visitTac(@NotNull Expr.TacExpr tactic, Unit unit) {
+        if (tactic != tac) {
+          theNested = tactic;
+          return unit;
+        }
+        return ExprConsumer.super.visitTac(tactic, unit);
+      }
+    };
+
+    tac.accept(nestChecker, Unit.unit());
+    return nestChecker.theNested;
+  }
+
+
+  /**
+   * Tactic elaboration result that contains expr with filled holes
+   *
+   * @param elaborated the {@link Expr} being elaborated
+   * @param result     the {@link ExprTycker.Result} after checking
+   * @author Luna
+   */
+  private record TacElabResult(@NotNull Expr elaborated, @NotNull ExprTycker.Result result) {
+    @Contract("_, _, _ -> new")
+    public static @NotNull TacElabResult error(@NotNull SourcePos sourcePos,
+                                               @NotNull AyaDocile description,
+                                               @NotNull ExprTycker.Result errorTyckResult) {
+      return new TacElabResult(new Expr.ErrorExpr(sourcePos, description), errorTyckResult);
+    }
+  }
+}

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -372,7 +372,7 @@ public final class ExprTycker extends Tycker {
       case TacNode.ListExprTac listExprTac -> {
         var tacNodes = listExprTac.tacNodes();
         var headNode = tacNodes.first();
-        var tailNodes = tacNodes.slice(1, tacNodes.size());
+        var tailNodes = tacNodes.drop(1);
         if (headNode instanceof TacNode.ExprTac exprTac) {
           // we need a local state here to store new metas, but we want to inherit to insert metas
           // for now we instantiate a new tycker

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -12,6 +12,7 @@ import kala.value.LazyValue;
 import org.aya.concrete.Expr;
 import org.aya.concrete.stmt.Decl;
 import org.aya.concrete.stmt.Signatured;
+import org.aya.concrete.visitor.ExprOps;
 import org.aya.concrete.visitor.ExprView;
 import org.aya.core.def.*;
 import org.aya.core.term.*;
@@ -32,6 +33,7 @@ import org.aya.tyck.trace.Trace;
 import org.aya.tyck.unify.DefEq;
 import org.aya.util.Ordering;
 import org.aya.util.distill.AyaDocile;
+import org.aya.util.distill.DistillerOptions;
 import org.aya.util.error.SourcePos;
 import org.aya.util.reporter.Problem;
 import org.aya.util.reporter.Reporter;
@@ -339,7 +341,40 @@ public final class ExprTycker extends Tycker {
           return new Result(new IntroTerm.Lambda(resultParam, rec.wellTyped), dt);
         });
       }
-      case Expr.TacExpr tac -> elaborateTactic(tac.tacNode(), term).result;
+      case Expr.TacExpr tac -> {
+        var NestedTacChecker = new ExprOps() {
+          boolean nested = false;
+          Expr.TacExpr theNested = null;
+
+          @Override public @NotNull ExprView view() {
+            return tac.view();
+          }
+
+          @Override public Expr pre(Expr expr) {
+            return switch (expr) {
+              case Expr.TacExpr nestedTac -> {
+                nested = true;
+                theNested = nestedTac;
+                yield nestedTac;
+              }
+              case Expr misc -> misc;
+            };
+          }
+
+          @Override public Expr lastly(Expr expr) {return nested ? theNested : expr;}
+        };
+
+        // if nested then the nested one is returned, otherwise the original one is returned.
+        var tacOrNested = NestedTacChecker.commit();
+
+        reporter.reportDoc(tacOrNested.toDoc(DistillerOptions.debug()));
+
+        if (tac != tacOrNested) {
+          yield tacFail(tac, new TacticProblem.NestedTactic(tac.sourcePos(), tac, (Expr.TacExpr) tacOrNested)).result;
+        }
+
+        yield elaborateTactic(tac.tacNode(), term).result;
+      }
       default -> unifyTyMaybeInsert(term, synthesize(expr), expr);
     };
   }
@@ -358,15 +393,14 @@ public final class ExprTycker extends Tycker {
           var exprToElab = exprTac.expr();
           var tacHead = tacTycker.inherit(exprToElab, term).wellTyped; // tyck this expr to insert all metas
 
-
-          var placeHolder = new Expr.ErrorExpr(SourcePos.NONE, Doc.english("Internal Error for expr hole filler"));
-          class ExprHoleFiller implements ExprView {
+          var holeFiller = new ExprOps() {
             boolean filled = false;
+            final Expr placeHolder = new Expr.ErrorExpr(SourcePos.NONE, Doc.english("Internal Error for expr hole filler"));
             Expr filling = placeHolder;
             Expr exprWithHole = placeHolder;
 
-            @Override public @NotNull Expr initial() {
-              return exprWithHole;
+            @Override public @NotNull ExprView view() {
+              return exprWithHole.view();
             }
 
             @Override public Expr pre(Expr expr) {
@@ -387,8 +421,7 @@ public final class ExprTycker extends Tycker {
               this.filling = filling;
               return commit();
             }
-          }
-          var holeFiller = new ExprHoleFiller();
+          };
 
           var metas = tacHead.allMetas();
           // we can check the remaining nodes against the meta type, but the problem is that the later expected types might change
@@ -665,8 +698,9 @@ public final class ExprTycker extends Tycker {
 
   /**
    * Tactic elaboration result that contains expr with filled holes
+   *
    * @param elaborated the {@link Expr} being elaborated
-   * @param result the {@link Result} after checking
+   * @param result     the {@link Result} after checking
    * @author Luna
    */
   public record TacElabResult(@NotNull Expr elaborated, @NotNull Result result) {}

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -383,6 +383,7 @@ public final class ExprTycker extends Tycker {
         var headNode = tacNodes.first();
         var tailNodes = tacNodes.drop(1);
         // enter into a new local state
+        var parentCtx = localCtx;
         localCtx = localCtx.deriveMap();
         if (headNode instanceof TacNode.ExprTac exprTac) {
           var exprToElab = exprTac.expr();
@@ -450,7 +451,7 @@ public final class ExprTycker extends Tycker {
           result = tacFail(listExprTac, new TacticProblem.TacHeadCannotBeList(listExprTac.sourcePos(), listExprTac));
         }
 
-        localCtx = Objects.requireNonNull(localCtx.parent()); // This should allow contexts to revert to original
+        localCtx = parentCtx; // This should allow contexts to revert to original
         yield result;
       }
     };

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -348,8 +348,11 @@ public final class ExprTycker extends Tycker {
           Expr.TacExpr theNested = null;
 
           @Override public Unit visitTac(@NotNull Expr.TacExpr tactic, Unit unit) {
-            if (tactic != tac) theNested = tactic;
-            return unit;
+            if (tactic != tac) {
+              theNested = tactic;
+              return unit;
+            }
+            return ExprConsumer.super.visitTac(tactic, unit);
           }
         };
 

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -350,7 +350,7 @@ public final class ExprTycker extends Tycker {
             return tac.view();
           }
 
-          @Override public Expr pre(Expr expr) {
+          @Override public @NotNull Expr pre(@NotNull Expr expr) {
             return switch (expr) {
               case Expr.TacExpr nestedTac -> {
                 nested = true;
@@ -361,7 +361,7 @@ public final class ExprTycker extends Tycker {
             };
           }
 
-          @Override public Expr lastly(Expr expr) {return nested ? theNested : expr;}
+          @Override public @NotNull Expr lastly(@NotNull Expr expr) {return nested ? theNested : expr;}
         };
 
         // if nested then the nested one is returned, otherwise the original one is returned.
@@ -400,7 +400,7 @@ public final class ExprTycker extends Tycker {
               return exprWithHole.view();
             }
 
-            @Override public Expr pre(Expr expr) {
+            @Override public @NotNull Expr pre(@NotNull Expr expr) {
               return switch (expr) {
                 case Expr.HoleExpr hole -> {
                   if (!filled) {

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -10,6 +10,7 @@ import kala.tuple.Tuple2;
 import kala.tuple.Tuple3;
 import kala.value.LazyValue;
 import org.aya.concrete.Expr;
+import org.aya.concrete.TacNode;
 import org.aya.concrete.stmt.Decl;
 import org.aya.concrete.stmt.Signatured;
 import org.aya.concrete.visitor.ExprOps;
@@ -375,14 +376,14 @@ public final class ExprTycker extends Tycker {
     };
   }
 
-  private TacElabResult elaborateTactic(Expr.TacNode tacNode, Term term) {
+  private TacElabResult elaborateTactic(TacNode tacNode, Term term) {
     return switch (tacNode) {
-      case Expr.TacNode.ExprTac exprTac -> new TacElabResult(exprTac.expr(), inherit(exprTac.expr(), term));
-      case Expr.TacNode.ListExprTac listExprTac -> {
+      case TacNode.ExprTac exprTac -> new TacElabResult(exprTac.expr(), inherit(exprTac.expr(), term));
+      case TacNode.ListExprTac listExprTac -> {
         var tacNodes = listExprTac.tacNodes();
         var headNode = tacNodes.first();
         var tailNodes = tacNodes.slice(1, tacNodes.size());
-        if (headNode instanceof Expr.TacNode.ExprTac exprTac) {
+        if (headNode instanceof TacNode.ExprTac exprTac) {
           // we need a local state here to store new metas, but we want to inherit to insert metas
           // for now we instantiate a new tycker
           var tacTycker = new ExprTycker(reporter, traceBuilder);
@@ -449,7 +450,7 @@ public final class ExprTycker extends Tycker {
     };
   }
 
-  private @NotNull TacElabResult tacFail(@NotNull Expr.TacNode.ListExprTac listExprTac, @NotNull Problem problem) {
+  private @NotNull TacElabResult tacFail(@NotNull TacNode.ListExprTac listExprTac, @NotNull Problem problem) {
     return new TacElabResult(new Expr.ErrorExpr(listExprTac.sourcePos(), listExprTac), fail(listExprTac, problem));
   }
 

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -458,7 +458,7 @@ public final class ExprTycker extends Tycker {
               metas = headTerm.allMetas();
 
               if (metas.size() >= metaSize)
-                throw new IllegalStateException("Meta is not solved after elaboration"); // TODO: internal error meta is not filled after tactic
+                throw new InternalException("Meta is not solved after elaboration");
             } else {
               result = tacFail(exprToElab,
                 new TacticProblem.HoleFillerNumberMismatch(listExprTac.sourcePos(), metaSize, tailNodes.size()));

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -444,7 +444,7 @@ public final class ExprTycker extends Tycker {
               if (metas.size() >= metaSize)
                 throw new UnsupportedOperationException(); // TODO: internal error meta is not filled after tactic
             } else yield tacFail(exprToElab,
-              new TacticProblem.HoleNumberMismatchError(listExprTac.sourcePos(), metaSize, tailNodes.size()));
+              new TacticProblem.HoleFillerNumberMismatch(listExprTac.sourcePos(), metaSize, tailNodes.size()));
           }
 
           yield new TacElabResult(exprToElab, new Result(inherit(exprToElab, term).wellTyped, term));

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -26,6 +26,7 @@ import org.aya.generic.Constants;
 import org.aya.generic.Modifier;
 import org.aya.generic.util.InternalException;
 import org.aya.generic.util.NormalizeMode;
+import org.aya.pretty.doc.Doc;
 import org.aya.ref.DefVar;
 import org.aya.ref.LocalVar;
 import org.aya.ref.Var;
@@ -235,6 +236,22 @@ public final class ExprTycker extends Tycker {
       case Expr.HoleExpr hole -> inherit(hole, localCtx.freshHole(null,
         Constants.randomName(hole), hole.sourcePos())._2);
       case Expr.ErrorExpr err -> Result.error(err.description());
+      case Expr.TacExpr tac -> switch (tac.tacNode()) {
+        case TacNode.ExprTac exprTac -> synthesize(exprTac.expr());
+        case TacNode.ListExprTac listExprTac -> {
+          var tacNodes = listExprTac.tacNodes();
+          var headTac = tacNodes.first();
+
+          if (headTac instanceof TacNode.ExprTac exprHead) {
+            var inferredResult = synthesize(exprHead.expr());
+            var inferredHead = inferredResult.wellTyped;
+            if (inferredHead instanceof ErrorTerm) yield inferredResult;
+            else yield inherit(tac, inferredResult.type);
+          } else yield tacFail(headTac,
+            new TacticProblem.TacHeadCannotBeList(listExprTac.sourcePos(),
+              listExprTac)).result;
+        }
+      };
       default -> fail(expr, new NoRuleError(expr, null));
     };
   }

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -377,12 +377,12 @@ public final class ExprTycker extends Tycker {
 
   private TacElabResult elaborateTactic(Expr.TacNode tacNode, Term term) {
     return switch (tacNode) {
-      case Expr.ExprTac exprTac -> new TacElabResult(exprTac.expr(), inherit(exprTac.expr(), term));
-      case Expr.ListExprTac listExprTac -> {
+      case Expr.TacNode.ExprTac exprTac -> new TacElabResult(exprTac.expr(), inherit(exprTac.expr(), term));
+      case Expr.TacNode.ListExprTac listExprTac -> {
         var tacNodes = listExprTac.tacNodes();
         var headNode = tacNodes.first();
         var tailNodes = tacNodes.slice(1, tacNodes.size());
-        if (headNode instanceof Expr.ExprTac exprTac) {
+        if (headNode instanceof Expr.TacNode.ExprTac exprTac) {
           // we need a local state here to store new metas, but we want to inherit to insert metas
           // for now we instantiate a new tycker
           var tacTycker = new ExprTycker(reporter, traceBuilder);
@@ -449,7 +449,7 @@ public final class ExprTycker extends Tycker {
     };
   }
 
-  private @NotNull TacElabResult tacFail(@NotNull Expr.ListExprTac listExprTac, @NotNull Problem problem) {
+  private @NotNull TacElabResult tacFail(@NotNull Expr.TacNode.ListExprTac listExprTac, @NotNull Problem problem) {
     return new TacElabResult(new Expr.ErrorExpr(listExprTac.sourcePos(), listExprTac), fail(listExprTac, problem));
   }
 

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -33,7 +33,6 @@ import org.aya.tyck.trace.Trace;
 import org.aya.tyck.unify.DefEq;
 import org.aya.util.Ordering;
 import org.aya.util.distill.AyaDocile;
-import org.aya.util.distill.DistillerOptions;
 import org.aya.util.error.SourcePos;
 import org.aya.util.reporter.Problem;
 import org.aya.util.reporter.Reporter;
@@ -366,9 +365,6 @@ public final class ExprTycker extends Tycker {
 
         // if nested then the nested one is returned, otherwise the original one is returned.
         var tacOrNested = NestedTacChecker.commit();
-
-        reporter.reportDoc(tacOrNested.toDoc(DistillerOptions.debug()));
-
         if (tac != tacOrNested) {
           yield tacFail(tac, new TacticProblem.NestedTactic(tac.sourcePos(), tac, (Expr.TacExpr) tacOrNested)).result;
         }

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -368,7 +368,14 @@ public final class ExprTycker extends Tycker {
 
   private @NotNull TacElabResult elaborateTactic(TacNode tacNode, Term term) {
     return switch (tacNode) {
-      case TacNode.ExprTac exprTac -> new TacElabResult(exprTac.expr(), inherit(exprTac.expr(), term));
+      case TacNode.ExprTac exprTac -> {
+        var result = inherit(exprTac.expr(), term);
+        var metaSize = result.wellTyped.allMetas().size();
+        if (metaSize != 0) {
+          yield tacFail(exprTac.expr(), new TacticProblem.HoleFillerNumberMismatch(exprTac.sourcePos(), 0, metaSize));
+        }
+        yield new TacElabResult(exprTac.expr(), inherit(exprTac.expr(), term));
+      }
       case TacNode.ListExprTac listExprTac -> {
         TacElabResult result = null;
 
@@ -429,7 +436,7 @@ public final class ExprTycker extends Tycker {
               metas = tacHead.allMetas();
 
               if (metas.size() >= metaSize)
-                throw new IllegalStateException("Meta is not solved after elab"); // TODO: internal error meta is not filled after tactic
+                throw new IllegalStateException("Meta is not solved after elaboration"); // TODO: internal error meta is not filled after tactic
             } else {
               result = tacFail(exprToElab,
                 new TacticProblem.HoleFillerNumberMismatch(listExprTac.sourcePos(), metaSize, tailNodes.size()));

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -421,7 +421,7 @@ public final class ExprTycker extends Tycker {
 
           var metas = tacHead.allMetas();
           // we can check the remaining nodes against the meta type, but the problem is that the later expected types might change
-          // so we probably need to instantiate the meta and tyck again?
+          // so we need to instantiate the meta and tyck again.
           // we should refill the final, filled concrete expr and type check it against the goal type
 
           while (metas.isNotEmpty()) {

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -12,6 +12,7 @@ import kala.value.LazyValue;
 import org.aya.concrete.Expr;
 import org.aya.concrete.stmt.Decl;
 import org.aya.concrete.stmt.Signatured;
+import org.aya.concrete.visitor.ExprView;
 import org.aya.core.def.*;
 import org.aya.core.term.*;
 import org.aya.core.visitor.Subst;
@@ -338,8 +339,93 @@ public final class ExprTycker extends Tycker {
           return new Result(new IntroTerm.Lambda(resultParam, rec.wellTyped), dt);
         });
       }
+      case Expr.TacExpr tac -> elaborateTactic(tac.tacNode(), term).result;
       default -> unifyTyMaybeInsert(term, synthesize(expr), expr);
     };
+  }
+
+  private TacElabResult elaborateTactic(Expr.TacNode tacNode, Term term) {
+    return switch (tacNode) {
+      case Expr.ExprTac exprTac -> new TacElabResult(exprTac.expr(), inherit(exprTac.expr(), term));
+      case Expr.ListExprTac listExprTac -> {
+        var tacNodes = listExprTac.tacNodes();
+        var headNode = tacNodes.first();
+        var tailNodes = tacNodes.slice(1, tacNodes.size());
+        if (headNode instanceof Expr.ExprTac exprTac) {
+          // we need a local state here to store new metas, but we want to inherit to insert metas
+          // for now we instantiate a new tycker
+          var tacTycker = new ExprTycker(reporter, traceBuilder);
+          var exprToElab = exprTac.expr();
+          var tacHead = tacTycker.inherit(exprToElab, term).wellTyped; // tyck this expr to insert all metas
+
+
+          var placeHolder = new Expr.ErrorExpr(SourcePos.NONE, Doc.english("Internal Error for expr hole filler"));
+          class ExprHoleFiller implements ExprView {
+            boolean filled = false;
+            Expr filling = placeHolder;
+            Expr exprWithHole = placeHolder;
+
+            @Override public @NotNull Expr initial() {
+              return exprWithHole;
+            }
+
+            @Override public Expr pre(Expr expr) {
+              return switch (expr) {
+                case Expr.HoleExpr hole -> {
+                  if (!filled) {
+                    filled = true;
+                    yield filling;
+                  } else yield hole;
+                }
+                case Expr misc -> misc;
+              };
+            }
+
+            public @NotNull Expr fill(Expr exprWithHole, Expr filling) {
+              this.exprWithHole = exprWithHole;
+              this.filling = filling;
+              return commit();
+            }
+          }
+          var holeFiller = new ExprHoleFiller();
+
+          var metas = tacHead.allMetas();
+          // we can check the remaining nodes against the meta type, but the problem is that the later expected types might change
+          // so we probably need to instantiate the meta and tyck again?
+          // we should refill the final, filled concrete expr and type check it against the goal type
+
+          while (metas.isNotEmpty()) {
+            var metaSize = metas.size();
+            if (tailNodes.size() == metaSize) {
+              var firstMeta = metas.first();
+              var firstNode = tailNodes.first();
+              var filling = elaborateTactic(firstNode, firstMeta.result).elaborated;
+
+              tailNodes = tailNodes.drop(0);
+
+              exprToElab = holeFiller.fill(exprToElab, filling);
+              tacTycker = new ExprTycker(reporter, traceBuilder);
+              tacHead = tacTycker.inherit(exprToElab, term).wellTyped;
+              metas = tacHead.allMetas();
+
+              if (metas.size() >= metaSize)
+                throw new UnsupportedOperationException(); // TODO: internal error meta is not filled after tactic
+            } else yield tacFail(exprToElab,
+              new TacticProblem.HoleNumberMismatchError(listExprTac.sourcePos(), metaSize, tailNodes.size()));
+          }
+
+          yield new TacElabResult(exprToElab, new Result(inherit(exprToElab, term).wellTyped, term));
+        } else yield tacFail(listExprTac, new TacticProblem.TacHeadCannotBeList(listExprTac.sourcePos(), listExprTac));
+      }
+    };
+  }
+
+  private @NotNull TacElabResult tacFail(@NotNull Expr.ListExprTac listExprTac, @NotNull Problem problem) {
+    return new TacElabResult(new Expr.ErrorExpr(listExprTac.sourcePos(), listExprTac), fail(listExprTac, problem));
+  }
+
+  private @NotNull TacElabResult tacFail(@NotNull Expr exprToElab, @NotNull Problem problem) {
+    return new TacElabResult(new Expr.ErrorExpr(exprToElab.sourcePos(), exprToElab), fail(exprToElab, problem));
   }
 
   private void traceExit(Result result, @NotNull Expr expr) {
@@ -576,4 +662,12 @@ public final class ExprTycker extends Tycker {
       return new Result(wellTyped.freezeHoles(state), type.freezeHoles(state));
     }
   }
+
+  /**
+   * Tactic elaboration result that contains expr with filled holes
+   * @param elaborated the {@link Expr} being elaborated
+   * @param result the {@link Result} after checking
+   * @author Luna
+   */
+  public record TacElabResult(@NotNull Expr elaborated, @NotNull Result result) {}
 }

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -469,7 +469,7 @@ public final class ExprTycker extends Tycker {
           if (result == null)
             result = new TacElabResult(exprToElab, new Result(inherit(exprToElab, term).wellTyped, term));
         } else {
-          result = tacFail(listExprTac, new TacticProblem.TacHeadCannotBeList(listExprTac.sourcePos(), listExprTac));
+          result = tacFail(headNode, new TacticProblem.TacHeadCannotBeList(listExprTac.sourcePos(), listExprTac));
         }
 
         localCtx = parentCtx; // This should allow contexts to revert to original

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -356,7 +356,7 @@ public final class ExprTycker extends Tycker {
           }
         };
 
-        // if nested then the nested one is returned, otherwise the original one is returned.
+        // if there is nested tactic then the nested one is recorded
         tac.accept(nestChecker, Unit.unit());
         if (nestChecker.theNested != null) {
           yield tacFail(tac, new TacticProblem.NestedTactic(tac.sourcePos(), tac, nestChecker.theNested)).result;

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -382,6 +382,7 @@ public final class ExprTycker extends Tycker {
             }
 
             public @NotNull Expr fill(Expr exprWithHole, Expr filling) {
+              filled = false;
               this.exprWithHole = exprWithHole;
               this.filling = filling;
               return commit();
@@ -401,8 +402,7 @@ public final class ExprTycker extends Tycker {
               var firstNode = tailNodes.first();
               var filling = elaborateTactic(firstNode, firstMeta.result).elaborated;
 
-              tailNodes = tailNodes.drop(0);
-
+              tailNodes = tailNodes.drop(1);
               exprToElab = holeFiller.fill(exprToElab, filling);
               tacTycker = new ExprTycker(reporter, traceBuilder);
               tacHead = tacTycker.inherit(exprToElab, term).wellTyped;

--- a/base/src/main/java/org/aya/tyck/error/TacticProblem.java
+++ b/base/src/main/java/org/aya/tyck/error/TacticProblem.java
@@ -29,11 +29,25 @@ public interface TacticProblem extends Problem {
   }
 
   record TacHeadCannotBeList(@NotNull SourcePos sourcePos, @NotNull Expr.ListExprTac tacList) implements TacticProblem {
-
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
       return Doc.sep(Doc.english("Tactic head of"),
+        Doc.line(),
         tacList.toDoc(options),
         Doc.english("cannot be a list"));
+    }
+  }
+
+  record NestedTactic(@NotNull SourcePos sourcePos, @NotNull Expr.TacExpr outer,
+                      @NotNull Expr.TacExpr inner) implements TacticProblem {
+    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.cat(
+        inner.toDoc(options),
+        Doc.line(),
+        Doc.line(),
+        Doc.english("is nested in"),
+        Doc.line(),
+        Doc.line(),
+        outer.toDoc(options));
     }
   }
 

--- a/base/src/main/java/org/aya/tyck/error/TacticProblem.java
+++ b/base/src/main/java/org/aya/tyck/error/TacticProblem.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.tyck.error;
+
+import org.aya.concrete.Expr;
+import org.aya.pretty.doc.Doc;
+import org.aya.util.distill.DistillerOptions;
+import org.aya.util.error.SourcePos;
+import org.aya.util.reporter.Problem;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author luna
+ */
+public interface TacticProblem extends Problem {
+
+  @Override default @NotNull Problem.Severity level() {
+    return Severity.ERROR;
+  }
+
+  record HoleNumberMismatchError(@NotNull SourcePos sourcePos,
+                                 int expected, int supplied) implements TacticProblem {
+    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.sep(Doc.english("Expected"),
+        Doc.plain(String.valueOf(expected)),
+        Doc.english("holes in the tactic head, but found"),
+        Doc.plain(String.valueOf(supplied)));
+    }
+  }
+
+  record TacHeadCannotBeList(@NotNull SourcePos sourcePos, @NotNull Expr.ListExprTac tacList,
+                              @NotNull Expr.TacNode first) implements TacticProblem {
+
+    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.english("Tactic head cannot be list");
+      // TODO: make this more verbose
+    }
+  }
+
+}

--- a/base/src/main/java/org/aya/tyck/error/TacticProblem.java
+++ b/base/src/main/java/org/aya/tyck/error/TacticProblem.java
@@ -18,12 +18,12 @@ public interface TacticProblem extends Problem {
     return Severity.ERROR;
   }
 
-  record HoleNumberMismatchError(@NotNull SourcePos sourcePos,
-                                 int expected, int supplied) implements TacticProblem {
+  record HoleFillerNumberMismatch(@NotNull SourcePos sourcePos,
+                                  int expected, int supplied) implements TacticProblem {
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
       return Doc.sep(Doc.english("Expected"),
         Doc.plain(String.valueOf(expected)),
-        Doc.english("holes in the tactic head, but found"),
+        Doc.english("filler(s) in the tactic block, but found"),
         Doc.plain(String.valueOf(supplied)));
     }
   }

--- a/base/src/main/java/org/aya/tyck/error/TacticProblem.java
+++ b/base/src/main/java/org/aya/tyck/error/TacticProblem.java
@@ -46,4 +46,10 @@ public sealed interface TacticProblem extends Problem {
     }
   }
 
+  record HoleFillerCannotHaveHole(@NotNull SourcePos sourcePos, @NotNull TacNode.ExprTac exprTac) implements TacticProblem {
+    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.english("Hole filler cannot have holes");
+    }
+  }
+
 }

--- a/base/src/main/java/org/aya/tyck/error/TacticProblem.java
+++ b/base/src/main/java/org/aya/tyck/error/TacticProblem.java
@@ -28,7 +28,8 @@ public interface TacticProblem extends Problem {
     }
   }
 
-  record TacHeadCannotBeList(@NotNull SourcePos sourcePos, @NotNull Expr.ListExprTac tacList) implements TacticProblem {
+  record TacHeadCannotBeList(@NotNull SourcePos sourcePos,
+                             @NotNull Expr.TacNode.ListExprTac tacList) implements TacticProblem {
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
       return Doc.sep(Doc.english("Tactic head of"),
         Doc.line(),

--- a/base/src/main/java/org/aya/tyck/error/TacticProblem.java
+++ b/base/src/main/java/org/aya/tyck/error/TacticProblem.java
@@ -10,7 +10,7 @@ import org.aya.util.reporter.Problem;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * @author luna
+ * @author Luna
  */
 public interface TacticProblem extends Problem {
 

--- a/base/src/main/java/org/aya/tyck/error/TacticProblem.java
+++ b/base/src/main/java/org/aya/tyck/error/TacticProblem.java
@@ -3,6 +3,7 @@
 package org.aya.tyck.error;
 
 import org.aya.concrete.Expr;
+import org.aya.concrete.TacNode;
 import org.aya.pretty.doc.Doc;
 import org.aya.util.distill.DistillerOptions;
 import org.aya.util.error.SourcePos;
@@ -12,8 +13,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author Luna
  */
-public interface TacticProblem extends Problem {
-
+public sealed interface TacticProblem extends Problem {
   @Override default @NotNull Problem.Severity level() {
     return Severity.ERROR;
   }
@@ -29,10 +29,9 @@ public interface TacticProblem extends Problem {
   }
 
   record TacHeadCannotBeList(@NotNull SourcePos sourcePos,
-                             @NotNull Expr.TacNode.ListExprTac tacList) implements TacticProblem {
+                             @NotNull TacNode.ListExprTac tacList) implements TacticProblem {
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
-      return Doc.sep(Doc.english("Tactic head of"),
-        Doc.line(),
+      return Doc.vcat(Doc.english("Tactic head of"),
         tacList.toDoc(options),
         Doc.english("cannot be a list"));
     }
@@ -41,14 +40,9 @@ public interface TacticProblem extends Problem {
   record NestedTactic(@NotNull SourcePos sourcePos, @NotNull Expr.TacExpr outer,
                       @NotNull Expr.TacExpr inner) implements TacticProblem {
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
-      return Doc.cat(
-        inner.toDoc(options),
-        Doc.line(),
-        Doc.line(),
+      return Doc.vcat(Doc.par(1, inner.toDoc(options)),
         Doc.english("is nested in"),
-        Doc.line(),
-        Doc.line(),
-        outer.toDoc(options));
+        Doc.par(1, outer.toDoc(options)));
     }
   }
 

--- a/base/src/main/java/org/aya/tyck/error/TacticProblem.java
+++ b/base/src/main/java/org/aya/tyck/error/TacticProblem.java
@@ -28,12 +28,12 @@ public interface TacticProblem extends Problem {
     }
   }
 
-  record TacHeadCannotBeList(@NotNull SourcePos sourcePos, @NotNull Expr.ListExprTac tacList,
-                              @NotNull Expr.TacNode first) implements TacticProblem {
+  record TacHeadCannotBeList(@NotNull SourcePos sourcePos, @NotNull Expr.ListExprTac tacList) implements TacticProblem {
 
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
-      return Doc.english("Tactic head cannot be list");
-      // TODO: make this more verbose
+      return Doc.sep(Doc.english("Tactic head of"),
+        tacList.toDoc(options),
+        Doc.english("cannot be a list"));
     }
   }
 

--- a/base/src/test/resources/failure/tactic/expr-tyck-error.aya
+++ b/base/src/test/resources/failure/tactic/expr-tyck-error.aya
@@ -1,0 +1,16 @@
+public open data Nat
+| zero
+| suc Nat
+
+def overlap infixl + (a b : Nat) : Nat
+| zero, a => a
+| a, zero => a
+| suc a, b => suc (a + b)
+| a, suc b => suc (a + b)
+
+
+example def exprTyckError: Nat => tactic {
+  | {??} + {??}
+  | zero {??} -- this results in a tyck error (application not allowed here)
+  | zero
+}

--- a/base/src/test/resources/failure/tactic/expr-tyck-error.aya.txt
+++ b/base/src/test/resources/failure/tactic/expr-tyck-error.aya.txt
@@ -1,0 +1,39 @@
+In file $FILE:13:4 ->
+
+  11 | 
+  12 | example def exprTyckError: Nat => tactic {
+  13 |   | {??} + {??}
+           ^--^
+
+Goal: Goal of type
+        Nat
+        (Normalized: Nat)
+      Context:
+
+In file $FILE:13:11 ->
+
+  11 | 
+  12 | example def exprTyckError: Nat => tactic {
+  13 |   | {??} + {??}
+                  ^--^
+
+Goal: Goal of type
+        Nat
+        (Normalized: Nat)
+      Context:
+
+In file $FILE:14:4 ->
+
+  12 | example def exprTyckError: Nat => tactic {
+  13 |   | {??} + {??}
+  14 |   | zero {??} -- this results in a tyck error (application not allowed here)
+           ^-------^
+
+Error: Unable to apply the expression
+         zero {??}
+       because the type of what you applied is not a Pi type, but instead:
+         Nat
+         (Normalized: Nat)
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tactic/hole-number-mismatch1.aya
+++ b/base/src/test/resources/failure/tactic/hole-number-mismatch1.aya
@@ -11,6 +11,5 @@ def overlap infixl + (a b : Nat) : Nat
 
 example def simpleTac1: Nat => tactic {
   | {??} + {??}
-  | tactic { | suc {??} | zero }
   | zero
 }

--- a/base/src/test/resources/failure/tactic/hole-number-mismatch1.aya.txt
+++ b/base/src/test/resources/failure/tactic/hole-number-mismatch1.aya.txt
@@ -1,7 +1,3 @@
-tactic {
-  | {??} + {??}
-  | zero
-}
 In file $FILE:13:4 ->
 
   11 | 

--- a/base/src/test/resources/failure/tactic/hole-number-mismatch1.aya.txt
+++ b/base/src/test/resources/failure/tactic/hole-number-mismatch1.aya.txt
@@ -1,0 +1,42 @@
+tactic {
+  | {??} + {??}
+  | zero
+}
+In file $FILE:13:4 ->
+
+  11 | 
+  12 | example def simpleTac1: Nat => tactic {
+  13 |   | {??} + {??}
+           ^--^
+
+Goal: Goal of type
+        Nat
+        (Normalized: Nat)
+      Context:
+
+In file $FILE:13:11 ->
+
+  11 | 
+  12 | example def simpleTac1: Nat => tactic {
+  13 |   | {??} + {??}
+                  ^--^
+
+Goal: Goal of type
+        Nat
+        (Normalized: Nat)
+      Context:
+
+In file $FILE:12:38 ->
+
+  10 | 
+  11 | 
+  12 | example def simpleTac1: Nat => tactic {
+                                             ^^
+  13 |   | {??} + {??}
+  14 |   | zero
+  15 | }
+
+Error: Expected 2 filler(s) in the tactic block, but found 1
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya
+++ b/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya
@@ -8,9 +8,9 @@ def overlap infixl + (a b : Nat) : Nat
 | suc a, b => suc (a + b)
 | a, suc b => suc (a + b)
 
-
-example def simpleTac1: Nat => tactic {
+example def simpleTac2: Nat => tactic {
   | {??} + {??}
   | tactic { | suc {??} | zero }
+  | zero
   | zero
 }

--- a/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya
+++ b/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya
@@ -10,7 +10,7 @@ def overlap infixl + (a b : Nat) : Nat
 
 example def simpleTac2: Nat => tactic {
   | {??} + {??}
-  | tactic { | suc {??} | zero }
+  | zero
   | zero
   | zero
 }

--- a/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya.txt
+++ b/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya.txt
@@ -10,22 +10,20 @@ In file $FILE:11:31 ->
   15 |   | zero
   16 | }
 
-Error: tactic {
-         | suc {??}
-         | zero
-       }
-       
+Error:  tactic {
+          | suc {??}
+          | zero
+        }
        is nested in
-       
-       tactic {
-         | {??} + {??}
-         | tactic {
-           | suc {??}
-           | zero
-         }
-         | zero
-         | zero
-       }
+         tactic {
+          | {??} + {??}
+          | tactic {
+            | suc {??}
+            | zero
+          }
+          | zero
+          | zero
+        }
 
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya.txt
+++ b/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya.txt
@@ -1,29 +1,40 @@
-In file $FILE:11:31 ->
+In file $FILE:12:4 ->
+
+  10 | 
+  11 | example def simpleTac2: Nat => tactic {
+  12 |   | {??} + {??}
+           ^--^
+
+Goal: Goal of type
+        Nat
+        (Normalized: Nat)
+      Context:
+
+In file $FILE:12:11 ->
+
+  10 | 
+  11 | example def simpleTac2: Nat => tactic {
+  12 |   | {??} + {??}
+                  ^--^
+
+Goal: Goal of type
+        Nat
+        (Normalized: Nat)
+      Context:
+
+In file $FILE:11:38 ->
 
    9 | | a, suc b => suc (a + b)
   10 | 
   11 | example def simpleTac2: Nat => tactic {
-                                      ^^
+                                             ^^
   12 |   | {??} + {??}
-  13 |   | tactic { | suc {??} | zero }
+  13 |   | zero
   14 |   | zero
   15 |   | zero
   16 | }
 
-Error:  tactic {
-          | suc {??}
-          | zero
-        }
-       is nested in
-         tactic {
-          | {??} + {??}
-          | tactic {
-            | suc {??}
-            | zero
-          }
-          | zero
-          | zero
-        }
+Error: Expected 2 filler(s) in the tactic block, but found 3
 
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya.txt
+++ b/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya.txt
@@ -2,14 +2,15 @@ tactic {
   | suc {??}
   | zero
 }
-In file $FILE:12:31 ->
+In file $FILE:11:31 ->
 
+   9 | | a, suc b => suc (a + b)
   10 | 
-  11 | 
-  12 | example def simpleTac1: Nat => tactic {
+  11 | example def simpleTac2: Nat => tactic {
                                       ^^
-  13 |   | {??} + {??}
-  14 |   | tactic { | suc {??} | zero }
+  12 |   | {??} + {??}
+  13 |   | tactic { | suc {??} | zero }
+  14 |   | zero
   15 |   | zero
   16 | }
 
@@ -26,6 +27,7 @@ Error: tactic {
            | suc {??}
            | zero
          }
+         | zero
          | zero
        }
 

--- a/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya.txt
+++ b/base/src/test/resources/failure/tactic/hole-number-mismatch2.aya.txt
@@ -1,7 +1,3 @@
-tactic {
-  | suc {??}
-  | zero
-}
 In file $FILE:11:31 ->
 
    9 | | a, suc b => suc (a + b)

--- a/base/src/test/resources/failure/tactic/hole-number-zero.aya
+++ b/base/src/test/resources/failure/tactic/hole-number-zero.aya
@@ -1,0 +1,14 @@
+public open data Nat
+| zero
+| suc Nat
+
+def overlap infixl + (a b : Nat) : Nat
+| zero, a => a
+| a, zero => a
+| suc a, b => suc (a + b)
+| a, suc b => suc (a + b)
+
+example def simpleTac1: Nat => tactic {
+  | {??}
+  | suc {??} -- every hole filler should have zero holes
+}

--- a/base/src/test/resources/failure/tactic/hole-number-zero.aya.txt
+++ b/base/src/test/resources/failure/tactic/hole-number-zero.aya.txt
@@ -1,0 +1,35 @@
+In file $FILE:12:4 ->
+
+  10 | 
+  11 | example def simpleTac1: Nat => tactic {
+  12 |   | {??}
+           ^--^
+
+Goal: Goal of type
+        Nat
+        (Normalized: Nat)
+      Context:
+
+In file $FILE:13:8 ->
+
+  11 | example def simpleTac1: Nat => tactic {
+  12 |   | {??}
+  13 |   | suc {??} -- every hole filler should have zero holes
+               ^--^
+
+Goal: Goal of type
+        Nat
+        (Normalized: Nat)
+      Context:
+
+In file $FILE:13:2 ->
+
+  11 | example def simpleTac1: Nat => tactic {
+  12 |   | {??}
+  13 |   | suc {??} -- every hole filler should have zero holes
+         ^--------^
+
+Error: Hole filler cannot have holes
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tactic/nested-tactic.aya
+++ b/base/src/test/resources/failure/tactic/nested-tactic.aya
@@ -1,0 +1,16 @@
+public open data Nat
+| zero
+| suc Nat
+
+def overlap infixl + (a b : Nat) : Nat
+| zero, a => a
+| a, zero => a
+| suc a, b => suc (a + b)
+| a, suc b => suc (a + b)
+
+
+example def simpleTac3: Nat => tactic {
+  | {??} + {??}
+  | tactic { | suc {??} | zero }
+  | zero
+}

--- a/base/src/test/resources/failure/tactic/nested-tactic.aya.txt
+++ b/base/src/test/resources/failure/tactic/nested-tactic.aya.txt
@@ -1,0 +1,33 @@
+tactic{
+  | suc {??}
+  | zero
+}
+In file $FILE:12:31 ->
+
+  10 | 
+  11 | 
+  12 | example def simpleTac3: Nat => tactic {
+                                      ^^
+  13 |   | {??} + {??}
+  14 |   | tactic { | suc {??} | zero }
+  15 |   | zero
+  16 | }
+
+Error: tactic{
+         | suc {??}
+         | zero
+       }
+       
+       is nested in
+       
+       tactic{
+         | {??} + {??}
+         | tactic{
+           | suc {??}
+           | zero
+         }
+         | zero
+       }
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tactic/nested-tactic.aya.txt
+++ b/base/src/test/resources/failure/tactic/nested-tactic.aya.txt
@@ -9,21 +9,19 @@ In file $FILE:12:31 ->
   15 |   | zero
   16 | }
 
-Error: tactic {
-         | suc {??}
-         | zero
-       }
-       
+Error:  tactic {
+          | suc {??}
+          | zero
+        }
        is nested in
-       
-       tactic {
-         | {??} + {??}
-         | tactic {
-           | suc {??}
-           | zero
-         }
-         | zero
-       }
+         tactic {
+          | {??} + {??}
+          | tactic {
+            | suc {??}
+            | zero
+          }
+          | zero
+        }
 
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/tactic/nested-tactic.aya.txt
+++ b/base/src/test/resources/failure/tactic/nested-tactic.aya.txt
@@ -1,7 +1,3 @@
-tactic {
-  | suc {??}
-  | zero
-}
 In file $FILE:12:31 ->
 
   10 | 

--- a/base/src/test/resources/failure/tactic/tac-head-list.aya
+++ b/base/src/test/resources/failure/tactic/tac-head-list.aya
@@ -1,0 +1,18 @@
+public open data Nat
+| zero
+| suc Nat
+
+def overlap infixl + (a b : Nat) : Nat
+| zero, a => a
+| a, zero => a
+| suc a, b => suc (a + b)
+| a, suc b => suc (a + b)
+
+
+example def tacHeadList: Nat => tactic {
+  { | {??}
+    | suc zero
+  }
+  { | suc {??} | zero }
+  | zero
+}

--- a/base/src/test/resources/failure/tactic/tac-head-list.aya.txt
+++ b/base/src/test/resources/failure/tactic/tac-head-list.aya.txt
@@ -1,0 +1,29 @@
+In file $FILE:12:39 ->
+
+  10 | 
+  11 | 
+  12 | example def tacHeadList: Nat => tactic {
+                                              ^^
+  13 |   { | {??}
+  14 |     | suc zero
+  15 |   }
+  16 |   { | suc {??} | zero }
+  17 |   | zero
+  18 | }
+
+Error: Tactic head of
+       {
+         {
+           | {??}
+           | suc zero
+         }
+         {
+           | suc {??}
+           | zero
+         }
+         | zero
+       }
+       cannot be a list
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tactic/tac-head-list2.aya
+++ b/base/src/test/resources/failure/tactic/tac-head-list2.aya
@@ -1,0 +1,12 @@
+public open data Nat
+| zero
+| suc Nat
+
+-- error at inference position
+example def tacHeadList2: Nat => tactic {
+  { | {??}
+    | suc zero
+  }
+  { | suc {??} | zero }
+  | zero
+} zero

--- a/base/src/test/resources/failure/tactic/tac-head-list2.aya.txt
+++ b/base/src/test/resources/failure/tactic/tac-head-list2.aya.txt
@@ -1,0 +1,29 @@
+In file $FILE:6:40 ->
+
+   4 | 
+   5 | -- error at inference position
+   6 | example def tacHeadList2: Nat => tactic {
+                                               ^^
+   7 |   { | {??}
+   8 |     | suc zero
+   9 |   }
+  10 |   { | suc {??} | zero }
+  11 |   | zero
+  12 | } zero
+
+Error: Tactic head of
+       {
+         {
+           | {??}
+           | suc zero
+         }
+         {
+           | suc {??}
+           | zero
+         }
+         | zero
+       }
+       cannot be a list
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tactic/tac-head-node-error.aya
+++ b/base/src/test/resources/failure/tactic/tac-head-node-error.aya
@@ -1,0 +1,15 @@
+public open data Nat
+| zero
+| suc Nat
+
+def overlap infixl + (a b : Nat) : Nat
+| zero, a => a
+| a, zero => a
+| suc a, b => suc (a + b)
+| a, suc b => suc (a + b)
+
+-- error at inference position
+example def headNodeError: Nat => tactic {
+  | zero {??}
+  | zero
+} zero

--- a/base/src/test/resources/failure/tactic/tac-head-node-error.aya.txt
+++ b/base/src/test/resources/failure/tactic/tac-head-node-error.aya.txt
@@ -1,0 +1,15 @@
+In file $FILE:13:4 ->
+
+  11 | -- error at inference position
+  12 | example def headNodeError: Nat => tactic {
+  13 |   | zero {??}
+           ^-------^
+
+Error: Unable to apply the expression
+         zero {??}
+       because the type of what you applied is not a Pi type, but instead:
+         Nat
+         (Normalized: Nat)
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tactic/tac-head-node-error2.aya
+++ b/base/src/test/resources/failure/tactic/tac-head-node-error2.aya
@@ -1,0 +1,15 @@
+public open data Nat
+| zero
+| suc Nat
+
+def overlap infixl + (a b : Nat) : Nat
+| zero, a => a
+| a, zero => a
+| suc a, b => suc (a + b)
+| a, suc b => suc (a + b)
+
+-- error at checking position
+example def headNodeError: Nat => tactic {
+  | zero {??}
+  | zero
+}

--- a/base/src/test/resources/failure/tactic/tac-head-node-error2.aya.txt
+++ b/base/src/test/resources/failure/tactic/tac-head-node-error2.aya.txt
@@ -1,0 +1,15 @@
+In file $FILE:13:4 ->
+
+  11 | -- error at checking position
+  12 | example def headNodeError: Nat => tactic {
+  13 |   | zero {??}
+           ^-------^
+
+Error: Unable to apply the expression
+         zero {??}
+       because the type of what you applied is not a Pi type, but instead:
+         Nat
+         (Normalized: Nat)
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/success/common/src/Data/Either.aya
+++ b/base/src/test/resources/success/common/src/Data/Either.aya
@@ -1,0 +1,3 @@
+public open data Either(A B: Type): Type
+  | lei A
+  | rei B

--- a/base/src/test/resources/success/common/src/Data/Maybe.aya
+++ b/base/src/test/resources/success/common/src/Data/Maybe.aya
@@ -1,0 +1,3 @@
+public open data Maybe (A: Type): Type
+| just A
+| none

--- a/base/src/test/resources/success/common/src/Data/Reflection.aya
+++ b/base/src/test/resources/success/common/src/Data/Reflection.aya
@@ -25,6 +25,8 @@ def Sort => List Lvl
 open data Term: Type
 ----------Ref----------------------
     | ref Name
+    | field-ref FieldDef
+    | meta-ref MataPat
 ----------Form---------------------
     | pi Param (cod: Term)
     | sig Tele
@@ -127,13 +129,19 @@ struct Hole: Type
 ---------------------------------------------------------------------------
 
 open data Pat: Type
-    | catch-all (explicit: Bool) Name (ty: Term)
-    | meta (explicit: Bool) (solution: Pat) (fakeBind: Name) (ty: Term)
-    | absurd (explicit: Bool)
-    | tup (explicit: Bool) (List Pat)
-    | ctor (explicit: Bool) Name (List Pat) DataDef CallArgs
-    | primPat (explicit: Bool) Name
+    | catch-all Explicit Name (ty: Term)
+    | meta MataPat
+    | absurd Explicit
+    | tup Explicit (List Pat)
+    | ctor Explicit Name (List Pat) DataDef CallArgs
+    | primPat Explicit Name
     | clause (List Pat)
+
+struct MetaPat: Type
+    | explicit: Explicit
+    | solution: Pat
+    | fakeBind: Name
+    | ty: Term
 
 struct Match: Type
     | pats: List Pat

--- a/base/src/test/resources/success/common/src/Data/Reflection.aya
+++ b/base/src/test/resources/success/common/src/Data/Reflection.aya
@@ -1,0 +1,140 @@
+open import Data::List
+open import Arith::Nat
+open import Data::Bool
+open import Data::Either
+
+def Name => Nat -- should be string
+def Param => Sig Name ** Term
+def Tele => List Param
+def Explicit => Bool
+def Arg(t: Type) => Sig t ** Explicit
+def Args(t: Type) => List (Arg t)
+def Meta => Nat -- should be a primitive
+
+data Lvl: Type
+    | const Nat
+    | ref Name (lift: Nat)
+
+def Sort => List Lvl
+
+
+---------------------------------------------------------------------------
+-----------------------------TERM------------------------------------------
+---------------------------------------------------------------------------
+
+open data Term: Type
+----------Ref----------------------
+    | ref Name
+----------Form---------------------
+    | pi Param (cod: Term)
+    | sig Tele
+    | univ Sort
+----------Intro--------------------
+    | lam Param (body: Term)
+    | new-struct StructDef CallArgs Tele
+----------Elim---------------------
+    | sig-proj Term Nat
+    | app Term (Arg Term)
+----------Call---------------------
+    | fn-call FnDef CallArgs
+    | prim-call PrimDef CallArgs
+    | data-call DataDef CallArgs
+    | struct-call StructDef CallArgs
+    | ctor-call CtorDef CtorArgs
+    | access-call StructDef Term AccessArgs
+    | hole-call Hole
+
+---------------------------------------------------------------------------
+-----------------------------DECLARATIONS----------------------------------
+---------------------------------------------------------------------------
+
+struct Modifiers: Type
+    | Opaque: Bool
+    | Inline: Bool
+    | Pattern: Bool
+    | Overlap: Bool
+
+struct FnDef: Type
+    | name: Name
+    | modifier: Modifiers
+    | params: Tele
+    | result-ty: Term
+    | param-lvls: List Lvl
+    | body: Either Term Match
+
+struct DataDef: Type
+    | name: Name
+    | tele: Tele
+    | tele-lvls: List Lvl
+    | sort: Sort
+    | body: List CtorDef
+
+struct CtorDef: Type
+    | name: Name
+    | ctor-tele: Tele
+    | data-name: Name
+    | data-tele: Tele
+
+struct StructDef: Type
+    | name: Name
+    | tele: Tele
+    | tele-lvls: List Lvl
+    | sort: Sort
+    | fields: List FieldDef
+
+struct FieldDef: Type
+    | name: Name
+    | field-tele: Tele
+    | struct-name: Name
+    | struct-tele: Tele
+
+struct PrimDef: Type
+    | name: Name
+    | ID: Name
+    | tele: Tele
+    | lvls: List Lvl
+    | result-ty: Term
+
+---------------------------------------------------------------------------
+----------------------------CALL ARGUMENTS---------------------------------
+---------------------------------------------------------------------------
+
+struct CallArgs: Type
+    | args: Args Term
+    | sort-args: Args Sort
+
+struct CtorArgs: Type
+    | args: Args Term
+    | sort-args: Args Sort
+    | data-args: Args Term
+
+struct AccessArgs: Type
+    | sort-args: Args Sort
+    | struct-args: Args Term
+    | field-args: Args Term
+
+---------------------------------------------------------------------------
+------------------------------HOLE-----------------------------------------
+---------------------------------------------------------------------------
+
+struct Hole: Type
+    | name: Meta
+    | ctxArgs: Args Term
+    | args: Args Term
+
+---------------------------------------------------------------------------
+-----------------------------PATTERNS--------------------------------------
+---------------------------------------------------------------------------
+
+open data Pat: Type
+    | catch-all (explicit: Bool) Name (ty: Term)
+    | meta (explicit: Bool) (solution: Pat) (fakeBind: Name) (ty: Term)
+    | absurd (explicit: Bool)
+    | tup (explicit: Bool) (List Pat)
+    | ctor (explicit: Bool) Name (List Pat) DataDef CallArgs
+    | primPat (explicit: Bool) Name
+    | clause (List Pat)
+
+struct Match: Type
+    | pats: List Pat
+    | body: Term

--- a/base/src/test/resources/success/common/src/Data/Reflection.aya
+++ b/base/src/test/resources/success/common/src/Data/Reflection.aya
@@ -26,7 +26,7 @@ open data Term: Type
 ----------Ref----------------------
     | ref Name
     | field-ref FieldDef
-    | meta-ref MataPat
+    | meta-ref MetaPat
 ----------Form---------------------
     | pi Param (cod: Term)
     | sig Tele
@@ -130,7 +130,7 @@ struct Hole: Type
 
 open data Pat: Type
     | catch-all Explicit Name (ty: Term)
-    | meta MataPat
+    | meta MetaPat
     | absurd Explicit
     | tup Explicit (List Pat)
     | ctor Explicit Name (List Pat) DataDef CallArgs

--- a/base/src/test/resources/success/common/src/Data/Reflection.aya
+++ b/base/src/test/resources/success/common/src/Data/Reflection.aya
@@ -11,9 +11,7 @@ def Arg(t: Type) => Sig t ** Explicit
 def Args(t: Type) => List (Arg t)
 def Meta => Nat -- should be a primitive
 
-data Lvl: Type
-    | const Nat
-    | ref Name (lift: Nat)
+def Lvl => Nat
 
 def Sort => List Lvl
 
@@ -128,7 +126,7 @@ struct Hole: Type
 -----------------------------PATTERNS--------------------------------------
 ---------------------------------------------------------------------------
 
-open data Pat: Type
+data Pat: Type
     | catch-all Explicit Name (ty: Term)
     | meta MetaPat
     | absurd Explicit
@@ -146,3 +144,22 @@ struct MetaPat: Type
 struct Match: Type
     | pats: List Pat
     | body: Term
+
+struct Field: Type
+| name: Name
+| bindings: Tele
+| body: Expr
+
+
+data Expr: Type
+| ref     Expr
+| lam     Name (dom: Expr) (body: Expr)
+| pi      Name (dom: Expr) (cod: Expr)
+| sigma   Name (fst: Expr) (snd: Expr)
+| univ    Lvl
+| app     Expr Expr
+| tup     (List Expr)
+| newEx   Expr (List Field)
+| hole    Name Expr
+
+

--- a/base/src/test/resources/success/src/SimpleTac.aya
+++ b/base/src/test/resources/success/src/SimpleTac.aya
@@ -1,0 +1,9 @@
+open import Arith::Nat
+
+example def simpleTac1: Nat => tactic | zero + zero
+
+example def simpleTac2: Nat => tactic {
+  | {??} + {??}
+  | zero
+  | zero
+}

--- a/base/src/test/resources/success/src/SimpleTac.aya
+++ b/base/src/test/resources/success/src/SimpleTac.aya
@@ -9,3 +9,12 @@ example def simpleTac2: Nat => tactic {
   }
   | zero
 }
+
+-- tactic can reference parameters in the parent context
+example def tacWithParam (a b: Nat) => tactic {
+  | {??} + {??}
+  { | suc {??}
+    | suc a
+  }
+  | suc b
+}

--- a/base/src/test/resources/success/src/SimpleTac.aya
+++ b/base/src/test/resources/success/src/SimpleTac.aya
@@ -4,6 +4,8 @@ example def simpleTac1: Nat => tactic | zero + zero
 
 example def simpleTac2: Nat => tactic {
   | {??} + {??}
-  | zero
+  { | suc {??}
+    | zero
+  }
   | zero
 }

--- a/base/src/test/resources/success/src/SimpleTac.aya
+++ b/base/src/test/resources/success/src/SimpleTac.aya
@@ -1,7 +1,9 @@
 open import Arith::Nat
 
+-- trivial tactic
 example def simpleTac1: Nat => tactic | zero + zero
 
+-- nested tactic nodes
 example def simpleTac2: Nat => tactic {
   | {??} + {??}
   { | suc {??}
@@ -18,3 +20,6 @@ example def tacWithParam (a b: Nat) => tactic {
   }
   | suc b
 }
+
+-- tactic can appear at application position
+example def badtac1: Nat => (tactic { | {??} | suc }) (tactic { | zero })

--- a/base/src/test/resources/success/src/SimpleTac.aya
+++ b/base/src/test/resources/success/src/SimpleTac.aya
@@ -22,4 +22,5 @@ example def tacWithParam (a b: Nat) => tactic {
 }
 
 -- tactic can appear at application position
-example def badtac1: Nat => (tactic { | {??} | suc }) (tactic { | zero })
+example def tacapp1: Nat => (tactic { | {??} | suc }) (tactic { | zero })
+example def tacapp2: Nat => (tactic | suc) zero

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
@@ -48,6 +48,7 @@ PRIM : 'prim';
 EXTENDS : 'extends';
 NEW_KW : 'new';
 PATTERN_KW : 'pattern';
+TACTIC : 'tactic';
 
 // Unimplemented but reserved
 DO_KW : 'do';

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -92,6 +92,7 @@ expr : atom                                 # single
      | SIGMA tele+ SUCHTHAT expr            # sigma
      | LAMBDA tele+ (IMPLIES expr?)?        # lam
      | MATCH exprList clauses               # match
+     | TACTIC LBRACE (BAR expr)* RBRACE     # tactic
      ;
 
 newArg : BAR weakId ids IMPLIES expr;

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -92,8 +92,12 @@ expr : atom                                 # single
      | SIGMA tele+ SUCHTHAT expr            # sigma
      | LAMBDA tele+ (IMPLIES expr?)?        # lam
      | MATCH exprList clauses               # match
-     | TACTIC LBRACE (BAR expr)* RBRACE     # tactic
+     | TACTIC tacNode                       # tactic
      ;
+
+tacNode : BAR expr
+        | LBRACE tacNode+ RBRACE
+        ;
 
 newArg : BAR weakId ids IMPLIES expr;
 // New body new body but you!

--- a/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
@@ -366,6 +366,7 @@ public record AyaProducer(
         visitForallTelescope(forall.tele()).view(),
         visitExpr(forall.expr()));
       // TODO: match
+      // TODO: tactic
       default -> throw new UnsupportedOperationException("TODO: " + ctx.getClass());
     };
   }

--- a/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
@@ -378,11 +378,11 @@ public record AyaProducer(
 
   private @NotNull Expr.TacNode visitTacNode(AyaParser.TacNodeContext tacNode) {
     if (tacNode.expr() != null) {
-      return new Expr.ExprTac(sourcePosOf(tacNode), visitExpr(tacNode.expr()));
+      return new Expr.TacNode.ExprTac(sourcePosOf(tacNode), visitExpr(tacNode.expr()));
     } else {
       var result = tacNode.tacNode()
         .stream().map(this::visitTacNode).collect(ImmutableSeq.factory());
-      return new Expr.ListExprTac(sourcePosOf(tacNode), result);
+      return new Expr.TacNode.ListExprTac(sourcePosOf(tacNode), result);
     }
   }
 

--- a/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
@@ -18,6 +18,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.aya.concrete.Expr;
 import org.aya.concrete.Pattern;
+import org.aya.concrete.TacNode;
 import org.aya.concrete.error.BadCounterexampleWarn;
 import org.aya.concrete.error.BadModifierWarn;
 import org.aya.concrete.error.ParseError;
@@ -376,13 +377,13 @@ public record AyaProducer(
     return new Expr.TacExpr(sourcePosOf(tactic), visitTacNode(tactic.tacNode()));
   }
 
-  private @NotNull Expr.TacNode visitTacNode(AyaParser.TacNodeContext tacNode) {
+  private @NotNull TacNode visitTacNode(AyaParser.TacNodeContext tacNode) {
     if (tacNode.expr() != null) {
-      return new Expr.TacNode.ExprTac(sourcePosOf(tacNode), visitExpr(tacNode.expr()));
+      return new TacNode.ExprTac(sourcePosOf(tacNode), visitExpr(tacNode.expr()));
     } else {
       var result = tacNode.tacNode()
         .stream().map(this::visitTacNode).collect(ImmutableSeq.factory());
-      return new Expr.TacNode.ListExprTac(sourcePosOf(tacNode), result);
+      return new TacNode.ListExprTac(sourcePosOf(tacNode), result);
     }
   }
 

--- a/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
@@ -366,9 +366,19 @@ public record AyaProducer(
         visitForallTelescope(forall.tele()).view(),
         visitExpr(forall.expr()));
       // TODO: match
-      // TODO: tactic
+      case AyaParser.TacticContext tactic -> visitTactic(tactic);
       default -> throw new UnsupportedOperationException("TODO: " + ctx.getClass());
     };
+  }
+
+  private @NotNull Expr visitTactic(AyaParser.TacticContext tactic) {
+    // return new TacticExpr(visitTacNode(tactic.tacNode()));
+    throw new UnsupportedOperationException();
+  }
+
+  private void visitTacNode(AyaParser.TacNodeContext tacNode) {
+    // TODO: return an instance of some sort of 'tactic node'
+    throw new UnsupportedOperationException();
   }
 
   private @NotNull Expr.Field visitField(AyaParser.NewArgContext na) {

--- a/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
@@ -107,7 +107,8 @@ public record AyaProducer(
     return unreachable(ctx);
   }
 
-  @NotNull private Remark visitRemark(AyaParser.RemarkContext remark) {
+  @NotNull
+  private Remark visitRemark(AyaParser.RemarkContext remark) {
     var sb = new StringBuilder();
     for (var docComment : remark.DOC_COMMENT()) {
       sb.append(docComment.getText().substring(3)).append("\n");
@@ -372,13 +373,17 @@ public record AyaProducer(
   }
 
   private @NotNull Expr visitTactic(AyaParser.TacticContext tactic) {
-    // return new TacticExpr(visitTacNode(tactic.tacNode()));
-    throw new UnsupportedOperationException();
+    return new Expr.TacExpr(sourcePosOf(tactic), visitTacNode(tactic.tacNode()));
   }
 
-  private void visitTacNode(AyaParser.TacNodeContext tacNode) {
-    // TODO: return an instance of some sort of 'tactic node'
-    throw new UnsupportedOperationException();
+  private @NotNull Expr.TacNode visitTacNode(AyaParser.TacNodeContext tacNode) {
+    if (tacNode.expr() != null) {
+      return new Expr.ExprTac(sourcePosOf(tacNode), visitExpr(tacNode.expr()));
+    } else {
+      var result = tacNode.tacNode()
+        .stream().map(this::visitTacNode).collect(ImmutableSeq.factory());
+      return new Expr.ListExprTac(sourcePosOf(tacNode), result);
+    }
   }
 
   private @NotNull Expr.Field visitField(AyaParser.NewArgContext na) {


### PR DESCRIPTION
- [x] Basic "Expr with hole" mechanism with stepwise refinement
- [x] Basic error reporting for tactics 
- [x] `ExprView` for expressions
- [x] Other minor improvements 
- [x] Isolate the tactic elaboration process

Currently, users can write code like [this](https://github.com/aya-prover/aya-dev/blob/062b2c09f8416aea33429f3388f8dbdbb41efa4a/base/src/test/resources/success/src/SimpleTac.aya), where users can create "tactic blocks" fill in holes in the "tactic head" one by one in the "tactic nodes" that follows, where these nodes can contain additional holes and be filled by nested nodes.

However, tactic blocks cannot be nested (see [this](https://github.com/aya-prover/aya-dev/blob/062b2c09f8416aea33429f3388f8dbdbb41efa4a/base/src/test/resources/failure/tactic/nested-tactic.aya)) because the holes are filled "in verbatim" from tactic node inputs. This means further tactic nodes will fill the first hole of the tactic head, and if this hole is contained in a tactic block it would be very problematic.

The result of elaborating tactic block is an expression that contains no holes (and no metas when elaborated into core term).