### PR TITLE
Move primitive related states to `TyckState`

### DIFF
--- a/base/src/main/java/org/aya/concrete/remark/Literate.java
+++ b/base/src/main/java/org/aya/concrete/remark/Literate.java
@@ -122,7 +122,7 @@ public sealed interface Literate extends Docile {
 
     private @NotNull Doc normalize(@NotNull Term term) {
       var mode = options.mode();
-      if (state == null) throw InternalException.unexpected("No tyck state");
+      if (state == null) throw new InternalException("No tyck state");
       return term.normalize(state, mode).toDoc(options.options());
     }
 

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -43,17 +43,12 @@ public final class PrimDef extends TopLevelDef {
     this(ref, ImmutableSeq.empty(), result, name);
   }
 
-  public static @NotNull CallTerm.Prim intervalCall() {
-    return new CallTerm.Prim(Factory.INSTANCE.getOption(ID.INTERVAL).get().ref(),
-      0, ImmutableSeq.empty());
-  }
-
   @Override public <P, R> R accept(@NotNull Visitor<P, R> visitor, P p) {
     return visitor.visitPrim(this, p);
   }
 
   public @NotNull Term unfold(@NotNull CallTerm.Prim primCall, @Nullable TyckState state) {
-    return Factory.INSTANCE.unfold(Objects.requireNonNull(ID.find(ref.name())), primCall, state);
+    return Objects.requireNonNull(state).primFactory().unfold(Objects.requireNonNull(ID.find(ref.name())), primCall, state);
   }
 
   public @NotNull ImmutableSeq<Term.Param> telescope() {
@@ -82,141 +77,148 @@ public final class PrimDef extends TopLevelDef {
     public @NotNull PrimDef supply(@NotNull DefVar<PrimDef, Decl.PrimDecl> ref) {
       return supplier.apply(ref);
     }
-
-    public static final @NotNull PrimSeed INTERVAL = new PrimSeed(
-      ID.INTERVAL,
-      (prim, state) -> prim,
-      ref -> new PrimDef(ref, FormTerm.Univ.ZERO, ID.INTERVAL),
-      ImmutableSeq.empty()
-    );
-    public static final @NotNull PrimDef.PrimSeed LEFT = new PrimSeed(
-      ID.LEFT,
-      (prim, state) -> prim,
-      ref -> new PrimDef(ref, intervalCall(), ID.LEFT),
-      ImmutableSeq.of(ID.INTERVAL)
-    );
-
-    // Right
-    public static final @NotNull PrimDef.PrimSeed RIGHT = new PrimSeed(
-      ID.RIGHT,
-      (prim, state) -> prim,
-      ref -> new PrimDef(ref, intervalCall(), ID.RIGHT),
-      ImmutableSeq.of(ID.INTERVAL)
-    );
-
-    /** Arend's coe */
-    private static @NotNull Term arcoe(CallTerm.@NotNull Prim prim, @Nullable TyckState state) {
-      var args = prim.args();
-      var argBase = args.get(1);
-      var argI = args.get(2);
-      var left = Factory.INSTANCE.getOption(ID.LEFT);
-      if (argI.term() instanceof CallTerm.Prim primCall && left.isNotEmpty() && primCall.ref() == left.get().ref)
-        return argBase.term();
-      var argA = args.get(0).term();
-
-      if (argA instanceof IntroTerm.Lambda lambda) {
-        var normalize = lambda.body().normalize(state, NormalizeMode.NF);
-        if (normalize.findUsages(lambda.param().ref()) == 0) return argBase.term();
-        else return new CallTerm.Prim(prim.ref(), prim.ulift(), ImmutableSeq.of(
-          new Arg<>(new IntroTerm.Lambda(lambda.param(), normalize), true), argBase, argI));
-      }
-      return prim;
-    }
-
-    public static final @NotNull PrimDef.PrimSeed ARCOE = new PrimSeed(ID.ARCOE, PrimSeed::arcoe, ref -> {
-      var paramA = new LocalVar("A");
-      var paramIToATy = new Term.Param(new LocalVar(Constants.ANONYMOUS_PREFIX), intervalCall(), true);
-      var paramI = new LocalVar("i");
-      var result = new FormTerm.Univ(0);
-      var paramATy = new FormTerm.Pi(paramIToATy, result);
-      var aRef = new RefTerm(paramA, 0);
-      var left = Factory.INSTANCE.getOption(ID.LEFT).get();
-      var baseAtLeft = new ElimTerm.App(aRef, new Arg<>(new CallTerm.Prim(left.ref, 0, ImmutableSeq.empty()), true));
-      return new PrimDef(
-        ref,
-        ImmutableSeq.of(
-          new Term.Param(paramA, paramATy, true),
-          new Term.Param(new LocalVar("base"), baseAtLeft, true),
-          new Term.Param(paramI, intervalCall(), true)
-        ),
-        new ElimTerm.App(aRef, new Arg<>(new RefTerm(paramI, 0), true)),
-        ID.ARCOE
-      );
-    }, ImmutableSeq.of(ID.INTERVAL, ID.LEFT));
-
-    private static @NotNull Tuple2<PrimDef, PrimDef> leftRight() {
-      return Tuple.of(
-        Factory.INSTANCE.getOption(ID.LEFT).get(),
-        Factory.INSTANCE.getOption(ID.RIGHT).get());
-    }
-
-    /** Involution, ~ in Cubical Agda */
-    private static @NotNull Term invol(CallTerm.@NotNull Prim prim, @Nullable TyckState state) {
-      var arg = prim.args().get(0).term().normalize(state, NormalizeMode.WHNF);
-      if (arg instanceof CallTerm.Prim primCall) {
-        var lr = leftRight();
-        var left = lr._1;
-        var right = lr._2;
-        if (primCall.ref() == left.ref)
-          return new CallTerm.Prim(right.ref, 0, ImmutableSeq.empty());
-        if (primCall.ref() == right.ref)
-          return new CallTerm.Prim(left.ref, 0, ImmutableSeq.empty());
-      }
-      return new CallTerm.Prim(prim.ref(), 0, ImmutableSeq.of(new Arg<>(arg, true)));
-    }
-
-    public static final @NotNull PrimDef.PrimSeed INVOL = new PrimSeed(ID.INVOL, PrimSeed::invol, ref -> new PrimDef(
-      ref,
-      ImmutableSeq.of(new Term.Param(new LocalVar("i"), intervalCall(), true)),
-      intervalCall(),
-      ID.INVOL
-    ), ImmutableSeq.of(ID.INTERVAL));
-
-    /** <code>/\</code> in CCHM, <code>I.squeeze</code> in Arend */
-    private static @NotNull Term squeezeLeft(CallTerm.@NotNull Prim prim, @Nullable TyckState state) {
-      var lhsArg = prim.args().get(0).term().normalize(state, NormalizeMode.WHNF);
-      var rhsArg = prim.args().get(1).term().normalize(state, NormalizeMode.WHNF);
-      var lr = leftRight();
-      var left = lr._1;
-      var right = lr._2;
-      if (lhsArg instanceof CallTerm.Prim lhs) {
-        if (lhs.ref() == left.ref) return lhs;
-        if (lhs.ref() == right.ref) return rhsArg;
-      } else if (rhsArg instanceof CallTerm.Prim rhs) {
-        if (rhs.ref() == left.ref) return rhs;
-        if (rhs.ref() == right.ref) return lhsArg;
-      }
-      return prim;
-    }
-
-
-    public static final @NotNull PrimDef.PrimSeed SQUEEZE_LEFT =
-      new PrimSeed(ID.SQUEEZE_LEFT, PrimSeed::squeezeLeft, ref -> new PrimDef(
-        ref,
-        ImmutableSeq.of(
-          new Term.Param(new LocalVar("i"), intervalCall(), true),
-          new Term.Param(new LocalVar("j"), intervalCall(), true)),
-        intervalCall(),
-        ID.SQUEEZE_LEFT
-      ), ImmutableSeq.of(ID.INTERVAL));
   }
 
   public static class Factory {
-    private final @NotNull EnumMap<@NotNull ID, @NotNull PrimDef> defs = new EnumMap<>(ID.class);
-    public static final @NotNull PrimDef.Factory INSTANCE = new Factory();
+    private final class Initializer {
+      public @NotNull CallTerm.Prim intervalCall() {
+        return new CallTerm.Prim(Factory.this.getOption(ID.INTERVAL).get().ref(),
+          0, ImmutableSeq.empty());
+      }
 
-    private Factory() {
+      public final @NotNull PrimSeed INTERVAL = new PrimSeed(
+        ID.INTERVAL,
+        (prim, state) -> prim,
+        ref -> new PrimDef(ref, FormTerm.Univ.ZERO, ID.INTERVAL),
+        ImmutableSeq.empty()
+      );
+      public final @NotNull PrimDef.PrimSeed LEFT = new PrimSeed(
+        ID.LEFT,
+        (prim, state) -> prim,
+        ref -> new PrimDef(ref, intervalCall(), ID.LEFT),
+        ImmutableSeq.of(ID.INTERVAL)
+      );
+
+      // Right
+      public final @NotNull PrimDef.PrimSeed RIGHT = new PrimSeed(
+        ID.RIGHT,
+        (prim, state) -> prim,
+        ref -> new PrimDef(ref, intervalCall(), ID.RIGHT),
+        ImmutableSeq.of(ID.INTERVAL)
+      );
+
+      /** Arend's coe */
+      private @NotNull Term arcoe(CallTerm.@NotNull Prim prim, @Nullable TyckState state) {
+        var args = prim.args();
+        var argBase = args.get(1);
+        var argI = args.get(2);
+        var left = Factory.this.getOption(ID.LEFT);
+        if (argI.term() instanceof CallTerm.Prim primCall && left.isNotEmpty() && primCall.ref() == left.get().ref)
+          return argBase.term();
+        var argA = args.get(0).term();
+
+        if (argA instanceof IntroTerm.Lambda lambda) {
+          var normalize = lambda.body().normalize(state, NormalizeMode.NF);
+          if (normalize.findUsages(lambda.param().ref()) == 0) return argBase.term();
+          else return new CallTerm.Prim(prim.ref(), prim.ulift(), ImmutableSeq.of(
+            new Arg<>(new IntroTerm.Lambda(lambda.param(), normalize), true), argBase, argI));
+        }
+        return prim;
+      }
+
+      public final @NotNull PrimDef.PrimSeed ARCOE = new PrimSeed(ID.ARCOE, this::arcoe, ref -> {
+        var paramA = new LocalVar("A");
+        var paramIToATy = new Term.Param(new LocalVar(Constants.ANONYMOUS_PREFIX), intervalCall(), true);
+        var paramI = new LocalVar("i");
+        var result = new FormTerm.Univ(0);
+        var paramATy = new FormTerm.Pi(paramIToATy, result);
+        var aRef = new RefTerm(paramA, 0);
+        var left = Factory.this.getOption(ID.LEFT).get();
+        var baseAtLeft = new ElimTerm.App(aRef, new Arg<>(new CallTerm.Prim(left.ref, 0, ImmutableSeq.empty()), true));
+        return new PrimDef(
+          ref,
+          ImmutableSeq.of(
+            new Term.Param(paramA, paramATy, true),
+            new Term.Param(new LocalVar("base"), baseAtLeft, true),
+            new Term.Param(paramI, intervalCall(), true)
+          ),
+          new ElimTerm.App(aRef, new Arg<>(new RefTerm(paramI, 0), true)),
+          ID.ARCOE
+        );
+      }, ImmutableSeq.of(ID.INTERVAL, ID.LEFT));
+
+      private @NotNull Tuple2<PrimDef, PrimDef> leftRight() {
+        return Tuple.of(
+          Factory.this.getOption(ID.LEFT).get(),
+          Factory.this.getOption(ID.RIGHT).get());
+      }
+
+      /** Involution, ~ in Cubical Agda */
+      private @NotNull Term invol(CallTerm.@NotNull Prim prim, @Nullable TyckState state) {
+        var arg = prim.args().get(0).term().normalize(state, NormalizeMode.WHNF);
+        if (arg instanceof CallTerm.Prim primCall) {
+          var lr = leftRight();
+          var left = lr._1;
+          var right = lr._2;
+          if (primCall.ref() == left.ref)
+            return new CallTerm.Prim(right.ref, 0, ImmutableSeq.empty());
+          if (primCall.ref() == right.ref)
+            return new CallTerm.Prim(left.ref, 0, ImmutableSeq.empty());
+        }
+        return new CallTerm.Prim(prim.ref(), 0, ImmutableSeq.of(new Arg<>(arg, true)));
+      }
+
+      public final @NotNull PrimDef.PrimSeed INVOL = new PrimSeed(ID.INVOL, this::invol, ref -> new PrimDef(
+        ref,
+        ImmutableSeq.of(new Term.Param(new LocalVar("i"), intervalCall(), true)),
+        intervalCall(),
+        ID.INVOL
+      ), ImmutableSeq.of(ID.INTERVAL));
+
+      /** <code>/\</code> in CCHM, <code>I.squeeze</code> in Arend */
+      private @NotNull Term squeezeLeft(CallTerm.@NotNull Prim prim, @Nullable TyckState state) {
+        var lhsArg = prim.args().get(0).term().normalize(state, NormalizeMode.WHNF);
+        var rhsArg = prim.args().get(1).term().normalize(state, NormalizeMode.WHNF);
+        var lr = leftRight();
+        var left = lr._1;
+        var right = lr._2;
+        if (lhsArg instanceof CallTerm.Prim lhs) {
+          if (lhs.ref() == left.ref) return lhs;
+          if (lhs.ref() == right.ref) return rhsArg;
+        } else if (rhsArg instanceof CallTerm.Prim rhs) {
+          if (rhs.ref() == left.ref) return rhs;
+          if (rhs.ref() == right.ref) return lhsArg;
+        }
+        return prim;
+      }
+
+      public final @NotNull PrimDef.PrimSeed SQUEEZE_LEFT =
+        new PrimSeed(ID.SQUEEZE_LEFT, this::squeezeLeft, ref -> new PrimDef(
+          ref,
+          ImmutableSeq.of(
+            new Term.Param(new LocalVar("i"), intervalCall(), true),
+            new Term.Param(new LocalVar("j"), intervalCall(), true)),
+          intervalCall(),
+          ID.SQUEEZE_LEFT
+        ), ImmutableSeq.of(ID.INTERVAL));
     }
 
-    private static final @NotNull Map<@NotNull ID, @NotNull PrimSeed> SEEDS = ImmutableSeq.of(
-        PrimSeed.INTERVAL,
-        PrimSeed.LEFT,
-        PrimSeed.RIGHT,
-        PrimSeed.ARCOE,
-        PrimSeed.SQUEEZE_LEFT,
-        PrimSeed.INVOL
-      ).map(seed -> Tuple.of(seed.name, seed))
-      .toImmutableMap();
+    private final @NotNull EnumMap<@NotNull ID, @NotNull PrimDef> defs = new EnumMap<>(ID.class);
+
+    private final @NotNull Map<@NotNull ID, @NotNull PrimSeed> SEEDS;
+
+    public Factory() {
+      var init = new Initializer();
+      SEEDS = ImmutableSeq.of(
+          init.INTERVAL,
+          init.LEFT,
+          init.RIGHT,
+          init.ARCOE,
+          init.SQUEEZE_LEFT,
+          init.INVOL
+        ).map(seed -> Tuple.of(seed.name, seed))
+        .toImmutableMap();
+    }
 
     public @NotNull PrimDef factory(@NotNull ID name, @NotNull DefVar<PrimDef, Decl.PrimDecl> ref) {
       assert !have(name);
@@ -245,7 +247,7 @@ public final class PrimDef extends TopLevelDef {
       return SEEDS.get(name).unfold.apply(primCall, state);
     }
 
-    public static final @NotNull ImmutableSeq<ID> LEFT_RIGHT = ImmutableSeq.of(ID.LEFT, ID.RIGHT);
+    public final @NotNull ImmutableSeq<ID> LEFT_RIGHT = ImmutableSeq.of(ID.LEFT, ID.RIGHT);
 
     public boolean leftOrRight(PrimDef core) {
       for (var primName : LEFT_RIGHT) {

--- a/base/src/main/java/org/aya/core/pat/PatMatcher.java
+++ b/base/src/main/java/org/aya/core/pat/PatMatcher.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
  * Matches a term with a pattern.
  *
  * @author ice1000
- * @apiNote Use {@link PatMatcher#tryBuildSubstArgs(LocalCtx, ImmutableSeq, SeqLike)} instead of instantiating the class directly.
+ * @apiNote Use {@link PatMatcher#tryBuildSubstArgs(PrimDef.Factory, LocalCtx, ImmutableSeq, SeqLike)} instead of instantiating the class directly.
  * @implNote The substitution built is made from parallel substitutions.
  */
 public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
@@ -34,33 +34,35 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
    * err(false) if fails positively, err(true) if fails negatively
    */
   public static Result<Subst, Boolean> tryBuildSubstArgs(
+    @NotNull PrimDef.Factory primFactory,
     @Nullable LocalCtx localCtx, @NotNull ImmutableSeq<@NotNull Pat> pats,
     @NotNull SeqLike<@NotNull Arg<@NotNull Term>> terms
   ) {
-    return tryBuildSubstTerms(localCtx, pats, terms.view().map(Arg::term));
+    return tryBuildSubstTerms(primFactory, localCtx, pats, terms.view().map(Arg::term));
   }
 
-  /** @see PatMatcher#tryBuildSubstArgs(LocalCtx, ImmutableSeq, SeqLike) */
+  /** @see PatMatcher#tryBuildSubstArgs(PrimDef.Factory, LocalCtx, ImmutableSeq, SeqLike) */
   public static Result<Subst, Boolean> tryBuildSubstTerms(
+    @NotNull PrimDef.Factory primFactory,
     @Nullable LocalCtx localCtx, @NotNull ImmutableSeq<@NotNull Pat> pats,
     @NotNull SeqView<@NotNull Term> terms
   ) {
     var matchy = new PatMatcher(new Subst(new MutableHashMap<>()), localCtx);
     try {
-      for (var pat : pats.zip(terms)) matchy.match(pat);
+      for (var pat : pats.zip(terms)) matchy.match(primFactory, pat);
       return Result.ok(matchy.subst());
     } catch (Mismatch mismatch) {
       return Result.err(mismatch.isBlocked);
     }
   }
 
-  private void match(@NotNull Pat pat, @NotNull Term term) throws Mismatch {
+  private void match(@NotNull PrimDef.Factory primFactory, @NotNull Pat pat, @NotNull Term term) throws Mismatch {
     switch (pat) {
       case Pat.Bind bind -> subst.addDirectly(bind.bind(), term);
       case Pat.Absurd ignored -> throw new InternalException("unreachable");
       case Pat.Prim prim -> {
         var core = prim.ref().core;
-        assert PrimDef.Factory.INSTANCE.leftOrRight(core);
+        assert primFactory.leftOrRight(core);
         switch (term) {
           case CallTerm.Prim primCall -> {
             if (primCall.ref() != prim.ref()) throw new Mismatch(false);
@@ -73,7 +75,7 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
         switch (term) {
           case CallTerm.Con conCall -> {
             if (ctor.ref() != conCall.ref()) throw new Mismatch(false);
-            visitList(ctor.params(), conCall.conArgs().view().map(Arg::term));
+            visitList(primFactory, ctor.params(), conCall.conArgs().view().map(Arg::term));
           }
           case RefTerm.MetaPat metaPat -> solve(pat, metaPat);
           default -> throw new Mismatch(true);
@@ -81,7 +83,7 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
       }
       case Pat.Tuple tuple -> {
         switch (term) {
-          case IntroTerm.Tuple tup -> visitList(tuple.pats(), tup.items());
+          case IntroTerm.Tuple tup -> visitList(primFactory, tuple.pats(), tup.items());
           case RefTerm.MetaPat metaPat -> solve(pat, metaPat);
           default -> throw new Mismatch(true);
         }
@@ -89,7 +91,7 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
       case Pat.Meta meta -> {
         var sol = meta.solution().value;
         assert sol != null : "Unsolved pattern " + meta;
-        match(sol, term);
+        match(primFactory, sol, term);
       }
     }
   }
@@ -104,13 +106,13 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
     todo.value = pat.rename(subst, localCtx, referee.explicit());
   }
 
-  private void visitList(ImmutableSeq<Pat> lpats, SeqLike<Term> terms) throws Mismatch {
+  private void visitList(@NotNull PrimDef.Factory primFactory, ImmutableSeq<Pat> lpats, SeqLike<Term> terms) throws Mismatch {
     assert lpats.sizeEquals(terms);
-    lpats.view().zip(terms).forEachChecked(this::match);
+    lpats.view().zip(terms).forEachChecked(t -> match(primFactory, t));
   }
 
-  private void match(@NotNull Tuple2<Pat, Term> pp) throws Mismatch {
-    match(pp._1, pp._2);
+  private void match(@NotNull PrimDef.Factory primFactory, @NotNull Tuple2<Pat, Term> pp) throws Mismatch {
+    match(primFactory, pp._1, pp._2);
   }
 
   private static final class Mismatch extends Exception {

--- a/base/src/main/java/org/aya/core/serde/CompiledAya.java
+++ b/base/src/main/java/org/aya/core/serde/CompiledAya.java
@@ -3,8 +3,8 @@
 package org.aya.core.serde;
 
 import kala.collection.immutable.ImmutableSeq;
-import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableHashMap;
+import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableMap;
 import kala.tuple.Unit;
 import org.aya.concrete.desugar.AyaBinOpSet;
@@ -119,7 +119,7 @@ public record CompiledAya(
   }
 
   public @NotNull ResolveInfo toResolveInfo(@NotNull ModuleLoader loader, @NotNull PhysicalModuleContext context, @NotNull SerTerm.DeState state) {
-    var resolveInfo = new ResolveInfo(context, ImmutableSeq.empty(), new AyaBinOpSet(context.reporter()));
+    var resolveInfo = new ResolveInfo(state.primFactory(), context, ImmutableSeq.empty(), new AyaBinOpSet(context.reporter()));
     shallowResolve(loader, resolveInfo);
     serDefs.forEach(serDef -> de(context, serDef, state));
     deOp(state, resolveInfo.opSet());

--- a/base/src/main/java/org/aya/core/serde/SerDef.java
+++ b/base/src/main/java/org/aya/core/serde/SerDef.java
@@ -123,7 +123,7 @@ public sealed interface SerDef extends Serializable {
     @Override
     public @NotNull Def de(SerTerm.@NotNull DeState state) {
       var defVar = DefVar.<PrimDef, Decl.PrimDecl>empty(name.id);
-      var def = PrimDef.Factory.INSTANCE.getOrCreate(name, defVar);
+      var def = state.primFactory().getOrCreate(name, defVar);
       state.putPrim(module, name, def.ref);
       return def;
     }

--- a/base/src/main/java/org/aya/core/serde/SerTerm.java
+++ b/base/src/main/java/org/aya/core/serde/SerTerm.java
@@ -26,10 +26,11 @@ import java.util.Objects;
 public sealed interface SerTerm extends Serializable {
   record DeState(
     @NotNull MutableMap<Seq<String>, MutableMap<String, DefVar<?, ?>>> defCache,
-    @NotNull MutableMap<Integer, LocalVar> localCache
+    @NotNull MutableMap<Integer, LocalVar> localCache,
+    @NotNull PrimDef.Factory primFactory
   ) {
-    public DeState() {
-      this(MutableMap.create(), MutableMap.create());
+    public DeState(@NotNull PrimDef.Factory primFactory) {
+      this(MutableMap.create(), MutableMap.create(), primFactory);
     }
 
     public @NotNull LocalVar var(@NotNull SimpVar var) {

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -85,7 +85,7 @@ public sealed interface Term extends AyaDocile permits
    *              Can be null only if we're absolutely sure that holes are frozen,
    *              like in the error messages.
    */
-  default @NotNull Term normalize(@Nullable TyckState state, @NotNull NormalizeMode mode) {
+  default @NotNull Term normalize(@NotNull TyckState state, @NotNull NormalizeMode mode) {
     if (mode == NormalizeMode.NULL) return this;
     if (mode == NormalizeMode.NF) return this.view().normalize(state).commit();
     return accept(new Normalizer(state), mode);

--- a/base/src/main/java/org/aya/core/visitor/TermView.java
+++ b/base/src/main/java/org/aya/core/visitor/TermView.java
@@ -19,37 +19,37 @@ import java.util.function.Function;
 public interface TermView {
   @NotNull Term initial();
 
-  default Term pre(Term term) {
+  default @NotNull Term pre(@NotNull Term term) {
     return term;
   }
 
-  default Term post(Term term) {
+  default @NotNull Term post(@NotNull Term term) {
     return term;
   }
 
-  private Term commit(Term term) {
+  private @NotNull Term commit(@NotNull Term term) {
     return post(traverse(pre(term)));
   }
 
-  private Term.Param commit(Term.Param param) {
+  private @NotNull Term.Param commit(@NotNull Term.Param param) {
     var type = commit(param.type());
     if (type == param.type()) return param;
     return new Term.Param(param, type);
   }
 
-  private Arg<Term> commit(Arg<Term> arg) {
+  private @NotNull Arg<Term> commit(@NotNull Arg<Term> arg) {
     var term = commit(arg.term());
     if (term == arg.term()) return arg;
     return new Arg<>(term, arg.explicit());
   }
 
-  private CallTerm.ConHead commit(CallTerm.ConHead head) {
+  private @NotNull CallTerm.ConHead commit(@NotNull CallTerm.ConHead head) {
     var args = head.dataArgs().map(this::commit);
     if (args.sameElements(head.dataArgs(), true)) return head;
     return new CallTerm.ConHead(head.dataRef(), head.ref(), head.ulift(), args);
   }
 
-  private Term traverse(Term term) {
+  private @NotNull Term traverse(@NotNull Term term) {
     return switch (term) {
       case FormTerm.Pi pi -> {
         var param = commit(pi.param());
@@ -152,23 +152,23 @@ public interface TermView {
     return subst.isEmpty() ? this : new TermOps.Subster(this, subst);
   }
 
-  default TermView normalize(TyckState state) {
+  default @NotNull TermView normalize(@NotNull TyckState state) {
     return new TermOps.Normalizer(this, state);
   }
 
-  default TermView postMap(Function<Term, Term> f) {
+  default @NotNull TermView postMap(@NotNull Function<Term, Term> f) {
     return new TermOps.Mapper(this, t -> t, f);
   }
 
-  default TermView preMap(Function<Term, Term> f) {
+  default @NotNull TermView preMap(@NotNull Function<Term, Term> f) {
     return new TermOps.Mapper(this, f, t -> t);
   }
 
-  default TermView map(Function<Term, Term> pre, Function<Term, Term> post) {
+  default @NotNull TermView map(@NotNull Function<Term, Term> pre, @NotNull Function<Term, Term> post) {
     return new TermOps.Mapper(this, pre, post);
   }
 
-  default TermView rename() {
+  default @NotNull TermView rename() {
     return new TermOps.Renamer(this);
   }
 }

--- a/base/src/main/java/org/aya/core/visitor/Unfolder.java
+++ b/base/src/main/java/org/aya/core/visitor/Unfolder.java
@@ -74,7 +74,7 @@ public interface Unfolder<P> extends TermFixpoint<P> {
 
   @Override @NotNull default Term visitPrimCall(@NotNull CallTerm.Prim prim, P p) {
     var state = state();
-    if (state == null) throw InternalException.unexpected("unfolding prims without TyckState");
+    if (state == null) throw new InternalException("unfolding prims without TyckState");
     return state.primFactory().unfold(prim.id(), prim, state());
   }
 
@@ -105,7 +105,7 @@ public interface Unfolder<P> extends TermFixpoint<P> {
     @NotNull ImmutableSeq<Matching> clauses
   ) {
     var state = state();
-    if (state == null) throw InternalException.unexpected("unfolding clauses without TyckState");
+    if (state == null) throw new InternalException("unfolding clauses without TyckState");
     for (var matchy : clauses) {
       var termSubst = PatMatcher.tryBuildSubstArgs(state.primFactory(), null, matchy.patterns(), args);
       if (termSubst.isOk()) {

--- a/base/src/main/java/org/aya/core/visitor/Zonker.java
+++ b/base/src/main/java/org/aya/core/visitor/Zonker.java
@@ -35,7 +35,7 @@ public record Zonker(
     return new Zonker(term.view(), tycker, MutableSinglyLinkedList.create());
   }
 
-  @Override public Term pre(Term term) {
+  @Override public @NotNull Term pre(@NotNull Term term) {
     stack.push(term);
     return switch (view.pre(term)) {
       case CallTerm.Hole hole -> {
@@ -55,7 +55,7 @@ public record Zonker(
     };
   }
 
-  @Override public Term post(Term term) {
+  @Override public @NotNull Term post(@NotNull Term term) {
     stack.pop();
     return view.post(term);
   }

--- a/base/src/main/java/org/aya/resolve/ResolveInfo.java
+++ b/base/src/main/java/org/aya/resolve/ResolveInfo.java
@@ -8,6 +8,7 @@ import kala.collection.mutable.MutableMap;
 import org.aya.concrete.desugar.AyaBinOpSet;
 import org.aya.concrete.stmt.BindBlock;
 import org.aya.concrete.stmt.Stmt;
+import org.aya.core.def.PrimDef;
 import org.aya.resolve.context.ModuleContext;
 import org.aya.tyck.order.TyckOrder;
 import org.aya.util.MutableGraph;
@@ -26,13 +27,14 @@ import org.jetbrains.annotations.NotNull;
 public record ResolveInfo(
   @NotNull ModuleContext thisModule,
   @NotNull ImmutableSeq<Stmt> program,
+  @NotNull PrimDef.Factory primFactory,
   @NotNull AyaBinOpSet opSet,
   @NotNull MutableMap<ImmutableSeq<String>, ResolveInfo> imports,
   @NotNull MutableList<ImmutableSeq<String>> reExports,
   @NotNull MutableGraph<TyckOrder> depGraph,
   @NotNull MutableMap<OpDecl, BindBlock> bindBlockRename
 ) {
-  public ResolveInfo(@NotNull ModuleContext thisModule, @NotNull ImmutableSeq<Stmt> thisProgram, @NotNull AyaBinOpSet opSet) {
-    this(thisModule, thisProgram, opSet, MutableMap.create(), MutableList.create(), MutableGraph.create(), MutableMap.create());
+  public ResolveInfo(@NotNull PrimDef.Factory primFactory, @NotNull ModuleContext thisModule, @NotNull ImmutableSeq<Stmt> thisProgram, @NotNull AyaBinOpSet opSet) {
+    this(thisModule, thisProgram, primFactory, opSet, MutableMap.create(), MutableList.create(), MutableGraph.create(), MutableMap.create());
   }
 }

--- a/base/src/main/java/org/aya/resolve/module/FileModuleLoader.java
+++ b/base/src/main/java/org/aya/resolve/module/FileModuleLoader.java
@@ -4,6 +4,7 @@ package org.aya.resolve.module;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.concrete.GenericAyaParser;
+import org.aya.core.def.PrimDef;
 import org.aya.generic.Constants;
 import org.aya.generic.util.InternalException;
 import org.aya.resolve.ResolveInfo;
@@ -23,6 +24,7 @@ public record FileModuleLoader(
   @NotNull Path basePath,
   @Override @NotNull Reporter reporter,
   @NotNull GenericAyaParser parser,
+  @NotNull PrimDef.Factory primFactory,
   Trace.@Nullable Builder builder
 ) implements ModuleLoader {
   @Override public @Nullable ResolveInfo load(@NotNull ImmutableSeq<@NotNull String> path, @NotNull ModuleLoader recurseLoader) {
@@ -30,7 +32,7 @@ public record FileModuleLoader(
     try {
       var program = parser.program(locator, sourcePath);
       var context = new EmptyContext(reporter, sourcePath).derive(path);
-      return tyckModule(builder, resolveModule(context, program, recurseLoader),  null);
+      return tyckModule(builder, resolveModule(primFactory, context, program, recurseLoader),  null);
     } catch (IOException e) {
       return null;
     }

--- a/base/src/main/java/org/aya/resolve/module/ModuleLoader.java
+++ b/base/src/main/java/org/aya/resolve/module/ModuleLoader.java
@@ -5,6 +5,7 @@ package org.aya.resolve.module;
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.concrete.desugar.AyaBinOpSet;
 import org.aya.concrete.stmt.Stmt;
+import org.aya.core.def.PrimDef;
 import org.aya.resolve.ModuleCallback;
 import org.aya.resolve.ResolveInfo;
 import org.aya.resolve.context.ModuleContext;
@@ -21,12 +22,13 @@ import org.jetbrains.annotations.Nullable;
  */
 public interface ModuleLoader {
   default <E extends Exception> @NotNull ResolveInfo tyckModule(
+    @NotNull PrimDef.Factory primFactory,
     @NotNull ModuleContext context,
     @NotNull ImmutableSeq<Stmt> program,
     @Nullable Trace.Builder builder,
     @Nullable ModuleCallback<E> onTycked
   ) throws E {
-    return tyckModule(builder, resolveModule(context, program, this), onTycked);
+    return tyckModule(builder, resolveModule(primFactory, context, program, this), onTycked);
   }
 
   default <E extends Exception> @NotNull ResolveInfo
@@ -45,11 +47,12 @@ public interface ModuleLoader {
   }
 
   default @NotNull ResolveInfo resolveModule(
+    @NotNull PrimDef.Factory primFactory,
     @NotNull ModuleContext context,
     @NotNull ImmutableSeq<Stmt> program,
     @NotNull ModuleLoader recurseLoader
   ) {
-    var resolveInfo = new ResolveInfo(context, program, new AyaBinOpSet(reporter()));
+    var resolveInfo = new ResolveInfo(primFactory, context, program, new AyaBinOpSet(reporter()));
     Stmt.resolve(program, resolveInfo, recurseLoader);
     return resolveInfo;
   }

--- a/base/src/main/java/org/aya/resolve/visitor/StmtShallowResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtShallowResolver.java
@@ -119,16 +119,17 @@ public record StmtShallowResolver(
         resolveOpInfo(decl, ctx);
       }
       case Decl.PrimDecl decl -> {
+        var factory = resolveInfo.primFactory();
         var name = decl.ref.name();
         var sourcePos = decl.sourcePos;
         var primID = PrimDef.ID.find(name);
         if (primID == null) context.reportAndThrow(new UnknownPrimError(sourcePos, name));
-        var lack = PrimDef.Factory.INSTANCE.checkDependency(primID);
+        var lack = factory.checkDependency(primID);
         if (lack.isNotEmpty() && lack.get().isNotEmpty())
           context.reportAndThrow(new PrimDependencyError(name, lack.get(), sourcePos));
-        else if (PrimDef.Factory.INSTANCE.have(primID))
+        else if (factory.have(primID))
           context.reportAndThrow(new RedefinitionPrimError(name, sourcePos));
-        PrimDef.Factory.INSTANCE.factory(primID, decl.ref);
+        factory.factory(primID, decl.ref);
         resolveDecl(decl, context);
       }
     }

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -31,15 +31,15 @@ import java.util.function.Consumer;
 /**
  * @author ice1000, kiva
  * @apiNote this class does not create {@link ExprTycker} instances itself,
- * but use the one passed to it. {@link StmtTycker#newTycker()} creates instances
+ * but use the one passed to it. {@link StmtTycker#newTycker(PrimDef.Factory)} creates instances
  * of expr tyckers.
  */
 public record StmtTycker(
   @NotNull Reporter reporter,
   Trace.@Nullable Builder traceBuilder
 ) {
-  public @NotNull ExprTycker newTycker() {
-    return new ExprTycker(reporter, traceBuilder);
+  public @NotNull ExprTycker newTycker(@NotNull PrimDef.Factory primFactory) {
+    return new ExprTycker(primFactory, reporter, traceBuilder);
   }
 
   private void tracing(@NotNull Consumer<Trace.@NotNull Builder> consumer) {

--- a/base/src/main/java/org/aya/tyck/TyckState.java
+++ b/base/src/main/java/org/aya/tyck/TyckState.java
@@ -8,6 +8,7 @@ import kala.tuple.Tuple;
 import kala.tuple.Tuple2;
 import kala.tuple.Unit;
 import org.aya.core.Meta;
+import org.aya.core.def.PrimDef;
 import org.aya.core.term.CallTerm;
 import org.aya.core.term.Term;
 import org.aya.core.visitor.TermConsumer;
@@ -32,10 +33,11 @@ import org.jetbrains.annotations.Nullable;
 public record TyckState(
   @NotNull MutableList<Eqn> eqns,
   @NotNull MutableList<WithPos<Meta>> activeMetas,
-  @NotNull MutableMap<@NotNull Meta, @NotNull Term> metas
+  @NotNull MutableMap<@NotNull Meta, @NotNull Term> metas,
+  @NotNull PrimDef.Factory primFactory
 ) {
-  public TyckState() {
-    this(MutableList.create(), MutableList.create(), MutableMap.create());
+  public TyckState(@NotNull PrimDef.Factory primFactory) {
+    this(MutableList.create(), MutableList.create(), MutableMap.create(), primFactory);
   }
 
   /**

--- a/base/src/main/java/org/aya/tyck/error/BadTypeError.java
+++ b/base/src/main/java/org/aya/tyck/error/BadTypeError.java
@@ -12,6 +12,7 @@ import org.aya.generic.util.NormalizeMode;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.doc.Style;
 import org.aya.ref.DefVar;
+import org.aya.tyck.TyckState;
 import org.aya.util.distill.AyaDocile;
 import org.aya.util.distill.DistillerOptions;
 import org.aya.util.error.SourcePos;
@@ -20,7 +21,8 @@ import org.jetbrains.annotations.NotNull;
 public record BadTypeError(
   @Override @NotNull Expr expr,
   @NotNull Term actualType, @NotNull Doc action,
-  @NotNull Doc thing, @NotNull AyaDocile desired
+  @NotNull Doc thing, @NotNull AyaDocile desired,
+  @NotNull TyckState state
 ) implements ExprProblem {
   @Override public @NotNull Severity level() {
     return Severity.ERROR;
@@ -32,7 +34,7 @@ public record BadTypeError(
       Doc.par(1, expr.toDoc(options)),
       Doc.sep(Doc.english("because the type"), thing, Doc.english("is not a"), Doc.cat(desired.toDoc(options), Doc.plain(",")), Doc.english("but instead:")),
       Doc.par(1, actualType.toDoc(options)),
-      Doc.par(1, Doc.parened(Doc.sep(Doc.plain("Normalized:"), actualType.normalize(null, NormalizeMode.NF).toDoc(options))))
+      Doc.par(1, Doc.parened(Doc.sep(Doc.plain("Normalized:"), actualType.normalize(state, NormalizeMode.NF).toDoc(options))))
     );
   }
 
@@ -48,51 +50,57 @@ public record BadTypeError(
     return Doc.empty();
   }
 
-  public static @NotNull BadTypeError pi(@NotNull Expr expr, @NotNull Term actualType) {
+  public static @NotNull BadTypeError pi(@NotNull TyckState state, @NotNull Expr expr, @NotNull Term actualType) {
     return new BadTypeError(expr, actualType, Doc.plain("apply"),
-      Doc.english("of what you applied"), options -> Doc.english("Pi type"));
+      Doc.english("of what you applied"), options -> Doc.english("Pi type"), state);
   }
 
-  public static @NotNull BadTypeError sigmaAcc(@NotNull Expr expr, int ix, @NotNull Term actualType) {
+  public static @NotNull BadTypeError sigmaAcc(@NotNull TyckState state, @NotNull Expr expr, int ix, @NotNull Term actualType) {
     return new BadTypeError(expr, actualType,
       Doc.sep(Doc.english("project the"), Doc.ordinal(ix), Doc.english("element of")),
       Doc.english("of what you projected on"),
-      options -> Doc.english("Sigma type"));
+      options -> Doc.english("Sigma type"),
+      state);
   }
 
-  public static @NotNull BadTypeError sigmaCon(@NotNull Expr expr, @NotNull Term actualType) {
+  public static @NotNull BadTypeError sigmaCon(@NotNull TyckState state, @NotNull Expr expr, @NotNull Term actualType) {
     return new BadTypeError(expr, actualType,
       Doc.sep(Doc.plain("construct")),
       Doc.english("you checks it against"),
-      options -> Doc.english("Sigma type"));
+      options -> Doc.english("Sigma type"),
+      state);
   }
 
-  public static @NotNull BadTypeError structAcc(@NotNull Expr expr, @NotNull String fieldName, @NotNull Term actualType) {
+  public static @NotNull BadTypeError structAcc(@NotNull TyckState state, @NotNull Expr expr, @NotNull String fieldName, @NotNull Term actualType) {
     return new BadTypeError(expr, actualType,
       Doc.sep(Doc.english("access field"), Doc.styled(Style.code(), Doc.plain(fieldName)), Doc.plain("of")),
       Doc.english("of what you accessed"),
-      options -> Doc.english("struct type"));
+      options -> Doc.english("struct type"),
+      state);
   }
 
-  public static @NotNull BadTypeError structCon(@NotNull Expr expr, @NotNull Term actualType) {
+  public static @NotNull BadTypeError structCon(@NotNull TyckState state, @NotNull Expr expr, @NotNull Term actualType) {
     return new BadTypeError(expr, actualType,
       Doc.sep(Doc.plain("construct")),
       Doc.english("you gave"),
-      options -> Doc.english("struct type"));
+      options -> Doc.english("struct type"),
+      state);
   }
 
-  public static @NotNull BadTypeError univ(@NotNull Expr expr, @NotNull Term actual) {
+  public static @NotNull BadTypeError univ(@NotNull TyckState state, @NotNull Expr expr, @NotNull Term actual) {
     return new BadTypeError(expr, actual,
       Doc.english("make sense of"),
       Doc.english("provided"),
-      options -> Doc.english("universe"));
+      options -> Doc.english("universe"),
+      state);
   }
 
-  public static @NotNull BadTypeError lamParam(@NotNull Expr lamExpr, @NotNull AyaDocile paramType,
+  public static @NotNull BadTypeError lamParam(@NotNull TyckState state, @NotNull Expr lamExpr, @NotNull AyaDocile paramType,
                                                @NotNull Term actualParamType) {
     return new BadTypeError(lamExpr, actualParamType,
       Doc.english("apply or construct"),
       Doc.english("of the lambda parameter"),
-      paramType);
+      paramType,
+      state);
   }
 }

--- a/base/src/main/java/org/aya/tyck/error/UnifyError.java
+++ b/base/src/main/java/org/aya/tyck/error/UnifyError.java
@@ -8,6 +8,7 @@ import org.aya.core.term.Term;
 import org.aya.generic.ExprProblem;
 import org.aya.generic.util.NormalizeMode;
 import org.aya.pretty.doc.Doc;
+import org.aya.tyck.TyckState;
 import org.aya.tyck.unify.DefEq;
 import org.aya.util.distill.DistillerOptions;
 import org.jetbrains.annotations.NotNull;
@@ -16,7 +17,8 @@ public record UnifyError(
   @Override @NotNull Expr expr,
   @NotNull Term expected,
   @NotNull Term actual,
-  @NotNull DefEq.FailureData failureData
+  @NotNull DefEq.FailureData failureData,
+  @NotNull TyckState state
 ) implements ExprProblem {
   @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
     var actualDoc = actual.toDoc(options);
@@ -25,13 +27,13 @@ public record UnifyError(
       Doc.par(1, expr.toDoc(options)),
       Doc.english("of type"),
       Doc.par(1, actualDoc));
-    var actualNFDoc = actual.normalize(null, NormalizeMode.NF).toDoc(options);
+    var actualNFDoc = actual.normalize(state, NormalizeMode.NF).toDoc(options);
     if (!actualNFDoc.equals(actualDoc))
       buf.append(Doc.par(1, Doc.parened(Doc.sep(Doc.plain("Normalized:"), actualNFDoc))));
     var expectedDoc = expected.toDoc(options);
     buf.append(Doc.english("against the type"));
     buf.append(Doc.par(1, expectedDoc));
-    var expectedNFDoc = expected.normalize(null, NormalizeMode.NF).toDoc(options);
+    var expectedNFDoc = expected.normalize(state, NormalizeMode.NF).toDoc(options);
     if (!expectedNFDoc.equals(expectedDoc))
       buf.append(Doc.par(1, Doc.parened(Doc.sep(Doc.plain("Normalized:"), expectedNFDoc))));
     var failureLhs = failureData.lhs().toDoc(options);

--- a/base/src/main/java/org/aya/tyck/pat/Conquer.java
+++ b/base/src/main/java/org/aya/tyck/pat/Conquer.java
@@ -6,7 +6,6 @@ import kala.collection.immutable.ImmutableSeq;
 import kala.tuple.Tuple;
 import org.aya.core.Matching;
 import org.aya.core.def.Def;
-import org.aya.core.def.PrimDef;
 import org.aya.core.pat.Pat;
 import org.aya.core.pat.PatMatcher;
 import org.aya.core.pat.PatToTerm;
@@ -48,10 +47,11 @@ public record Conquer(
   }
 
   public void visit(@NotNull Pat pat, int nth) {
+    var primFactory = tycker.state.primFactory();
     switch (pat) {
       case Pat.Prim prim -> {
         var core = prim.ref().core;
-        assert PrimDef.Factory.INSTANCE.leftOrRight(core);
+        assert primFactory.leftOrRight(core);
       }
       case Pat.Ctor ctor -> {
         var params = ctor.params();
@@ -59,7 +59,7 @@ public record Conquer(
         var conditions = ctor.ref().core.clauses;
         for (int i = 0, size = conditions.size(); i < size; i++) {
           var condition = conditions.get(i);
-          var matchy = PatMatcher.tryBuildSubstTerms(null, params, condition.patterns().view().map(Pat::toTerm));
+          var matchy = PatMatcher.tryBuildSubstTerms(primFactory, null, params, condition.patterns().view().map(Pat::toTerm));
           if (matchy.isOk()) {
             var ctx = new MapLocalCtx();
             condition.patterns().forEach(tern -> tern.storeBindings(ctx));

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -201,9 +201,10 @@ public record PatClassifier(
           // so in case we need coverage, report an error on this pattern matching
           if (coverage) reporter.report(new ClausesProblem.SplitInterval(pos, lrSplit.get()));
           // For `left` and `right`,
-          for (var primName : PrimDef.Factory.LEFT_RIGHT) {
+          var primFactory = state.primFactory();
+          for (var primName : primFactory.LEFT_RIGHT) {
             builder.append(new PatTree(primName.id, explicit, 0));
-            var prim = PrimDef.Factory.INSTANCE.getOption(primName);
+            var prim = primFactory.getOption(primName);
             var patClass = new MCT.Leaf<>(subPatsSeq.view()
               // Filter out all patterns that matches it,
               .mapIndexedNotNull((ix, subPats) -> matches(subPats, ix, prim)).map(MCT.SubPats::ix).toImmutableSeq());

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -178,7 +178,7 @@ public final class PatTycker {
           && prim.ref().core.id == PrimDef.ID.INTERVAL
           && var instanceof DefVar<?, ?> defVar
           && defVar.core instanceof PrimDef def
-          && PrimDef.Factory.LEFT_RIGHT.contains(def.id)
+          && exprTycker.state.primFactory().LEFT_RIGHT.contains(def.id)
         ) yield new Pat.Prim(ctor.explicit(), (DefVar<PrimDef, Decl.PrimDecl>) defVar);
         var realCtor = selectCtor(term, var, ctor);
         if (realCtor == null) yield randomPat(pattern, term);
@@ -391,7 +391,7 @@ public final class PatTycker {
 
   public static Result<Subst, Boolean>
   mischa(CallTerm.Data dataCall, CtorDef ctor, @Nullable LocalCtx ctx, @NotNull TyckState state) {
-    if (ctor.pats.isNotEmpty()) return PatMatcher.tryBuildSubstTerms(ctx, ctor.pats, dataCall.args().view()
+    if (ctor.pats.isNotEmpty()) return PatMatcher.tryBuildSubstTerms(state.primFactory(), ctx, ctor.pats, dataCall.args().view()
       .map(arg -> arg.term().normalize(state, NormalizeMode.WHNF)));
     else return Result.ok(Unfolder.buildSubst(Def.defTele(dataCall.ref()), dataCall.args()));
   }

--- a/base/src/test/java/org/aya/concrete/DesugarTest.java
+++ b/base/src/test/java/org/aya/concrete/DesugarTest.java
@@ -4,6 +4,7 @@ package org.aya.concrete;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.concrete.desugar.AyaBinOpSet;
+import org.aya.core.def.PrimDef;
 import org.aya.pretty.doc.Doc;
 import org.aya.resolve.ResolveInfo;
 import org.aya.resolve.context.EmptyContext;
@@ -49,7 +50,7 @@ public class DesugarTest {
   }
 
   private void desugarAndPretty(@NotNull @NonNls @Language("TEXT") String code, @NotNull @NonNls @Language("TEXT") String pretty) {
-    var resolveInfo = new ResolveInfo(new EmptyContext(ThrowingReporter.INSTANCE, Path.of("dummy")).derive("dummy"), ImmutableSeq.empty(), new AyaBinOpSet(ThrowingReporter.INSTANCE));
+    var resolveInfo = new ResolveInfo(new PrimDef.Factory(), new EmptyContext(ThrowingReporter.INSTANCE, Path.of("dummy")).derive("dummy"), ImmutableSeq.empty(), new AyaBinOpSet(ThrowingReporter.INSTANCE));
     var stmt = ParseTest.parseStmt(code);
     stmt.forEach(s -> s.desugar(resolveInfo));
     assertEquals(pretty.trim(), Doc.vcat(stmt.view()

--- a/base/src/test/java/org/aya/concrete/VisitorTest.java
+++ b/base/src/test/java/org/aya/concrete/VisitorTest.java
@@ -5,7 +5,6 @@ package org.aya.concrete;
 import kala.collection.mutable.MutableList;
 import kala.tuple.Unit;
 import org.aya.concrete.visitor.StmtConsumer;
-import org.aya.core.def.PrimDef;
 import org.aya.util.error.Global;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
@@ -16,13 +15,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VisitorTest {
   @BeforeAll public static void enableTest() {
-    PrimDef.Factory.INSTANCE.clear();
     Global.NO_RANDOM_NAME = true;
     Global.UNITE_SOURCE_POS = true;
   }
 
   @AfterAll public static void exit() {
-    PrimDef.Factory.INSTANCE.clear();
     Global.reset();
   }
 

--- a/base/src/test/java/org/aya/core/DistillerTest.java
+++ b/base/src/test/java/org/aya/core/DistillerTest.java
@@ -3,13 +3,11 @@
 package org.aya.core;
 
 import org.aya.core.def.FnDef;
-import org.aya.core.def.PrimDef;
 import org.aya.pretty.doc.Doc;
 import org.aya.tyck.TyckDeclTest;
 import org.aya.util.distill.DistillerOptions;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -79,7 +77,6 @@ public class DistillerTest {
         | id_l (a: A) : op id a = a
       """;
     assertFalse(declDoc(code).renderToTeX().isEmpty());
-    tearDown();
     assertFalse(declCDoc(code).renderToTeX().isEmpty());
   }
 
@@ -88,22 +85,18 @@ public class DistillerTest {
       def infix = (A B : Type) => A
       def test1 (X : Type) => Pi (A : Type) -> A ulift = X
       def test2 (X : Type) => (Pi (A : Type) -> A) ulift = X
-      """);
+      """)._2;
     var test1 = ((FnDef) decls.get(1)).body.getLeftValue();
     var test2 = ((FnDef) decls.get(2)).body.getLeftValue();
     assertEquals("Pi (A : Type 0) -> A = X", test1.toDoc(DistillerOptions.informative()).debugRender());
     assertEquals("(Pi (A : Type 0) -> A) = X", test2.toDoc(DistillerOptions.informative()).debugRender());
   }
 
-  @AfterEach public void tearDown() {
-    PrimDef.Factory.INSTANCE.clear();
-  }
-
   private @NotNull Doc declDoc(@Language("TEXT") String text) {
-    return Doc.vcat(TyckDeclTest.successTyckDecls(text).map(d -> d.toDoc(DistillerOptions.debug())));
+    return Doc.vcat(TyckDeclTest.successTyckDecls(text)._2.map(d -> d.toDoc(DistillerOptions.debug())));
   }
 
   private @NotNull Doc declCDoc(@Language("TEXT") String text) {
-    return Doc.vcat(TyckDeclTest.successDesugarDecls(text).map(s -> s.toDoc(DistillerOptions.debug())));
+    return Doc.vcat(TyckDeclTest.successDesugarDecls(text)._2.map(s -> s.toDoc(DistillerOptions.debug())));
   }
 }

--- a/base/src/test/java/org/aya/core/SuedeTest.java
+++ b/base/src/test/java/org/aya/core/SuedeTest.java
@@ -3,21 +3,15 @@
 package org.aya.core;
 
 import kala.tuple.Unit;
-import org.aya.core.def.PrimDef;
 import org.aya.core.serde.SerTerm;
 import org.aya.core.serde.Serializer;
 import org.aya.tyck.TyckDeclTest;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class SuedeTest {
-  @BeforeEach public void cleanup() {
-    PrimDef.Factory.INSTANCE.clear();
-  }
-
   @Test public void nat() {
     suedeAll("""
       open data Nat : Type | zero | suc Nat
@@ -69,9 +63,10 @@ public class SuedeTest {
   }
 
   private void suedeAll(@Language("TEXT") @NotNull String code) {
-    var state = new SerTerm.DeState();
+    var res = TyckDeclTest.successTyckDecls(code);
+    var state = new SerTerm.DeState(res._1);
     var serializer = new Serializer(new Serializer.State());
-    TyckDeclTest.successTyckDecls(code).view()
+    res._2.view()
       .map(def -> def.accept(serializer, Unit.unit()))
       .map(ser -> ser.de(state))
       .forEach(Assertions::assertNotNull);

--- a/base/src/test/java/org/aya/core/UsagesTest.java
+++ b/base/src/test/java/org/aya/core/UsagesTest.java
@@ -24,7 +24,7 @@ public class UsagesTest {
        | pos n => n
        | neg n => n
       open data Fin (n : Nat) : Type | suc m => fzero | suc m => fsuc (Fin m)
-      """).forEach(def -> {
+      """)._2.forEach(def -> {
       var of = MutableList.<Def>create();
       def.accept(RefFinder.HEADER_AND_BODY, of);
       assertFalse(of.isEmpty());

--- a/base/src/test/java/org/aya/experiments/NormalizeHugeChurch.java
+++ b/base/src/test/java/org/aya/experiments/NormalizeHugeChurch.java
@@ -5,6 +5,7 @@ package org.aya.experiments;
 import org.aya.core.def.FnDef;
 import org.aya.generic.util.NormalizeMode;
 import org.aya.tyck.TyckDeclTest;
+import org.aya.tyck.TyckState;
 import org.aya.util.distill.DistillerOptions;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ public class NormalizeHugeChurch {
 
   @Test @Timeout(value = 5000) public void ppBench() {
     var startup = System.currentTimeMillis();
-    var decls = TyckDeclTest.successTyckDecls("""
+    var res = TyckDeclTest.successTyckDecls("""
       def Num => Pi (x : Type 0) -> (x -> x) -> (x -> x)
       def zero : Num => \\ A f x => x
       def suc (a : Num) : Num => \\ A f x => a A f (f x)
@@ -28,6 +29,8 @@ public class NormalizeHugeChurch {
       def #16 : Num => mul #4 #4
       def #256 : Num => add #16 #16
       """);
+    var state = new TyckState(res._1);
+    var decls = res._2;
     var last = ((FnDef) decls.last()).body.getLeftValue();
     println("Tyck: " + (System.currentTimeMillis() - startup));
     startup = System.currentTimeMillis();

--- a/base/src/test/java/org/aya/test/LibraryTest.java
+++ b/base/src/test/java/org/aya/test/LibraryTest.java
@@ -3,6 +3,7 @@
 package org.aya.test;
 
 import org.aya.cli.library.LibraryCompiler;
+import org.aya.core.def.PrimDef;
 import org.aya.util.FileUtil;
 import org.aya.util.reporter.ThrowingReporter;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,6 @@ public class LibraryTest {
   }
 
   private static int compile() throws IOException {
-    return LibraryCompiler.compile(ThrowingReporter.INSTANCE, TestRunner.flags(), DIR);
+    return LibraryCompiler.compile(new PrimDef.Factory(), ThrowingReporter.INSTANCE, TestRunner.flags(), DIR);
   }
 }

--- a/base/src/test/java/org/aya/test/TestRunner.java
+++ b/base/src/test/java/org/aya/test/TestRunner.java
@@ -5,7 +5,6 @@ package org.aya.test;
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.cli.single.CompilerFlags;
 import org.aya.cli.single.SingleFileCompiler;
-import org.aya.core.def.PrimDef;
 import org.aya.prelude.GeneratedVersion;
 import org.aya.util.FileUtil;
 import org.aya.util.error.Global;
@@ -34,7 +33,6 @@ public class TestRunner {
   };
 
   @BeforeAll public static void startDash() {
-    PrimDef.Factory.INSTANCE.clear();
     Global.NO_RANDOM_NAME = true;
   }
 

--- a/base/src/test/java/org/aya/tyck/PatCCTest.java
+++ b/base/src/test/java/org/aya/tyck/PatCCTest.java
@@ -4,6 +4,7 @@ package org.aya.tyck;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.core.def.FnDef;
+import org.aya.core.def.PrimDef;
 import org.aya.core.pat.Pat;
 import org.aya.core.term.Term;
 import org.aya.tyck.pat.PatClassifier;
@@ -19,47 +20,50 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * CC = coverage and confluence
  */
 public class PatCCTest {
-  public static @NotNull ImmutableSeq<MCT.PatClass<Term, PatClassifier.PatErr>> testClassify(@NotNull FnDef fnDef) {
+  public static @NotNull ImmutableSeq<MCT.PatClass<Term, PatClassifier.PatErr>> testClassify(@NotNull PrimDef.Factory factory, @NotNull FnDef fnDef) {
     var clauses = fnDef.body.getRightValue().map(Pat.Preclause::weaken);
-    return PatClassifier.classify(clauses, fnDef.telescope, new TyckState(), ThrowingReporter.INSTANCE, SourcePos.NONE, true).toSeq();
+    return PatClassifier.classify(clauses, fnDef.telescope, new TyckState(factory), ThrowingReporter.INSTANCE, SourcePos.NONE, true).toSeq();
   }
 
   @Test public void addCC() {
-    var decls = TyckDeclTest.successTyckDecls("""
+    var res = TyckDeclTest.successTyckDecls("""
       open data Nat : Type | zero | suc Nat
       def overlap add (a b : Nat) : Nat
        | zero, b => b
        | a, zero => a
        | suc a, b => suc (add a b)
        | a, suc b => suc (add a b)""");
-    var classified = testClassify((FnDef) decls.get(1));
+    var decls = res._2;
+    var classified = testClassify(res._1, (FnDef) decls.get(1));
     assertEquals(4, classified.size());
     classified.forEach(cls ->
       assertEquals(2, cls.contents().size()));
   }
 
   @Test public void maxCC() {
-    var decls = TyckDeclTest.successTyckDecls("""
+    var res = TyckDeclTest.successTyckDecls("""
       open data Nat : Type | zero | suc Nat
       def max (a b : Nat) : Nat
        | zero, b => b
        | a, zero => a
        | suc a, suc b => suc (max a b)""");
-    var classified = testClassify((FnDef) decls.get(1));
+    var decls = res._2;
+    var classified = testClassify(res._1, (FnDef) decls.get(1));
     assertEquals(4, classified.size());
     assertEquals(3, classified.filter(patClass -> patClass.contents().sizeEquals(1)).size());
     assertEquals(1, classified.filter(patClass -> patClass.contents().sizeEquals(2)).size());
   }
 
   @Test public void tupleCC() {
-    var decls = TyckDeclTest.successTyckDecls("""
+    var res = TyckDeclTest.successTyckDecls("""
       open data Nat : Type | zero | suc Nat
       open data Unit : Type | unit Nat
       def max (a : Sig Nat ** Nat) (b : Unit) : Nat
        | (zero, b), unit x => b
        | (a, zero), y => a
        | (suc a, suc b), unit y => suc (max (a, b) (unit zero))""");
-    var classified = testClassify((FnDef) decls.get(2));
+    var decls = res._2;
+    var classified = testClassify(res._1, (FnDef) decls.get(2));
     assertEquals(4, classified.size());
     assertEquals(3, classified.filter(patClass -> patClass.contents().sizeEquals(1)).size());
     assertEquals(1, classified.filter(patClass -> patClass.contents().sizeEquals(2)).size());

--- a/base/src/test/java/org/aya/tyck/TracingTest.java
+++ b/base/src/test/java/org/aya/tyck/TracingTest.java
@@ -31,10 +31,11 @@ public class TracingTest {
   }
 
   @NotNull private Trace.Builder mkBuilder(@Language("TEXT") String code) {
-    var decls = TyckDeclTest.successDesugarDecls(code);
+    var res =  TyckDeclTest.successDesugarDecls(code);
+    var decls = res._2;
     var builder = new Trace.Builder();
     decls.forEach(decl -> {
-      if (decl instanceof Decl signatured) TyckDeclTest.tyck(signatured, builder);
+      if (decl instanceof Decl signatured) TyckDeclTest.tyck(res._1, signatured, builder);
     });
     return builder;
   }

--- a/base/src/test/java/org/aya/tyck/TyckDeclTest.java
+++ b/base/src/test/java/org/aya/tyck/TyckDeclTest.java
@@ -3,13 +3,14 @@
 package org.aya.tyck;
 
 import kala.collection.immutable.ImmutableSeq;
+import kala.tuple.Tuple;
+import kala.tuple.Tuple2;
 import org.aya.cli.parse.AyaParserImpl;
-import org.aya.concrete.ParseTest;
 import org.aya.concrete.desugar.AyaBinOpSet;
 import org.aya.concrete.stmt.Decl;
 import org.aya.concrete.stmt.Stmt;
 import org.aya.core.def.Def;
-import org.aya.core.def.FnDef;
+import org.aya.core.def.PrimDef;
 import org.aya.resolve.ResolveInfo;
 import org.aya.resolve.context.EmptyContext;
 import org.aya.resolve.context.ModuleContext;
@@ -26,39 +27,31 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TyckDeclTest {
-  public static Def tyck(@NotNull Decl decl, Trace.@Nullable Builder builder) {
+  public static Def tyck(@NotNull PrimDef.Factory factory, @NotNull Decl decl, Trace.@Nullable Builder builder) {
     var tycker = new StmtTycker(ThrowingReporter.INSTANCE, builder);
-    return tycker.tyck(decl, tycker.newTycker());
+    return tycker.tyck(decl, tycker.newTycker(factory));
   }
 
-  private FnDef successTyckFn(@NotNull @NonNls @Language("TEXT") String code) {
-    var decl = ParseTest.parseDecl(code)._1;
-    var ctx = new EmptyContext(ThrowingReporter.INSTANCE, Path.of("TestSource")).derive("decl");
-    resolve(ImmutableSeq.of(decl), ctx);
-    var def = tyck(decl, null);
-    assertNotNull(def);
-    assertTrue(def instanceof FnDef);
-    return ((FnDef) def);
-  }
-
-  public static @NotNull ImmutableSeq<Stmt> successDesugarDecls(@Language("TEXT") @NonNls @NotNull String text) {
+  public static @NotNull Tuple2<PrimDef.Factory, ImmutableSeq<Stmt>> successDesugarDecls(@Language("TEXT") @NonNls @NotNull String text) {
     var decls = new AyaParserImpl(ThrowingReporter.INSTANCE).program(new SourceFile("114514", Path.of("114514"), text));
     var ctx = new EmptyContext(ThrowingReporter.INSTANCE, Path.of("TestSource")).derive("decl");
-    resolve(decls, ctx);
-    return decls;
+    var factory = resolve(decls, ctx);
+    return Tuple.of(factory, decls);
   }
 
-  private static void resolve(@NotNull ImmutableSeq<Stmt> decls, @NotNull ModuleContext module) {
-    Stmt.resolve(decls, new ResolveInfo(module, decls, new AyaBinOpSet(ThrowingReporter.INSTANCE)), EmptyModuleLoader.INSTANCE);
+  private static @NotNull PrimDef.Factory resolve(@NotNull ImmutableSeq<Stmt> decls, @NotNull ModuleContext module) {
+    var primFactory = new PrimDef.Factory();
+    Stmt.resolve(decls, new ResolveInfo(primFactory, module, decls, new AyaBinOpSet(ThrowingReporter.INSTANCE)), EmptyModuleLoader.INSTANCE);
     assertNotNull(module.underlyingFile());
+    return primFactory;
   }
 
-  public static @NotNull ImmutableSeq<Def> successTyckDecls(@Language("TEXT") @NonNls @NotNull String text) {
-    return successDesugarDecls(text).view()
-      .map(i -> i instanceof Decl s ? tyck(s, null) : null)
-      .filter(Objects::nonNull).toImmutableSeq();
+  public static @NotNull Tuple2<PrimDef.Factory, ImmutableSeq<Def>> successTyckDecls(@Language("TEXT") @NonNls @NotNull String text) {
+    var res = successDesugarDecls(text);
+    return Tuple.of(res._1, res._2.view()
+      .map(i -> i instanceof Decl s ? tyck(res._1, s, null) : null)
+      .filter(Objects::nonNull).toImmutableSeq());
   }
 }

--- a/cli/src/main/java/org/aya/cli/Main.java
+++ b/cli/src/main/java/org/aya/cli/Main.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.cli;
 
@@ -9,6 +9,7 @@ import org.aya.cli.single.CliReporter;
 import org.aya.cli.single.CompilerFlags;
 import org.aya.cli.single.SingleFileCompiler;
 import org.aya.cli.utils.MainArgs;
+import org.aya.core.def.PrimDef;
 import org.aya.tyck.trace.MdUnicodeTrace;
 import org.aya.tyck.trace.Trace;
 import picocli.CommandLine;
@@ -49,7 +50,7 @@ public class Main extends MainArgs implements Callable<Integer> {
 
     if (action.compile.isLibrary || action.compile.isRemake) {
       // TODO: move to a new tool
-      return LibraryCompiler.compile(reporter, flags, filePath);
+      return LibraryCompiler.compile(new PrimDef.Factory(), reporter, flags, filePath);
     }
     var traceBuilder = enableTrace ? new Trace.Builder() : null;
     var compiler = new SingleFileCompiler(reporter, null, traceBuilder, distillOptions);

--- a/cli/src/main/java/org/aya/cli/library/LibraryCompiler.java
+++ b/cli/src/main/java/org/aya/cli/library/LibraryCompiler.java
@@ -13,6 +13,7 @@ import org.aya.cli.single.CompilerFlags;
 import org.aya.cli.utils.AyaCompiler;
 import org.aya.concrete.stmt.QualifiedID;
 import org.aya.generic.util.InternalException;
+import org.aya.core.def.PrimDef;
 import org.aya.resolve.module.CachedModuleLoader;
 import org.aya.resolve.module.ModuleLoader;
 import org.aya.util.FileUtil;
@@ -45,22 +46,22 @@ public class LibraryCompiler {
     this.owner = owner;
   }
 
-  public static @NotNull LibraryCompiler newCompiler(@NotNull Reporter reporter, @NotNull CompilerFlags flags, @NotNull LibraryOwner owner) {
-    return new LibraryCompiler(reporter, flags, owner, new LibraryModuleLoader.United());
+  public static @NotNull LibraryCompiler newCompiler(@NotNull PrimDef.Factory primFactory, @NotNull Reporter reporter, @NotNull CompilerFlags flags, @NotNull LibraryOwner owner) {
+    return new LibraryCompiler(reporter, flags, owner, new LibraryModuleLoader.United(primFactory));
   }
 
-  public static @NotNull LibraryCompiler newCompiler(@NotNull Reporter reporter, @NotNull CompilerFlags flags, @NotNull Path libraryRoot) throws IOException {
+  public static @NotNull LibraryCompiler newCompiler(@NotNull PrimDef.Factory primFactory, @NotNull Reporter reporter, @NotNull CompilerFlags flags, @NotNull Path libraryRoot) throws IOException {
     var config = LibraryConfigData.fromLibraryRoot(FileUtil.canonicalize(libraryRoot));
     var owner = DiskLibraryOwner.from(config);
-    return newCompiler(reporter, flags, owner);
+    return newCompiler(primFactory, reporter, flags, owner);
   }
 
-  public static int compile(@NotNull Reporter reporter, @NotNull CompilerFlags flags, @NotNull Path libraryRoot) throws IOException {
+  public static int compile(@NotNull PrimDef.Factory primFactory, @NotNull Reporter reporter, @NotNull CompilerFlags flags, @NotNull Path libraryRoot) throws IOException {
     if (!Files.exists(libraryRoot)) {
       reporter.reportString("Specified library root does not exist: " + libraryRoot);
       return 1;
     }
-    return newCompiler(reporter, flags, libraryRoot).start();
+    return newCompiler(primFactory, reporter, flags, libraryRoot).start();
   }
 
   private void resolveImports(@NotNull LibrarySource source) throws IOException {

--- a/cli/src/main/java/org/aya/cli/library/LibraryModuleLoader.java
+++ b/cli/src/main/java/org/aya/cli/library/LibraryModuleLoader.java
@@ -7,6 +7,7 @@ import org.aya.cli.library.source.LibraryOwner;
 import org.aya.cli.library.source.LibrarySource;
 import org.aya.cli.utils.AyaCompiler;
 import org.aya.core.def.Def;
+import org.aya.core.def.PrimDef;
 import org.aya.core.serde.CompiledAya;
 import org.aya.core.serde.SerTerm;
 import org.aya.core.serde.Serializer;
@@ -45,7 +46,7 @@ record LibraryModuleLoader(
   @NotNull CountingReporter reporter,
   @NotNull LibraryOwner owner,
   @NotNull LibraryModuleLoader.United states
-) implements ModuleLoader {
+  ) implements ModuleLoader {
   private void saveCompiledCore(@NotNull LibrarySource file, @NotNull ResolveInfo resolveInfo, @NotNull ImmutableSeq<Def> defs) {
     try {
       var coreFile = file.coreFile();
@@ -82,7 +83,7 @@ record LibraryModuleLoader(
     var program = source.program().value;
     assert program != null;
     var context = new EmptyContext(reporter(), sourcePath).derive(mod);
-    var resolveInfo = resolveModule(context, program, recurseLoader);
+    var resolveInfo = resolveModule(states.primFactory, context, program, recurseLoader);
     source.resolveInfo().value = resolveInfo;
     return tyckModule(null, resolveInfo, (moduleResolve, defs) -> {
       source.tycked().value = defs;
@@ -104,9 +105,9 @@ record LibraryModuleLoader(
     }
   }
 
-  record United(@NotNull SerTerm.DeState de, @NotNull Serializer.State ser) {
-    public United() {
-      this(new SerTerm.DeState(), new Serializer.State());
+  record United(@NotNull SerTerm.DeState de, @NotNull Serializer.State ser, @NotNull PrimDef.Factory primFactory) {
+    public United(@NotNull PrimDef.Factory primFactory) {
+      this(new SerTerm.DeState(primFactory), new Serializer.State(), primFactory);
     }
   }
 }

--- a/cli/src/main/java/org/aya/cli/utils/AyaCompiler.java
+++ b/cli/src/main/java/org/aya/cli/utils/AyaCompiler.java
@@ -6,7 +6,6 @@ import kala.collection.immutable.ImmutableSeq;
 import kala.function.CheckedRunnable;
 import org.aya.cli.single.CompilerFlags;
 import org.aya.core.def.Def;
-import org.aya.core.def.PrimDef;
 import org.aya.core.serde.CompiledAya;
 import org.aya.core.serde.Serializer;
 import org.aya.generic.util.InternalException;
@@ -36,8 +35,6 @@ public class AyaCompiler {
     } catch (InterruptException e) {
       reporter.reportString(e.stage().name() + " interrupted due to:");
       if (flags.interruptedTrace()) e.printStackTrace();
-    } finally {
-      PrimDef.Factory.INSTANCE.clear();
     }
     if (reporter.noError()) {
       reporter.reportString(flags.message().successNotion());

--- a/lsp/src/main/java/org/aya/lsp/server/AyaServer.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaServer.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.lsp.server;
 
@@ -29,12 +29,12 @@ public class AyaServer implements LanguageClientAware, LanguageServer {
 
   @JsonRequest("aya/computeType")
   public @NotNull CompletableFuture<@NotNull ComputeTermResult> computeType(ComputeTermResult.Params input) {
-    return CompletableFuture.supplyAsync(() -> service.computeTerm(input, ComputeTerm.Kind.Type));
+    return CompletableFuture.supplyAsync(() -> service.computeTerm(input, ComputeTerm.Kind.type(service.sharedPrimFactory)));
   }
 
   @JsonRequest("aya/computeNF")
   public @NotNull CompletableFuture<@NotNull ComputeTermResult> computeNF(ComputeTermResult.Params input) {
-    return CompletableFuture.supplyAsync(() -> service.computeTerm(input, ComputeTerm.Kind.Nf));
+    return CompletableFuture.supplyAsync(() -> service.computeTerm(input, ComputeTerm.Kind.nf(service.sharedPrimFactory)));
   }
 
   @Override public void connect(@NotNull LanguageClient client) {


### PR DESCRIPTION
## Changes
- `normalize` of Terms now accept a `@NotNull TyckState` (it is `@Nullable` before), because it holds primitives.
- `PrimDef.Factory` is no longer a singleton, instead, it is created every time the compilation task was created. (except for LSP, where we only clear the primitive factory)

## Tasks
- [x] Get rid of global states
- [x] Update tests
- [x] Test these changes in LSP, make sure it does not break any LSP feature