### PR TITLE
Java integer backed literals

### DIFF
--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -227,6 +227,7 @@ public sealed interface Pat extends AyaDocile {
     }
   }
 
+  /** TODO[literal]: literal type needs meta-solving for first-class patterns */
   record ShapedInt(
     @Override int repr,
     @Override @NotNull AyaShape shape,
@@ -263,6 +264,10 @@ public sealed interface Pat extends AyaDocile {
 
     @Override public @NotNull Pat destruct(int repr) {
       return new Pat.ShapedInt(repr, this.shape, this.type, true);
+    }
+
+    @Override public @NotNull Pat self() {
+      return this;
     }
   }
 

--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -10,6 +10,7 @@ import org.aya.concrete.Expr;
 import org.aya.concrete.stmt.Decl;
 import org.aya.core.Matching;
 import org.aya.core.def.CtorDef;
+import org.aya.core.repr.AyaShape;
 import org.aya.core.term.CallTerm;
 import org.aya.core.term.RefTerm;
 import org.aya.core.term.Term;
@@ -222,6 +223,38 @@ public sealed interface Pat extends AyaDocile {
 
     @Override public void storeBindings(@NotNull LocalCtx localCtx) {
       // do nothing
+    }
+  }
+
+  record ShapedInt(
+    int integer,
+    @NotNull AyaShape shape,
+    // TODO: remove the type
+    @NotNull CallTerm.Data type,
+    boolean explicit
+  ) implements Pat {
+    @Override public @NotNull Expr toExpr(@NotNull SourcePos pos) {
+      return new Expr.LitIntExpr(pos, integer);
+    }
+
+    @Override public @NotNull Pat rename(@NotNull Subst subst, @NotNull LocalCtx localCtx, boolean explicit) {
+      return this;
+    }
+
+    @Override public @NotNull Pat zonk(@NotNull Tycker tycker) {
+      return this;
+    }
+
+    @Override public @NotNull Pat inline() {
+      return this;
+    }
+
+    @Override public void storeBindings(@NotNull LocalCtx localCtx) {
+      // do nothing
+    }
+
+    public @NotNull Pat constructorForm() {
+      return shape.transformPat(this, type);
     }
   }
 

--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -15,6 +15,7 @@ import org.aya.core.term.CallTerm;
 import org.aya.core.term.RefTerm;
 import org.aya.core.term.Term;
 import org.aya.core.visitor.Subst;
+import org.aya.core.visitor.Zonker;
 import org.aya.distill.BaseDistiller;
 import org.aya.distill.CoreDistiller;
 import org.aya.generic.Arg;
@@ -243,7 +244,8 @@ public sealed interface Pat extends AyaDocile {
     }
 
     @Override public @NotNull Pat zonk(@NotNull Tycker tycker) {
-      return this;
+      // The cast must succeed
+      return new Pat.ShapedInt(repr, shape, (CallTerm.Data) tycker.zonk(type), explicit);
     }
 
     @Override public @NotNull Pat inline() {

--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author kiva, ice1000
  */
-@Debug.Renderer(text = "toTerm().toDoc(DistillerOptions.DEBUG).debugRender()")
+@Debug.Renderer(text = "toTerm().toDoc(DistillerOptions.debug()).debugRender()")
 public sealed interface Pat extends AyaDocile {
   boolean explicit();
   default @NotNull Term toTerm() {

--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -15,7 +15,6 @@ import org.aya.core.term.CallTerm;
 import org.aya.core.term.RefTerm;
 import org.aya.core.term.Term;
 import org.aya.core.visitor.Subst;
-import org.aya.core.visitor.Zonker;
 import org.aya.distill.BaseDistiller;
 import org.aya.distill.CoreDistiller;
 import org.aya.generic.Arg;
@@ -24,6 +23,7 @@ import org.aya.generic.util.InternalException;
 import org.aya.pretty.doc.Doc;
 import org.aya.ref.DefVar;
 import org.aya.ref.LocalVar;
+import org.aya.tyck.TyckState;
 import org.aya.tyck.Tycker;
 import org.aya.tyck.env.LocalCtx;
 import org.aya.tyck.env.SeqLocalCtx;
@@ -228,7 +228,13 @@ public sealed interface Pat extends AyaDocile {
     }
   }
 
-  /** TODO[literal]: literal type needs meta-solving for first-class patterns */
+  /**
+   * TODO[literal]: literal type needs meta-solving for first-class patterns. Possible changes:
+   *  - Make {@link ShapedInt#type} a {@link Term} instead of {@link CallTerm.Data}
+   *  - Call {@link ShapedInt#constructorForm()} with a {@link org.aya.tyck.TyckState}
+   *  - Call {@link ShapedInt#sameValue(TyckState, Shaped)} with a {@link org.aya.tyck.TyckState}
+   *  see https://github.com/aya-prover/aya-dev/pull/400#discussion_r862371935
+   */
   record ShapedInt(
     @Override int repr,
     @Override @NotNull AyaShape shape,

--- a/base/src/main/java/org/aya/core/pat/PatMatcher.java
+++ b/base/src/main/java/org/aya/core/pat/PatMatcher.java
@@ -86,7 +86,7 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
       case Pat.ShapedInt lit -> {
         switch (term) {
           case LitTerm.ShapedInt litTerm -> {
-            if (!lit.sameValue(litTerm)) throw new Mismatch(true);
+            if (!lit.sameValue(null, litTerm)) throw new Mismatch(true);
           }
           // TODO[literal]: We may convert constructor call to literals to avoid possible stack overflow?
           case CallTerm.Con con -> match(lit.constructorForm(), con);

--- a/base/src/main/java/org/aya/core/pat/PatMatcher.java
+++ b/base/src/main/java/org/aya/core/pat/PatMatcher.java
@@ -86,8 +86,7 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
       case Pat.ShapedInt lit -> {
         switch (term) {
           case LitTerm.ShapedInt litTerm -> {
-            if (lit.shape() != litTerm.shape()) throw new Mismatch(true);
-            if (lit.integer() != litTerm.integer()) throw new Mismatch(true);
+            if (!lit.sameValue(litTerm)) throw new Mismatch(true);
           }
           // TODO[literal]: We may convert constructor call to literals to avoid possible stack overflow?
           case CallTerm.Con con -> match(lit.constructorForm(), con);

--- a/base/src/main/java/org/aya/core/pat/PatMatcher.java
+++ b/base/src/main/java/org/aya/core/pat/PatMatcher.java
@@ -61,7 +61,7 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
             visitList(ctor.params(), conCall.conArgs().view().map(Arg::term));
           }
           case RefTerm.MetaPat metaPat -> solve(pat, metaPat);
-          // TODO: convert con to literal?
+          // TODO[literal]: We may convert constructor call to literals to avoid possible stack overflow?
           case LitTerm.ShapedInt litTerm -> match(ctor, litTerm.constructorForm());
           default -> throw new Mismatch(true);
         }
@@ -89,10 +89,10 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
             if (lit.shape() != litTerm.shape()) throw new Mismatch(true);
             if (lit.integer() != litTerm.integer()) throw new Mismatch(true);
           }
-          case CallTerm.Con con -> {
-            // TODO: convert con to literal?
-            match(lit.constructorForm(), term);
-          }
+          // TODO[literal]: We may convert constructor call to literals to avoid possible stack overflow?
+          case CallTerm.Con con -> match(lit.constructorForm(), con);
+          // we only need to handle matching both literals, otherwise we just rematch it
+          // with constructor form to reuse the code as much as possible (like solving MetaPats).
           default -> match(lit.constructorForm(), term);
         }
       }

--- a/base/src/main/java/org/aya/core/pat/PatMatcher.java
+++ b/base/src/main/java/org/aya/core/pat/PatMatcher.java
@@ -86,7 +86,7 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
       case Pat.ShapedInt lit -> {
         switch (term) {
           case LitTerm.ShapedInt litTerm -> {
-            if (!lit.sameValue(null, litTerm)) throw new Mismatch(true);
+            if (!lit.sameValue(null, litTerm)) throw new Mismatch(false);
           }
           // TODO[literal]: We may convert constructor call to literals to avoid possible stack overflow?
           case CallTerm.Con con -> match(lit.constructorForm(), con);

--- a/base/src/main/java/org/aya/core/pat/PatToTerm.java
+++ b/base/src/main/java/org/aya/core/pat/PatToTerm.java
@@ -26,6 +26,7 @@ public class PatToTerm {
       case Pat.Tuple tuple -> new IntroTerm.Tuple(tuple.pats().map(this::visit));
       case Pat.Meta meta -> new RefTerm.MetaPat(meta, 0);
       case Pat.End end -> end.isRight() ? PrimTerm.End.RIGHT : PrimTerm.End.LEFT;
+      case Pat.ShapedInt lit -> new LitTerm.ShapedInt(lit.integer(), lit.shape(), lit.type());
     };
   }
 

--- a/base/src/main/java/org/aya/core/pat/PatToTerm.java
+++ b/base/src/main/java/org/aya/core/pat/PatToTerm.java
@@ -26,7 +26,7 @@ public class PatToTerm {
       case Pat.Tuple tuple -> new IntroTerm.Tuple(tuple.pats().map(this::visit));
       case Pat.Meta meta -> new RefTerm.MetaPat(meta, 0);
       case Pat.End end -> end.isRight() ? PrimTerm.End.RIGHT : PrimTerm.End.LEFT;
-      case Pat.ShapedInt lit -> new LitTerm.ShapedInt(lit.integer(), lit.shape(), lit.type());
+      case Pat.ShapedInt lit -> new LitTerm.ShapedInt(lit.repr(), lit.shape(), lit.type());
     };
   }
 

--- a/base/src/main/java/org/aya/core/pat/PatUnify.java
+++ b/base/src/main/java/org/aya/core/pat/PatUnify.java
@@ -45,7 +45,7 @@ public record PatUnify(@NotNull Subst lhsSubst, @NotNull Subst rhsSubst, @NotNul
       case Pat.ShapedInt lhsInt -> {
         switch (rhs) {
           case Pat.ShapedInt rhsInt -> {
-            if (!lhsInt.sameValue(rhsInt)) reportError(lhs, rhs);
+            if (!lhsInt.sameValue(null, rhsInt)) reportError(lhs, rhs);
           }
           case Pat.Ctor ctor -> unifyLitWithCtor(ctor, lhsInt, lhs);
           // Try one more time in case we add more rhs case when lhs is a constructor.

--- a/base/src/main/java/org/aya/core/pat/PatUnify.java
+++ b/base/src/main/java/org/aya/core/pat/PatUnify.java
@@ -45,8 +45,7 @@ public record PatUnify(@NotNull Subst lhsSubst, @NotNull Subst rhsSubst, @NotNul
       case Pat.ShapedInt lhsInt -> {
         switch (rhs) {
           case Pat.ShapedInt rhsInt -> {
-            if (lhsInt.shape() != rhsInt.shape()) reportError(lhs, rhs);
-            if (lhsInt.integer() != rhsInt.integer()) reportError(lhs, rhs);
+            if (!lhsInt.sameValue(rhsInt)) reportError(lhs, rhs);
           }
           case Pat.Ctor ctor -> unifyLitWithCtor(ctor, lhsInt, lhs);
           // Try one more time in case we add more rhs case when lhs is a constructor.

--- a/base/src/main/java/org/aya/core/repr/AyaShape.java
+++ b/base/src/main/java/org/aya/core/repr/AyaShape.java
@@ -86,14 +86,11 @@ public sealed interface AyaShape {
       this(MutableLinkedHashMap.of());
     }
 
-    public @NotNull Option<Def> findImpl(@NotNull AyaShape shape) {
-      var defs = discovered.view().map(Tuple::of)
+    public @NotNull ImmutableSeq<Def> findImpl(@NotNull AyaShape shape) {
+      return discovered.view().map(Tuple::of)
         .filter(t -> t._2 == shape)
         .map(t -> t._1)
         .toImmutableSeq();
-      // TODO[literal]: what if a shaped can be encoded by multiple defs?
-      if (defs.sizeGreaterThan(1)) return Option.none();
-      return defs.firstOption();
     }
 
     public @NotNull Option<AyaShape> find(@NotNull Def def) {

--- a/base/src/main/java/org/aya/core/repr/AyaShape.java
+++ b/base/src/main/java/org/aya/core/repr/AyaShape.java
@@ -7,17 +7,8 @@ import kala.collection.mutable.MutableLinkedHashMap;
 import kala.collection.mutable.MutableMap;
 import kala.control.Option;
 import kala.tuple.Tuple;
-import org.aya.core.def.CtorDef;
 import org.aya.core.def.Def;
-import org.aya.core.pat.Pat;
-import org.aya.core.term.CallTerm;
-import org.aya.core.term.LitTerm;
-import org.aya.core.term.Term;
-import org.aya.generic.Arg;
-import org.aya.generic.util.InternalException;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.function.BiFunction;
 
 import static org.aya.core.repr.CodeShape.CtorShape;
 import static org.aya.core.repr.CodeShape.DataShape;
@@ -27,57 +18,18 @@ import static org.aya.core.repr.CodeShape.DataShape;
  */
 public sealed interface AyaShape {
   @NotNull CodeShape codeShape();
-  @NotNull Term transformTerm(@NotNull Term term, @NotNull Term type);
-  @NotNull Pat transformPat(@NotNull Pat pat, @NotNull Term type);
-
-  @NotNull CodeShape DATA_NAT = new DataShape(ImmutableSeq.empty(), ImmutableSeq.of(
-    new CtorShape(ImmutableSeq.empty()),
-    new CtorShape(ImmutableSeq.of(CodeShape.ParamShape.ex(new CodeShape.TermShape.Call(0))))
-  ));
 
   @NotNull AyaShape NAT_SHAPE = new AyaIntLitShape();
   @NotNull ImmutableSeq<AyaShape> LITERAL_SHAPES = ImmutableSeq.of(NAT_SHAPE);
 
   record AyaIntLitShape() implements AyaShape {
+    public static final @NotNull CodeShape DATA_NAT = new DataShape(ImmutableSeq.empty(), ImmutableSeq.of(
+      new CtorShape(ImmutableSeq.empty()),
+      new CtorShape(ImmutableSeq.of(CodeShape.ParamShape.ex(new CodeShape.TermShape.Call(0))))
+    ));
+
     @Override public @NotNull CodeShape codeShape() {
       return DATA_NAT;
-    }
-
-    @Override public @NotNull Term transformTerm(@NotNull Term term, @NotNull Term type) {
-      assert type instanceof CallTerm.Data;
-      assert term instanceof LitTerm.ShapedInt;
-      var litTerm = ((LitTerm.ShapedInt) term);
-      var integer = ((LitTerm.ShapedInt) term).integer();
-      var dataCall = ((CallTerm.Data) type);
-      return with(dataCall, (zero, suc) -> {
-        if (integer == 0) return new CallTerm.Con(dataCall.ref(), zero.ref, ImmutableSeq.empty(), 0, ImmutableSeq.empty());
-        return new CallTerm.Con(dataCall.ref(), suc.ref, ImmutableSeq.empty(), 0, ImmutableSeq.of(new Arg<>(
-          new LitTerm.ShapedInt(integer - 1, litTerm.shape(), litTerm.type()), true)));
-      });
-    }
-
-    @Override public @NotNull Pat transformPat(@NotNull Pat pat, @NotNull Term type) {
-      assert type instanceof CallTerm.Data;
-      assert pat instanceof Pat.ShapedInt;
-      var litPat = ((Pat.ShapedInt) pat);
-      var integer = ((Pat.ShapedInt) pat).integer();
-      var dataCall = (CallTerm.Data) type;
-      return with(dataCall, (zero, suc) -> {
-        if (integer == 0) return new Pat.Ctor(pat.explicit(), zero.ref, ImmutableSeq.empty(), dataCall);
-        return new Pat.Ctor(pat.explicit(), suc.ref, ImmutableSeq.of(
-          new Pat.ShapedInt(integer - 1, litPat.shape(), dataCall, pat.explicit())),
-          dataCall);
-      });
-    }
-
-    private <T> T with(@NotNull CallTerm.Data type, @NotNull BiFunction<CtorDef, CtorDef, T> block) {
-      var dataDef = type.ref().core;
-      var zeroOpt = dataDef.body.find(it -> it.selfTele.sizeEquals(0));
-      var sucOpt = dataDef.body.find(it -> it.selfTele.sizeEquals(1));
-      if (zeroOpt.isEmpty() || sucOpt.isEmpty()) throw new InternalException("shape recognition bug");
-      var zero = zeroOpt.get();
-      var suc = sucOpt.get();
-      return block.apply(zero, suc);
     }
   }
 

--- a/base/src/main/java/org/aya/core/repr/AyaShape.java
+++ b/base/src/main/java/org/aya/core/repr/AyaShape.java
@@ -4,8 +4,9 @@ package org.aya.core.repr;
 
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableLinkedHashMap;
-import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableMap;
+import kala.control.Option;
+import kala.tuple.Tuple;
 import org.aya.core.def.CtorDef;
 import org.aya.core.def.Def;
 import org.aya.core.pat.Pat;
@@ -80,9 +81,28 @@ public sealed interface AyaShape {
     }
   }
 
-  record Factory(@NotNull MutableMap<Def, MutableList<AyaShape>> discovered) {
+  record Factory(@NotNull MutableMap<Def, AyaShape> discovered) {
     public Factory() {
       this(MutableLinkedHashMap.of());
+    }
+
+    public @NotNull Option<Def> findImpl(@NotNull AyaShape shape) {
+      var defs = discovered.view().map(Tuple::of)
+        .filter(t -> t._2 == shape)
+        .map(t -> t._1)
+        .toImmutableSeq();
+      // TODO[literal]: what if a shaped can be encoded by multiple defs?
+      if (defs.sizeGreaterThan(1)) return Option.none();
+      return defs.firstOption();
+    }
+
+    public @NotNull Option<AyaShape> find(@NotNull Def def) {
+      return discovered.getOption(def);
+    }
+
+    public void bonjour(@NotNull Def def, @NotNull AyaShape shape) {
+      // TODO[literal]: what if a def has multiple shapes?
+      discovered.put(def, shape);
     }
   }
 }

--- a/base/src/main/java/org/aya/core/repr/AyaShape.java
+++ b/base/src/main/java/org/aya/core/repr/AyaShape.java
@@ -6,9 +6,17 @@ import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableLinkedHashMap;
 import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableMap;
+import org.aya.core.def.CtorDef;
 import org.aya.core.def.Def;
+import org.aya.core.term.CallTerm;
+import org.aya.core.term.LitTerm;
 import org.aya.core.term.Term;
+import org.aya.generic.Arg;
+import org.aya.generic.util.InternalException;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static org.aya.core.repr.CodeShape.CtorShape;
 import static org.aya.core.repr.CodeShape.DataShape;
@@ -18,7 +26,7 @@ import static org.aya.core.repr.CodeShape.DataShape;
  */
 public sealed interface AyaShape {
   @NotNull CodeShape codeShape();
-  @NotNull Term transform(@NotNull Term term, @NotNull Term type);
+  @NotNull Term transformTerm(@NotNull Term term, @NotNull Term type);
 
   @NotNull CodeShape DATA_NAT = new DataShape(ImmutableSeq.empty(), ImmutableSeq.of(
     new CtorShape(ImmutableSeq.empty()),
@@ -33,8 +41,37 @@ public sealed interface AyaShape {
       return DATA_NAT;
     }
 
-    @Override public @NotNull Term transform(@NotNull Term term, @NotNull Term type) {
-      return term;
+    @Override public @NotNull Term transformTerm(@NotNull Term term, @NotNull Term type) {
+      assert type instanceof CallTerm.Data;
+      assert term instanceof LitTerm.ShapedInt;
+      var integer = ((LitTerm.ShapedInt) term).integer();
+      var dataCall = ((CallTerm.Data) type);
+      var dataRef = dataCall.ref();
+      return transform(integer, dataCall,
+        zero -> new CallTerm.Con(dataRef, zero.ref, ImmutableSeq.empty(), 0, ImmutableSeq.empty()),
+        (suc, nat) -> new CallTerm.Con(dataRef, suc.ref, ImmutableSeq.empty(), 0, ImmutableSeq.of(new Arg<>(nat, true))));
+    }
+
+    private <T> T transform(int integer, @NotNull CallTerm.Data type,
+                            @NotNull Function<CtorDef, T> makeZero,
+                            @NotNull BiFunction<CtorDef, T, T> makeSuc) {
+      return with(type, (zero, suc) -> {
+        var zeroT = makeZero.apply(zero);
+        for (int i = 0; i < integer; i++) {
+          zeroT = makeSuc.apply(suc, zeroT);
+        }
+        return zeroT;
+      });
+    }
+
+    private <T> T with(@NotNull CallTerm.Data type, @NotNull BiFunction<CtorDef, CtorDef, T> block) {
+      var dataDef = type.ref().core;
+      var zeroOpt = dataDef.body.find(it -> it.selfTele.sizeEquals(0));
+      var sucOpt = dataDef.body.find(it -> it.selfTele.sizeEquals(1));
+      if (zeroOpt.isEmpty() || sucOpt.isEmpty()) throw new InternalException("shape recognition bug");
+      var zero = zeroOpt.get();
+      var suc = sucOpt.get();
+      return block.apply(zero, suc);
     }
   }
 

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -247,4 +247,8 @@ public record Serializer(@NotNull Serializer.State state) implements
     assert def.ref.module != null;
     return new SerDef.Prim(def.ref.module, def.id);
   }
+
+  @Override public SerTerm visitShapedLit(LitTerm.@NotNull ShapedInt shaped, Unit unit) {
+    throw new UnsupportedOperationException("TODO");
+  }
 }

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -40,6 +40,8 @@ public record Serializer(@NotNull Serializer.State state) implements
       case Pat.Bind bind -> new SerPat.Bind(bind.explicit(), state.local(bind.bind()), serialize(bind.type()));
       case Pat.End end -> new SerPat.End(end.isRight(), end.explicit());
       case Pat.Meta meta -> throw new InternalException(meta + " is illegal here");
+      // TODO: serialize lit patterns
+      case Pat.ShapedInt lit -> throw new UnsupportedOperationException("TODO");
     };
   }
 
@@ -249,6 +251,7 @@ public record Serializer(@NotNull Serializer.State state) implements
   }
 
   @Override public SerTerm visitShapedLit(LitTerm.@NotNull ShapedInt shaped, Unit unit) {
+    // TODO: serialize lit terms
     throw new UnsupportedOperationException("TODO");
   }
 }

--- a/base/src/main/java/org/aya/core/term/LitTerm.java
+++ b/base/src/main/java/org/aya/core/term/LitTerm.java
@@ -9,6 +9,7 @@ public sealed interface LitTerm extends Term {
   record ShapedInt(
     int integer,
     @NotNull AyaShape shape,
+    // TODO: remove the type
     @NotNull CallTerm.Data type
   ) implements LitTerm {
     @Override public <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p) {
@@ -16,7 +17,7 @@ public sealed interface LitTerm extends Term {
     }
 
     public @NotNull Term constructorForm() {
-      return shape.transform(this, type);
+      return shape.transformTerm(this, type);
     }
   }
 }

--- a/base/src/main/java/org/aya/core/term/LitTerm.java
+++ b/base/src/main/java/org/aya/core/term/LitTerm.java
@@ -2,14 +2,21 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.term;
 
-import kala.collection.immutable.ImmutableSeq;
-import org.aya.core.repr.CodeShape;
+import org.aya.core.repr.AyaShape;
 import org.jetbrains.annotations.NotNull;
 
 public sealed interface LitTerm extends Term {
-  record ShapedInt(int value, @NotNull ImmutableSeq<CodeShape> possibleShapes) implements LitTerm {
+  record ShapedInt(
+    int integer,
+    @NotNull AyaShape shape,
+    @NotNull CallTerm.Data type
+  ) implements LitTerm {
     @Override public <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p) {
       return visitor.visitShapedLit(this, p);
+    }
+
+    public @NotNull Term constructorForm() {
+      return shape.transform(this, type);
     }
   }
 }

--- a/base/src/main/java/org/aya/core/term/LitTerm.java
+++ b/base/src/main/java/org/aya/core/term/LitTerm.java
@@ -13,23 +13,27 @@ public sealed interface LitTerm extends Term {
   record ShapedInt(
     @Override int repr,
     @Override @NotNull AyaShape shape,
-    @NotNull CallTerm.Data type
+    @Override @NotNull Term type
   ) implements LitTerm, Shaped.Inductively<Term> {
     @Override public <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p) {
       return visitor.visitShapedLit(this, p);
     }
 
     @Override public @NotNull Term makeZero(@NotNull CtorDef zero) {
-      return new CallTerm.Con(type.ref(), zero.ref, ImmutableSeq.empty(), 0, ImmutableSeq.empty());
+      return new CallTerm.Con(zero.dataRef, zero.ref, ImmutableSeq.empty(), 0, ImmutableSeq.empty());
     }
 
     @Override public @NotNull Term makeSuc(@NotNull CtorDef suc, @NotNull Term term) {
-      return new CallTerm.Con(type.ref(), suc.ref, ImmutableSeq.empty(), 0,
+      return new CallTerm.Con(suc.dataRef, suc.ref, ImmutableSeq.empty(), 0,
         ImmutableSeq.of(new Arg<>(term, true)));
     }
 
     @Override public @NotNull Term destruct(int repr) {
       return new LitTerm.ShapedInt(repr, this.shape, this.type);
+    }
+
+    @Override public @NotNull Term self() {
+      return this;
     }
   }
 }

--- a/base/src/main/java/org/aya/core/term/LitTerm.java
+++ b/base/src/main/java/org/aya/core/term/LitTerm.java
@@ -2,22 +2,34 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.term;
 
+import kala.collection.immutable.ImmutableSeq;
+import org.aya.core.def.CtorDef;
 import org.aya.core.repr.AyaShape;
+import org.aya.generic.Arg;
+import org.aya.generic.Shaped;
 import org.jetbrains.annotations.NotNull;
 
 public sealed interface LitTerm extends Term {
   record ShapedInt(
-    int integer,
-    @NotNull AyaShape shape,
-    // TODO: remove the type
+    @Override int repr,
+    @Override @NotNull AyaShape shape,
     @NotNull CallTerm.Data type
-  ) implements LitTerm {
+  ) implements LitTerm, Shaped.Inductively<Term> {
     @Override public <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p) {
       return visitor.visitShapedLit(this, p);
     }
 
-    public @NotNull Term constructorForm() {
-      return shape.transformTerm(this, type);
+    @Override public @NotNull Term makeZero(@NotNull CtorDef zero) {
+      return new CallTerm.Con(type.ref(), zero.ref, ImmutableSeq.empty(), 0, ImmutableSeq.empty());
+    }
+
+    @Override public @NotNull Term makeSuc(@NotNull CtorDef suc, @NotNull Term term) {
+      return new CallTerm.Con(type.ref(), suc.ref, ImmutableSeq.empty(), 0,
+        ImmutableSeq.of(new Arg<>(term, true)));
+    }
+
+    @Override public @NotNull Term destruct(int repr) {
+      return new LitTerm.ShapedInt(repr, this.shape, this.type);
     }
   }
 }

--- a/base/src/main/java/org/aya/core/term/LitTerm.java
+++ b/base/src/main/java/org/aya/core/term/LitTerm.java
@@ -1,0 +1,15 @@
+// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.core.term;
+
+import kala.collection.immutable.ImmutableSeq;
+import org.aya.core.repr.CodeShape;
+import org.jetbrains.annotations.NotNull;
+
+public sealed interface LitTerm extends Term {
+  record ShapedInt(int value, @NotNull ImmutableSeq<CodeShape> possibleShapes) implements LitTerm {
+    @Override public <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p) {
+      return visitor.visitShapedLit(this, p);
+    }
+  }
+}

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.TestOnly;
  * @author ice1000
  */
 public sealed interface Term extends AyaDocile permits CallTerm, ElimTerm, ErrorTerm,
-        FormTerm, IntroTerm, PrimTerm, RefTerm, RefTerm.Field, RefTerm.MetaPat {
+        FormTerm, IntroTerm, PrimTerm, RefTerm, RefTerm.Field, RefTerm.MetaPat, LitTerm {
   <P, R> R doAccept(@NotNull Visitor<P, R> visitor, P p);
 
   default <P, R> R accept(@NotNull Visitor<P, R> visitor, P p) {
@@ -138,6 +138,7 @@ public sealed interface Term extends AyaDocile permits CallTerm, ElimTerm, Error
     R visitMetaPat(@NotNull RefTerm.MetaPat metaPat, P p);
     R visitInterval(@NotNull FormTerm.Interval interval, P p);
     R visitEnd(@NotNull PrimTerm.End end, P p);
+    R visitShapedLit(@NotNull LitTerm.ShapedInt shaped, P p);
   }
 
   /**

--- a/base/src/main/java/org/aya/core/visitor/TermConsumer.java
+++ b/base/src/main/java/org/aya/core/visitor/TermConsumer.java
@@ -118,9 +118,8 @@ public interface TermConsumer<P> extends Term.Visitor<P, Unit> {
     return Unit.unit();
   }
 
-  @Override
-  default Unit visitEnd(PrimTerm.@NotNull End end, P p) {
-    return  Unit.unit();
+  @Override default Unit visitEnd(PrimTerm.@NotNull End end, P p) {
+    return Unit.unit();
   }
 
   @Override default Unit visitProj(@NotNull ElimTerm.Proj term, P p) {
@@ -131,5 +130,9 @@ public interface TermConsumer<P> extends Term.Visitor<P, Unit> {
     visitArgs(p, term.fieldArgs());
     visitCall(term, p);
     return term.of().accept(this, p);
+  }
+
+  @Override default Unit visitShapedLit(LitTerm.@NotNull ShapedInt shaped, P p) {
+    return Unit.unit();
   }
 }

--- a/base/src/main/java/org/aya/core/visitor/TermConsumer.java
+++ b/base/src/main/java/org/aya/core/visitor/TermConsumer.java
@@ -133,6 +133,7 @@ public interface TermConsumer<P> extends Term.Visitor<P, Unit> {
   }
 
   @Override default Unit visitShapedLit(LitTerm.@NotNull ShapedInt shaped, P p) {
+    shaped.type().accept(this, p);
     return Unit.unit();
   }
 }

--- a/base/src/main/java/org/aya/core/visitor/TermFixpoint.java
+++ b/base/src/main/java/org/aya/core/visitor/TermFixpoint.java
@@ -161,4 +161,8 @@ public interface TermFixpoint<P> extends Term.Visitor<P, @NotNull Term> {
       && tuple == term.of()) return term;
     return new CallTerm.Access(tuple, term.ref(), structArgs, args);
   }
+
+  @Override default @NotNull Term visitShapedLit(LitTerm.@NotNull ShapedInt shaped, P p) {
+    return shaped;
+  }
 }

--- a/base/src/main/java/org/aya/core/visitor/TermFixpoint.java
+++ b/base/src/main/java/org/aya/core/visitor/TermFixpoint.java
@@ -163,6 +163,8 @@ public interface TermFixpoint<P> extends Term.Visitor<P, @NotNull Term> {
   }
 
   @Override default @NotNull Term visitShapedLit(LitTerm.@NotNull ShapedInt shaped, P p) {
-    return shaped;
+    var type = shaped.type().accept(this, p);
+    if (type == shaped.type()) return shaped;
+    return new LitTerm.ShapedInt(shaped.repr(), shaped.shape(), type);
   }
 }

--- a/base/src/main/java/org/aya/core/visitor/TermOps.java
+++ b/base/src/main/java/org/aya/core/visitor/TermOps.java
@@ -26,11 +26,11 @@ public interface TermOps extends TermView {
     return view().initial();
   }
 
-  @Override default Term pre(Term term) {
+  @Override default @NotNull Term pre(@NotNull Term term) {
     return view().pre(term);
   }
 
-  @Override default Term post(Term term) {
+  @Override default @NotNull Term post(@NotNull Term term) {
     return view().post(term);
   }
 

--- a/base/src/main/java/org/aya/core/visitor/TermView.java
+++ b/base/src/main/java/org/aya/core/visitor/TermView.java
@@ -135,7 +135,11 @@ public interface TermView {
         if (contextArgs.sameElements(hole.contextArgs(), true) && args.sameElements(hole.args(), true)) yield hole;
         yield new CallTerm.Hole(hole.ref(), hole.ulift(), contextArgs, args);
       }
-      case LitTerm.ShapedInt shaped -> shaped;
+      case LitTerm.ShapedInt shaped -> {
+        var type = commit(shaped.type());
+        if (type == shaped.type()) yield shaped;
+        yield new LitTerm.ShapedInt(shaped.repr(), shaped.shape(), type);
+      }
       case RefTerm.Field field -> field;
       case RefTerm ref -> ref;
       case RefTerm.MetaPat metaPat -> metaPat;

--- a/base/src/main/java/org/aya/core/visitor/TermView.java
+++ b/base/src/main/java/org/aya/core/visitor/TermView.java
@@ -135,6 +135,7 @@ public interface TermView {
         if (contextArgs.sameElements(hole.contextArgs(), true) && args.sameElements(hole.args(), true)) yield hole;
         yield new CallTerm.Hole(hole.ref(), hole.ulift(), contextArgs, args);
       }
+      case LitTerm.ShapedInt shaped -> shaped;
       case RefTerm.Field field -> field;
       case RefTerm ref -> ref;
       case RefTerm.MetaPat metaPat -> metaPat;

--- a/base/src/main/java/org/aya/core/visitor/Unfolder.java
+++ b/base/src/main/java/org/aya/core/visitor/Unfolder.java
@@ -13,7 +13,6 @@ import org.aya.core.def.PrimDef;
 import org.aya.core.pat.PatMatcher;
 import org.aya.core.term.CallTerm;
 import org.aya.core.term.IntroTerm;
-import org.aya.core.term.LitTerm;
 import org.aya.core.term.Term;
 import org.aya.generic.Arg;
 import org.aya.generic.Modifier;
@@ -148,10 +147,6 @@ public interface Unfolder<P> extends TermFixpoint<P> {
     var arguments = buildSubst(fieldDef.ownerTele, term.structArgs());
     var fieldBody = term.fieldArgs().foldLeft(n.params().get(fieldRef), CallTerm::make);
     return fieldBody.subst(arguments).accept(this, p);
-  }
-
-  @Override @NotNull default Term visitShapedLit(@NotNull LitTerm.ShapedInt shaped, P p) {
-    return shaped.constructorForm();
   }
 
   /**

--- a/base/src/main/java/org/aya/core/visitor/Unfolder.java
+++ b/base/src/main/java/org/aya/core/visitor/Unfolder.java
@@ -13,6 +13,7 @@ import org.aya.core.def.PrimDef;
 import org.aya.core.pat.PatMatcher;
 import org.aya.core.term.CallTerm;
 import org.aya.core.term.IntroTerm;
+import org.aya.core.term.LitTerm;
 import org.aya.core.term.Term;
 import org.aya.generic.Arg;
 import org.aya.generic.Modifier;
@@ -147,6 +148,10 @@ public interface Unfolder<P> extends TermFixpoint<P> {
     var arguments = buildSubst(fieldDef.ownerTele, term.structArgs());
     var fieldBody = term.fieldArgs().foldLeft(n.params().get(fieldRef), CallTerm::make);
     return fieldBody.subst(arguments).accept(this, p);
+  }
+
+  @Override @NotNull default Term visitShapedLit(@NotNull LitTerm.ShapedInt shaped, P p) {
+    return shaped.constructorForm();
   }
 
   /**

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -151,7 +151,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
       }
       case CallTerm.Struct structCall -> visitArgsCalls(structCall.ref(), STRUCT_CALL, structCall.args(), outer);
       case CallTerm.Data dataCall -> visitArgsCalls(dataCall.ref(), DATA_CALL, dataCall.args(), outer);
-      case LitTerm.ShapedInt shaped -> Doc.plain(String.valueOf(shaped.integer()));
+      case LitTerm.ShapedInt shaped -> Doc.plain(String.valueOf(shaped.repr()));
     };
   }
 
@@ -193,7 +193,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
       case Pat.Tuple tuple -> Doc.licit(tuple.explicit(),
         Doc.commaList(tuple.pats().view().map(sub -> pat(sub, Outer.Free))));
       case Pat.End end -> Doc.bracedUnless(Doc.styled(KEYWORD, !end.isRight() ? "0" : "1"), end.explicit());
-      case Pat.ShapedInt lit -> Doc.bracedUnless(Doc.plain(String.valueOf(lit.integer())), lit.explicit());
+      case Pat.ShapedInt lit -> Doc.bracedUnless(Doc.plain(String.valueOf(lit.repr())), lit.explicit());
     };
   }
 

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -151,6 +151,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
       }
       case CallTerm.Struct structCall -> visitArgsCalls(structCall.ref(), STRUCT_CALL, structCall.args(), outer);
       case CallTerm.Data dataCall -> visitArgsCalls(dataCall.ref(), DATA_CALL, dataCall.args(), outer);
+      case LitTerm.ShapedInt shaped -> Doc.plain(String.valueOf(shaped.value()));
     };
   }
 

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -151,7 +151,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
       }
       case CallTerm.Struct structCall -> visitArgsCalls(structCall.ref(), STRUCT_CALL, structCall.args(), outer);
       case CallTerm.Data dataCall -> visitArgsCalls(dataCall.ref(), DATA_CALL, dataCall.args(), outer);
-      case LitTerm.ShapedInt shaped -> Doc.plain(String.valueOf(shaped.value()));
+      case LitTerm.ShapedInt shaped -> Doc.plain(String.valueOf(shaped.integer()));
     };
   }
 

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -193,6 +193,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
       case Pat.Tuple tuple -> Doc.licit(tuple.explicit(),
         Doc.commaList(tuple.pats().view().map(sub -> pat(sub, Outer.Free))));
       case Pat.End end -> Doc.bracedUnless(Doc.styled(KEYWORD, !end.isRight() ? "0" : "1"), end.explicit());
+      case Pat.ShapedInt lit -> Doc.bracedUnless(Doc.plain(String.valueOf(lit.integer())), lit.explicit());
     };
   }
 

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -1,0 +1,58 @@
+// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.generic;
+
+import org.aya.core.def.CtorDef;
+import org.aya.core.repr.AyaShape;
+import org.aya.core.term.CallTerm;
+import org.aya.core.term.Term;
+import org.aya.generic.util.InternalException;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.BiFunction;
+
+public interface Shaped<T> {
+  @NotNull AyaShape shape();
+  @NotNull Term type();
+  @NotNull T constructorForm();
+  <O> boolean sameEncoding(@NotNull Shaped<O> other);
+
+  interface Inductively<T> extends Shaped<T> {
+    @Override @NotNull CallTerm.Data type();
+    @NotNull T makeZero(@NotNull CtorDef zero);
+    @NotNull T makeSuc(@NotNull CtorDef suc, @NotNull T t);
+    @NotNull T destruct(int repr);
+    int repr();
+
+    default @Override <O> boolean sameEncoding(@NotNull Shaped<O> other) {
+      if (shape() != other.shape()) return false;
+      if (!(other instanceof Inductively otherData)) return false;
+      return type().ref().core == otherData.type().ref().core;
+    }
+
+    default <O> boolean sameValue(@NotNull Shaped<O> other) {
+      if (!sameEncoding(other)) return false;
+      var otherData = ((Inductively<O>) other);
+      return repr() == otherData.repr();
+    }
+
+    default @Override @NotNull T constructorForm() {
+      int repr = repr();
+      return with((zero, suc) -> {
+        if (repr == 0) return makeZero(zero);
+        return makeSuc(suc, destruct(repr - 1));
+      });
+    }
+
+    default <R> R with(@NotNull BiFunction<CtorDef, CtorDef, R> block) {
+      var type = type();
+      var dataDef = type.ref().core;
+      var zeroOpt = dataDef.body.find(it -> it.selfTele.sizeEquals(0));
+      var sucOpt = dataDef.body.find(it -> it.selfTele.sizeEquals(1));
+      if (zeroOpt.isEmpty() || sucOpt.isEmpty()) throw new InternalException("shape recognition bug");
+      var zero = zeroOpt.get();
+      var suc = sucOpt.get();
+      return block.apply(zero, suc);
+    }
+  }
+}

--- a/base/src/main/java/org/aya/ref/DefVar.java
+++ b/base/src/main/java/org/aya/ref/DefVar.java
@@ -7,6 +7,7 @@ import kala.collection.mutable.MutableMap;
 import org.aya.concrete.stmt.GenericDecl;
 import org.aya.concrete.stmt.Signatured;
 import org.aya.core.def.Def;
+import org.aya.resolve.ResolveInfo;
 import org.aya.core.def.GenericDef;
 import org.aya.util.binop.OpDecl;
 import org.jetbrains.annotations.Contract;
@@ -27,7 +28,11 @@ public final class DefVar<Core extends GenericDef, Concrete extends GenericDecl>
   public @Nullable ImmutableSeq<String> module;
   /** Initialized in the resolver or core deserialization */
   public @Nullable OpDecl opDecl;
-  /** Initialized in the resolver or core deserialization */
+  /**
+   * Binary operators can be renamed in other modules.
+   * Initialized in the resolver or core deserialization.
+   * see {@link ResolveInfo#bindBlockRename()}
+   */
   public @NotNull MutableMap<ImmutableSeq<String>, OpDecl> opDeclRename = MutableMap.create();
 
 

--- a/base/src/main/java/org/aya/resolve/ResolveInfo.java
+++ b/base/src/main/java/org/aya/resolve/ResolveInfo.java
@@ -5,12 +5,11 @@ package org.aya.resolve;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableMap;
-import kala.collection.mutable.MutableSeq;
 import org.aya.concrete.desugar.AyaBinOpSet;
 import org.aya.concrete.stmt.BindBlock;
 import org.aya.concrete.stmt.Stmt;
-import org.aya.core.def.Def;
 import org.aya.core.def.PrimDef;
+import org.aya.core.repr.AyaShape;
 import org.aya.core.repr.CodeShape;
 import org.aya.resolve.context.ModuleContext;
 import org.aya.tyck.order.TyckOrder;
@@ -20,21 +19,21 @@ import org.jetbrains.annotations.Debug;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * @param primFactory      all primitives shared among all modules in a compilation task.
- * @param discoveredShapes {@link CodeShape} that are discovered during tycking this module, modified by tycker.
- * @param opSet            binary operators.
- * @param bindBlockRename  bind block for renaming-as-infix operators, see {@link org.aya.ref.DefVar#opDeclRename}.
- * @param imports          modules imported using `import` command.
- * @param reExports        modules re-exported using `public open` command.
- * @param depGraph         dependency graph of definitions. for each (v, successors) in the graph,
- *                         `successors` should be tycked first.
+ * @param primFactory     all primitives shared among all modules in a compilation task.
+ * @param shapeFactory    {@link CodeShape} that are discovered during tycking this module, modified by tycker.
+ * @param opSet           binary operators.
+ * @param bindBlockRename bind block for renaming-as-infix operators, see {@link org.aya.ref.DefVar#opDeclRename}.
+ * @param imports         modules imported using `import` command.
+ * @param reExports       modules re-exported using `public open` command.
+ * @param depGraph        dependency graph of definitions. for each (v, successors) in the graph,
+ *                        `successors` should be tycked first.
  */
 @Debug.Renderer(text = "thisModule.moduleName().joinToString(\"::\")")
 public record ResolveInfo(
   @NotNull ModuleContext thisModule,
   @NotNull ImmutableSeq<Stmt> program,
   @NotNull PrimDef.Factory primFactory,
-  @NotNull MutableMap<CodeShape, MutableSeq<Def>> discoveredShapes,
+  @NotNull AyaShape.Factory shapeFactory,
   @NotNull AyaBinOpSet opSet,
   @NotNull MutableMap<OpDecl, BindBlock> bindBlockRename,
   @NotNull MutableMap<ImmutableSeq<String>, ResolveInfo> imports,
@@ -42,7 +41,7 @@ public record ResolveInfo(
   @NotNull MutableGraph<TyckOrder> depGraph
 ) {
   public ResolveInfo(@NotNull PrimDef.Factory primFactory, @NotNull ModuleContext thisModule, @NotNull ImmutableSeq<Stmt> thisProgram, @NotNull AyaBinOpSet opSet) {
-    this(thisModule, thisProgram, primFactory, MutableMap.create(),
+    this(thisModule, thisProgram, primFactory, new AyaShape.Factory(),
       opSet, MutableMap.create(),
       MutableMap.create(), MutableList.create(),
       MutableGraph.create());

--- a/base/src/main/java/org/aya/resolve/ResolveInfo.java
+++ b/base/src/main/java/org/aya/resolve/ResolveInfo.java
@@ -5,10 +5,13 @@ package org.aya.resolve;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableMap;
+import kala.collection.mutable.MutableSeq;
 import org.aya.concrete.desugar.AyaBinOpSet;
 import org.aya.concrete.stmt.BindBlock;
 import org.aya.concrete.stmt.Stmt;
+import org.aya.core.def.Def;
 import org.aya.core.def.PrimDef;
+import org.aya.core.repr.CodeShape;
 import org.aya.resolve.context.ModuleContext;
 import org.aya.tyck.order.TyckOrder;
 import org.aya.util.MutableGraph;
@@ -17,24 +20,31 @@ import org.jetbrains.annotations.Debug;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * @param opSet     binary operators
- * @param imports   modules imported using `import` command
- * @param reExports modules re-exported using `public open` command
- * @param depGraph  dependency graph of definitions. for each (v, successors) in the graph,
- *                  `successors` should be tycked first.
+ * @param primFactory      all primitives shared among all modules in a compilation task.
+ * @param discoveredShapes {@link CodeShape} that are discovered during tycking this module, modified by tycker.
+ * @param opSet            binary operators.
+ * @param bindBlockRename  bind block for renaming-as-infix operators, see {@link org.aya.ref.DefVar#opDeclRename}.
+ * @param imports          modules imported using `import` command.
+ * @param reExports        modules re-exported using `public open` command.
+ * @param depGraph         dependency graph of definitions. for each (v, successors) in the graph,
+ *                         `successors` should be tycked first.
  */
 @Debug.Renderer(text = "thisModule.moduleName().joinToString(\"::\")")
 public record ResolveInfo(
   @NotNull ModuleContext thisModule,
   @NotNull ImmutableSeq<Stmt> program,
   @NotNull PrimDef.Factory primFactory,
+  @NotNull MutableMap<CodeShape, MutableSeq<Def>> discoveredShapes,
   @NotNull AyaBinOpSet opSet,
+  @NotNull MutableMap<OpDecl, BindBlock> bindBlockRename,
   @NotNull MutableMap<ImmutableSeq<String>, ResolveInfo> imports,
   @NotNull MutableList<ImmutableSeq<String>> reExports,
-  @NotNull MutableGraph<TyckOrder> depGraph,
-  @NotNull MutableMap<OpDecl, BindBlock> bindBlockRename
+  @NotNull MutableGraph<TyckOrder> depGraph
 ) {
   public ResolveInfo(@NotNull PrimDef.Factory primFactory, @NotNull ModuleContext thisModule, @NotNull ImmutableSeq<Stmt> thisProgram, @NotNull AyaBinOpSet opSet) {
-    this(thisModule, thisProgram, primFactory, opSet, MutableMap.create(), MutableList.create(), MutableGraph.create(), MutableMap.create());
+    this(thisModule, thisProgram, primFactory, MutableMap.create(),
+      opSet, MutableMap.create(),
+      MutableMap.create(), MutableList.create(),
+      MutableGraph.create());
   }
 }

--- a/base/src/main/java/org/aya/resolve/visitor/StmtShallowResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtShallowResolver.java
@@ -75,12 +75,16 @@ public record StmtShallowResolver(
           useHide::uses,
           useHide.renaming(),
           cmd.sourcePos());
-        // open operator precedence bindings from imported modules (not submodules)
-        // because submodules always share the same opSet with file-level resolveInfo.
+        // open necessities from imported modules (not submodules)
+        // because the module itself and its submodules share the same ResolveInfo
         var modInfo = resolveInfo.imports().getOption(mod);
         if (modInfo.isDefined()) {
           if (acc == Stmt.Accessibility.Public) resolveInfo.reExports().append(mod);
-          resolveInfo.opSet().importBind(modInfo.get().opSet(), cmd.sourcePos());
+          var modResolveInfo = modInfo.get();
+          // open operator precedence bindings
+          resolveInfo.opSet().importBind(modResolveInfo.opSet(), cmd.sourcePos());
+          // open discovered shapes as well
+          resolveInfo.discoveredShapes().putAll(modResolveInfo.discoveredShapes());
         }
         // renaming as infix
         if (useHide.strategy() == Command.Open.UseHide.Strategy.Using) useHide.list().forEach(use -> {

--- a/base/src/main/java/org/aya/resolve/visitor/StmtShallowResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtShallowResolver.java
@@ -84,7 +84,7 @@ public record StmtShallowResolver(
           // open operator precedence bindings
           resolveInfo.opSet().importBind(modResolveInfo.opSet(), cmd.sourcePos());
           // open discovered shapes as well
-          resolveInfo.discoveredShapes().putAll(modResolveInfo.discoveredShapes());
+          resolveInfo.shapeFactory().discovered().putAll(modResolveInfo.shapeFactory().discovered());
         }
         // renaming as infix
         if (useHide.strategy() == Command.Open.UseHide.Strategy.Using) useHide.list().forEach(use -> {

--- a/base/src/main/java/org/aya/terck/CallResolver.java
+++ b/base/src/main/java/org/aya/terck/CallResolver.java
@@ -82,7 +82,7 @@ public record CallResolver(
       case Pat.ShapedInt intPat -> switch (term) {
         case LitTerm.ShapedInt intTerm -> {
           if (intTerm.shape() != intPat.shape()) yield Relation.Unknown;
-          yield Relation.fromCompare(Integer.compare(intTerm.integer(), intPat.integer()));
+          yield Relation.fromCompare(Integer.compare(intTerm.repr(), intPat.repr()));
         }
         // TODO[literal]: We may convert constructor call to literals to avoid possible stack overflow?
         case CallTerm.Con con -> compare(con, intPat.constructorForm());

--- a/base/src/main/java/org/aya/terck/CallResolver.java
+++ b/base/src/main/java/org/aya/terck/CallResolver.java
@@ -9,10 +9,7 @@ import org.aya.core.Matching;
 import org.aya.core.def.Def;
 import org.aya.core.def.FnDef;
 import org.aya.core.pat.Pat;
-import org.aya.core.term.CallTerm;
-import org.aya.core.term.ElimTerm;
-import org.aya.core.term.RefTerm;
-import org.aya.core.term.Term;
+import org.aya.core.term.*;
 import org.aya.core.visitor.DefConsumer;
 import org.aya.ref.DefVar;
 import org.jetbrains.annotations.NotNull;
@@ -55,28 +52,44 @@ public record CallResolver(
   }
 
   /** foetus dependencies */
-  private @NotNull Relation compare(@NotNull Term lhs, @NotNull Pat rhs) {
-    if (rhs instanceof Pat.Ctor ctor) {
-      if (lhs instanceof CallTerm.Con con) {
-        if (con.ref() != ctor.ref()) return Relation.Unknown;
-        if (ctor.params().isEmpty()) return Relation.Equal;
-        var subCompare = con.conArgs()
-          .zipView(ctor.params())
-          .map(sub -> compare(sub._1.term(), sub._2));
-        // compare one level deeper for sub-ctor-patterns like `cons (suc x) xs`, see FoetusLimitation.aya
-        // return subCompare.anyMatch(r -> r != Relation.Unknown) ? Relation.Equal : Relation.Unknown;
-        return subCompare.max();
+  private @NotNull Relation compare(@NotNull Term term, @NotNull Pat pat) {
+    return switch (pat) {
+      case Pat.Ctor ctor -> switch (term) {
+        case CallTerm.Con con -> {
+          if (con.ref() != ctor.ref()) yield Relation.Unknown;
+          if (ctor.params().isEmpty()) yield Relation.Equal;
+          var subCompare = con.conArgs()
+            .zipView(ctor.params())
+            .map(sub -> compare(sub._1.term(), sub._2));
+          // compare one level deeper for sub-ctor-patterns like `cons (suc x) xs`, see FoetusLimitation.aya
+          // return subCompare.anyMatch(r -> r != Relation.Unknown) ? Relation.Equal : Relation.Unknown;
+          yield subCompare.max();
+        }
+        // TODO[literal]: We may convert constructor call to literals to avoid possible stack overflow?
+        case LitTerm.ShapedInt lit -> compare(lit.constructorForm(), ctor);
+        default -> {
+          var subCompare = ctor.params().view().map(sub -> compare(term, sub));
+          yield subCompare.anyMatch(r -> r != Relation.Unknown) ? Relation.LessThan : Relation.Unknown;
+        }
+      };
+      case Pat.Bind bind -> {
+        if (term instanceof RefTerm ref)
+          yield ref.var() == bind.bind() ? Relation.Equal : Relation.Unknown;
+        if (headOf(term) instanceof RefTerm ref)
+          yield ref.var() == bind.bind() ? Relation.LessThan : Relation.Unknown;
+        yield Relation.Unknown;
       }
-      var subCompare = ctor.params().view().map(sub -> compare(lhs, sub));
-      return subCompare.anyMatch(r -> r != Relation.Unknown)
-        ? Relation.LessThan : Relation.Unknown;
-    } else if (rhs instanceof Pat.Bind bind) {
-      if (lhs instanceof RefTerm ref)
-        return ref.var() == bind.bind() ? Relation.Equal : Relation.Unknown;
-      if (headOf(lhs) instanceof RefTerm ref)
-        return ref.var() == bind.bind() ? Relation.LessThan : Relation.Unknown;
-    }
-    return Relation.Unknown;
+      case Pat.ShapedInt intPat -> switch (term) {
+        case LitTerm.ShapedInt intTerm -> {
+          if (intTerm.shape() != intPat.shape()) yield Relation.Unknown;
+          yield Relation.fromCompare(Integer.compare(intTerm.integer(), intPat.integer()));
+        }
+        // TODO[literal]: We may convert constructor call to literals to avoid possible stack overflow?
+        case CallTerm.Con con -> compare(con, intPat.constructorForm());
+        default -> compare(term, intPat.constructorForm());
+      };
+      default -> Relation.Unknown;
+    };
   }
 
   /** @return the head of application or projection */

--- a/base/src/main/java/org/aya/terck/Relation.java
+++ b/base/src/main/java/org/aya/terck/Relation.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.terck;
 
@@ -55,5 +55,9 @@ public enum Relation implements Comparable<Relation>{
     return this.ordinal() <= rhs.ordinal();
   }
 
-
+  public static @NotNull Relation fromCompare(int compare) {
+    if (compare == 0) return Relation.Equal;
+    if (compare < 0) return Relation.LessThan;
+    return Relation.Unknown;
+  }
 }

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -3,9 +3,9 @@
 package org.aya.tyck;
 
 import kala.collection.immutable.ImmutableMap;
+import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableMap;
-import kala.range.primitive.IntRange;
 import kala.tuple.Tuple;
 import kala.tuple.Tuple2;
 import kala.tuple.Tuple3;
@@ -14,6 +14,7 @@ import org.aya.concrete.Expr;
 import org.aya.concrete.stmt.Decl;
 import org.aya.concrete.stmt.Signatured;
 import org.aya.core.def.*;
+import org.aya.core.repr.AyaShape;
 import org.aya.core.term.*;
 import org.aya.core.visitor.Subst;
 import org.aya.core.visitor.Unfolder;
@@ -49,6 +50,7 @@ import java.util.function.Consumer;
  */
 public final class ExprTycker extends Tycker {
   public @NotNull LocalCtx localCtx = new MapLocalCtx();
+  public @NotNull AyaShape.Factory literalShapes;
   public final @Nullable Trace.Builder traceBuilder;
 
   private void tracing(@NotNull Consumer<Trace.@NotNull Builder> consumer) {
@@ -232,6 +234,19 @@ public final class ExprTycker extends Tycker {
       case Expr.HoleExpr hole -> inherit(hole, localCtx.freshHole(null,
         Constants.randomName(hole), hole.sourcePos())._2);
       case Expr.ErrorExpr err -> Result.error(err.description());
+      case Expr.LitIntExpr lit -> {
+        int integer = lit.integer();
+        if (integer < 0) throw new UnsupportedOperationException("TODO: int shape");
+        var nats = literalShapes.discovered().view()
+          .map(Tuple::of)
+          .filter(t -> t._2.contains(AyaShape.NAT_SHAPE))
+          .map(t -> t._1)
+          .toImmutableSeq();
+        if (nats.sizeGreaterThan(1)) throw new UnsupportedOperationException("TODO: how to choose?");
+        var dataDef = ((DataDef) nats.first());
+        var type = new CallTerm.Data(dataDef.ref, 0, ImmutableSeq.empty());
+        yield new Result(new LitTerm.ShapedInt(integer, AyaShape.NAT_SHAPE, type), type);
+      }
       default -> fail(expr, new NoRuleError(expr, null));
     };
   }
@@ -341,13 +356,22 @@ public final class ExprTycker extends Tycker {
         });
       }
       case Expr.LitIntExpr lit -> {
-        if (term.normalize(state, NormalizeMode.WHNF) instanceof FormTerm.Interval) {
-          if (IntRange.closed(0, 1).contains(lit.integer()))
-            yield new Result(lit.integer() == 1 ? PrimTerm.End.RIGHT : PrimTerm.End.LEFT, term);
-          yield fail(lit, new NotAnIntervalError(lit.sourcePos(), lit.integer()));
-        } else {
-          yield fail(expr, new NoRuleError(expr, null));
+        var ty = term.normalize(state, NormalizeMode.WHNF);
+        if (ty instanceof FormTerm.Interval) {
+          var end = lit.integer();
+          if (end == 0 || end == 1) yield new Result(end == 1 ? PrimTerm.End.RIGHT : PrimTerm.End.LEFT, term);
+          else yield fail(expr, new NotAnIntervalError(lit.sourcePos(), lit.integer()));
         }
+        if (ty instanceof CallTerm.Data dataCall) {
+          var data = dataCall.ref().core;
+          var shapes = literalShapes.discovered().getOption(data);
+          if (shapes.isDefined()) {
+            var shape = shapes.get();
+            if (shape.sizeGreaterThan(1)) throw new UnsupportedOperationException("TODO: how to choose?");
+            yield new Result(new LitTerm.ShapedInt(lit.integer(), shape.first(), dataCall), term);
+          }
+        }
+        yield unifyTyMaybeInsert(term, synthesize(expr), expr);
       }
       default -> unifyTyMaybeInsert(term, synthesize(expr), expr);
     };
@@ -381,9 +405,14 @@ public final class ExprTycker extends Tycker {
   }
   */
 
-  public ExprTycker(@NotNull PrimDef.Factory primFactory, @NotNull Reporter reporter, Trace.@Nullable Builder traceBuilder) {
+  public ExprTycker(
+    @NotNull PrimDef.Factory primFactory,
+    @NotNull AyaShape.Factory literalShapes,
+    @NotNull Reporter reporter, Trace.@Nullable Builder traceBuilder
+  ) {
     super(reporter, new TyckState(primFactory));
     this.traceBuilder = traceBuilder;
+    this.literalShapes = literalShapes;
   }
 
   public void solveMetas() {

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -237,9 +237,10 @@ public final class ExprTycker extends Tycker {
       case Expr.LitIntExpr lit -> {
         int integer = lit.integer();
         // TODO[literal]: int literals. Currently the parser does not allow negative literals.
-        var dataDef = shapeFactory.findImpl(AyaShape.NAT_SHAPE);
-        if (dataDef.isEmpty()) yield fail(expr, new NoRuleError(expr, null));
-        var type = new CallTerm.Data(((DataDef) dataDef.get()).ref, 0, ImmutableSeq.empty());
+        var defs = shapeFactory.findImpl(AyaShape.NAT_SHAPE);
+        if (defs.isEmpty()) yield fail(expr, new NoRuleError(expr, null));
+        if (defs.sizeGreaterThan(1)) yield fail(expr, new AmbiguousLitError(expr, defs));
+        var type = new CallTerm.Data(((DataDef) defs.first()).ref, 0, ImmutableSeq.empty());
         yield new Result(new LitTerm.ShapedInt(integer, AyaShape.NAT_SHAPE, type), type);
       }
       default -> fail(expr, new NoRuleError(expr, null));

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -363,6 +363,9 @@ public final class ExprTycker extends Tycker {
           var shape = shapeFactory.find(data);
           if (shape.isDefined()) yield new Result(new LitTerm.ShapedInt(lit.integer(), shape.get(), dataCall), term);
         }
+        if (ty instanceof CallTerm.Hole hole) {
+          yield new Result(new LitTerm.ShapedInt(lit.integer(), AyaShape.NAT_SHAPE, hole), term);
+        }
         yield unifyTyMaybeInsert(term, synthesize(expr), expr);
       }
       default -> unifyTyMaybeInsert(term, synthesize(expr), expr);

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -77,7 +77,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       case FormTerm.Univ univ -> new FormTerm.Univ(univ.lift() + 1);
       case FormTerm.Interval interval -> new FormTerm.Univ(0);
       case PrimTerm.End end -> FormTerm.Interval.INSTANCE;
-      case LitTerm.ShapedInt shaped -> throw new UnsupportedOperationException("TODO");
+      case LitTerm.ShapedInt shaped -> shaped.type();
     };
   }
 

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -77,6 +77,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       case FormTerm.Univ univ -> new FormTerm.Univ(univ.lift() + 1);
       case FormTerm.Interval interval -> new FormTerm.Univ(0);
       case PrimTerm.End end -> FormTerm.Interval.INSTANCE;
+      case LitTerm.ShapedInt shaped -> throw new UnsupportedOperationException("TODO");
     };
   }
 

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -10,6 +10,7 @@ import org.aya.concrete.stmt.Decl;
 import org.aya.concrete.stmt.Signatured;
 import org.aya.core.def.*;
 import org.aya.core.pat.Pat;
+import org.aya.core.repr.AyaShape;
 import org.aya.core.term.CallTerm;
 import org.aya.core.term.FormTerm;
 import org.aya.core.term.Term;
@@ -32,15 +33,15 @@ import java.util.function.Consumer;
 /**
  * @author ice1000, kiva
  * @apiNote this class does not create {@link ExprTycker} instances itself,
- * but use the one passed to it. {@link StmtTycker#newTycker(PrimDef.Factory)} creates instances
+ * but use the one passed to it. {@link StmtTycker#newTycker(PrimDef.Factory, AyaShape.Factory)} creates instances
  * of expr tyckers.
  */
 public record StmtTycker(
   @NotNull Reporter reporter,
   Trace.@Nullable Builder traceBuilder
 ) {
-  public @NotNull ExprTycker newTycker(@NotNull PrimDef.Factory primFactory) {
-    return new ExprTycker(primFactory, reporter, traceBuilder);
+  public @NotNull ExprTycker newTycker(@NotNull PrimDef.Factory primFactory, @NotNull AyaShape.Factory literalShapes) {
+    return new ExprTycker(primFactory, literalShapes, reporter, traceBuilder);
   }
 
   private void tracing(@NotNull Consumer<Trace.@NotNull Builder> consumer) {

--- a/base/src/main/java/org/aya/tyck/error/AmbiguousLitError.java
+++ b/base/src/main/java/org/aya/tyck/error/AmbiguousLitError.java
@@ -1,0 +1,31 @@
+// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.tyck.error;
+
+import kala.collection.immutable.ImmutableSeq;
+import org.aya.concrete.Expr;
+import org.aya.core.def.Def;
+import org.aya.generic.ExprProblem;
+import org.aya.pretty.doc.Doc;
+import org.aya.pretty.doc.Style;
+import org.aya.util.distill.DistillerOptions;
+import org.jetbrains.annotations.NotNull;
+
+public record AmbiguousLitError(@Override @NotNull Expr expr, @NotNull ImmutableSeq<Def> defs) implements ExprProblem {
+  @Override public @NotNull Severity level() {
+    return Severity.ERROR;
+  }
+
+  @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+    return Doc.vcat(
+      Doc.english("More than one types can be used to encode the literal:"),
+      Doc.par(1, expr.toDoc(options)),
+      Doc.english("Candidates are:"),
+      Doc.par(1, Doc.join(Doc.plain(", "), defs.map(d -> Doc.styled(Style.code(), d.ref().name()))))
+    );
+  }
+
+  @Override public @NotNull Doc hint(@NotNull DistillerOptions options) {
+    return Doc.english("Specify the type explicitly can resolve the ambiguity.");
+  }
+}

--- a/base/src/main/java/org/aya/tyck/error/BadLiteralPatternError.java
+++ b/base/src/main/java/org/aya/tyck/error/BadLiteralPatternError.java
@@ -1,0 +1,27 @@
+// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.tyck.error;
+
+import org.aya.core.term.Term;
+import org.aya.pretty.doc.Doc;
+import org.aya.util.distill.DistillerOptions;
+import org.aya.util.error.SourcePos;
+import org.aya.util.reporter.Problem;
+import org.jetbrains.annotations.NotNull;
+
+public record BadLiteralPatternError(
+  @NotNull SourcePos sourcePos,
+  int integer,
+  @NotNull Term type
+) implements Problem {
+  @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+    return Doc.vcat(Doc.english("The literal"),
+      Doc.par(1, Doc.plain(String.valueOf(integer))),
+      Doc.english("cannot be encoded as a term of type:"),
+      Doc.par(1, type.toDoc(options)));
+  }
+
+  @Override public @NotNull Severity level() {
+    return Severity.ERROR;
+  }
+}

--- a/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
@@ -201,7 +201,7 @@ public record AyaSccTycker(
   private void bonjour(@NotNull Def def) {
     AyaShape.LITERAL_SHAPES.view()
       .filter(shape -> ShapeMatcher.match(shape.codeShape(), def))
-      .forEach(shape -> resolveInfo.shapeFactory().discovered().getOrPut(def, MutableList::create).append(shape));
+      .forEach(shape -> resolveInfo.shapeFactory().bonjour(def, shape));
   }
 
   private @NotNull ExprTycker reuse(@NotNull TopLevelDecl decl) {

--- a/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
@@ -206,13 +206,19 @@ public record AyaSccTycker(
 
   private @NotNull ExprTycker reuse(@NotNull TopLevelDecl decl) {
     // prevent counterexample errors from being reported to the user reporter
-    if (decl.personality() == Decl.Personality.COUNTEREXAMPLE)
-      return tyckerReuse.getOrPut(decl, () -> new ExprTycker(resolveInfo.primFactory(), sampleReporters.getOrPut(decl, BufferReporter::new), tycker.traceBuilder()));
+    if (decl.personality() == Decl.Personality.COUNTEREXAMPLE) {
+      var reporter = sampleReporters.getOrPut(decl, BufferReporter::new);
+      return tyckerReuse.getOrPut(decl, () -> newExprTycker(reporter));
+    }
     return tyckerReuse.getOrPut(decl, this::newExprTycker);
   }
 
   private @NotNull ExprTycker newExprTycker() {
-    return tycker.newTycker(resolveInfo.primFactory());
+    return tycker.newTycker(resolveInfo.primFactory(), resolveInfo.shapeFactory());
+  }
+
+  private @NotNull ExprTycker newExprTycker(@NotNull Reporter reporter) {
+    return new ExprTycker(resolveInfo.primFactory(), resolveInfo.shapeFactory(), reporter, tycker.traceBuilder());
   }
 
   private void terck(@NotNull SeqView<TyckOrder> units) {

--- a/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
@@ -14,6 +14,8 @@ import org.aya.concrete.stmt.TopLevelDecl;
 import org.aya.core.def.Def;
 import org.aya.core.def.FnDef;
 import org.aya.core.def.UserDef;
+import org.aya.core.repr.AyaShape;
+import org.aya.core.repr.ShapeMatcher;
 import org.aya.core.term.Term;
 import org.aya.generic.util.InterruptException;
 import org.aya.resolve.ResolveInfo;
@@ -182,7 +184,10 @@ public record AyaSccTycker(
 
   private void decideTyckResult(@NotNull Decl decl, @NotNull Def def) {
     switch (decl.personality) {
-      case NORMAL -> wellTyped.append(def);
+      case NORMAL -> {
+        wellTyped.append(def);
+        bonjour(def);
+      }
       case COUNTEREXAMPLE -> {
         var sampleReporter = sampleReporters.getOrPut(decl, BufferReporter::new);
         var problems = sampleReporter.problems().toImmutableSeq();
@@ -190,6 +195,13 @@ public record AyaSccTycker(
         if (def instanceof UserDef userDef) userDef.problems = problems;
       }
     }
+  }
+
+  /** Discovery of shaped literals */
+  private void bonjour(@NotNull Def def) {
+    AyaShape.LITERAL_SHAPES.view()
+      .filter(shape -> ShapeMatcher.match(shape.codeShape(), def))
+      .forEach(shape -> resolveInfo.shapeFactory().discovered().getOrPut(def, MutableList::create).append(shape));
   }
 
   private @NotNull ExprTycker reuse(@NotNull TopLevelDecl decl) {

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -139,8 +139,11 @@ public record PatClassifier(
   }
 
   private static @NotNull Pat head(@NotNull MCT.SubPats<Pat> subPats) {
+    var head = subPats.head();
+    // Just build the head to avoid unnecessary computation
+    if (head instanceof Pat.ShapedInt lit) return lit.constructorForm();
     // This 'inline' is actually a 'dereference'
-    return subPats.head().inline();
+    else return head.inline();
   }
 
   /**

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -8,7 +8,6 @@ import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableMap;
 import kala.control.Result;
-import kala.range.primitive.IntRange;
 import kala.tuple.Tuple;
 import kala.tuple.Tuple2;
 import kala.tuple.Tuple3;
@@ -28,6 +27,7 @@ import org.aya.core.visitor.Subst;
 import org.aya.core.visitor.TermFixpoint;
 import org.aya.core.visitor.Unfolder;
 import org.aya.generic.Constants;
+import org.aya.generic.util.InternalException;
 import org.aya.generic.util.NormalizeMode;
 import org.aya.pretty.doc.Doc;
 import org.aya.ref.LocalVar;
@@ -196,15 +196,24 @@ public final class PatTycker {
       case Pattern.CalmFace face -> new Pat.Meta(face.explicit(), new Ref<>(),
         new LocalVar(Constants.ANONYMOUS_PREFIX, face.sourcePos()), term);
       case Pattern.Number num -> {
-        if (term.normalize(exprTycker.state, NormalizeMode.WHNF) instanceof FormTerm.Interval) {
-          if (IntRange.closed(0, 1).contains(num.number()))
-            yield new Pat.End(num.number() == 1, num.explicit());
-          yield withError(new NotAnIntervalError(num.sourcePos(), num.number()), num, term);
-        } else {
-          throw new UnsupportedOperationException("Number patterns are unsupported yet");
+        var ty = term.normalize(exprTycker.state, NormalizeMode.WHNF);
+        if (ty instanceof FormTerm.Interval) {
+          var end = num.number();
+          if (end == 0 || end == 1) yield new Pat.End(num.number() == 1, num.explicit());
+          yield withError(new NotAnIntervalError(num.sourcePos(), end), num, term);
         }
+        if (ty instanceof CallTerm.Data dataCall) {
+          var data = dataCall.ref().core;
+          var shapes = exprTycker.literalShapes.discovered().getOption(data);
+          if (shapes.isDefined()) {
+            var shape = shapes.get();
+            if (shape.sizeGreaterThan(1)) throw new UnsupportedOperationException("TODO: how to choose?");
+            yield new Pat.ShapedInt(num.number(), shape.first(), dataCall, num.explicit());
+          }
+        }
+        throw new UnsupportedOperationException("Number patterns are unsupported yet");
       }
-      default -> throw new UnsupportedOperationException("Number patterns are unsupported yet");
+      case Pattern.BinOpSeq binOpSeq -> throw new InternalException("BinOpSeq patterns should be desugared");
     };
   }
 

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -35,6 +35,7 @@ import org.aya.ref.Var;
 import org.aya.tyck.ExprTycker;
 import org.aya.tyck.TyckState;
 import org.aya.tyck.env.LocalCtx;
+import org.aya.tyck.error.BadLiteralPatternError;
 import org.aya.tyck.error.NotAnIntervalError;
 import org.aya.tyck.error.NotYetTyckedError;
 import org.aya.tyck.trace.Trace;
@@ -207,7 +208,7 @@ public final class PatTycker {
           var shape = exprTycker.shapeFactory.find(data);
           if (shape.isDefined()) yield new Pat.ShapedInt(num.number(), shape.get(), dataCall, num.explicit());
         }
-        throw new UnsupportedOperationException("Number patterns are unsupported yet");
+        yield withError(new BadLiteralPatternError(num.sourcePos(), num.number(), term), num, term);
       }
       case Pattern.BinOpSeq binOpSeq -> throw new InternalException("BinOpSeq patterns should be desugared");
     };

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -204,12 +204,8 @@ public final class PatTycker {
         }
         if (ty instanceof CallTerm.Data dataCall) {
           var data = dataCall.ref().core;
-          var shapes = exprTycker.literalShapes.discovered().getOption(data);
-          if (shapes.isDefined()) {
-            var shape = shapes.get();
-            if (shape.sizeGreaterThan(1)) throw new UnsupportedOperationException("TODO: how to choose?");
-            yield new Pat.ShapedInt(num.number(), shape.first(), dataCall, num.explicit());
-          }
+          var shape = exprTycker.shapeFactory.find(data);
+          if (shape.isDefined()) yield new Pat.ShapedInt(num.number(), shape.get(), dataCall, num.explicit());
         }
         throw new UnsupportedOperationException("Number patterns are unsupported yet");
       }

--- a/base/src/main/java/org/aya/tyck/unify/DefEq.java
+++ b/base/src/main/java/org/aya/tyck/unify/DefEq.java
@@ -147,8 +147,17 @@ public final class DefEq {
         lhs.ref() != rhs.ref() ? null : visitCall(lhs, rhs, lr, rl, lhs.ref(), lhs.ulift());
       case CallTerm.Con lhs && preRhs instanceof CallTerm.Con rhs ->
         lhs.ref() != rhs.ref() ? null : visitCall(lhs, rhs, lr, rl, lhs.ref(), lhs.ulift());
+      case CallTerm.Con lhs && preRhs instanceof LitTerm.ShapedInt rhs ->
+        compareApprox(lhs, rhs.constructorForm(), lr, rl);
+      case LitTerm.ShapedInt lhs && preRhs instanceof CallTerm.Con rhs ->
+        compareApprox(lhs.constructorForm(), rhs, lr, rl);
       case CallTerm.Prim lhs && preRhs instanceof CallTerm.Prim rhs ->
         lhs.ref() != rhs.ref() ? null : visitCall(lhs, rhs, lr, rl, lhs.ref(), lhs.ulift());
+      case LitTerm.ShapedInt lhs && preRhs instanceof LitTerm.ShapedInt rhs -> {
+        if (lhs.shape() != rhs.shape()) yield null;
+        if (lhs.integer() != rhs.integer()) yield null;
+        yield lhs.type(); // TODO: what about rhs.type()? Does same shape imply same type?
+      }
       default -> null;
     };
   }

--- a/base/src/main/java/org/aya/tyck/unify/DefEq.java
+++ b/base/src/main/java/org/aya/tyck/unify/DefEq.java
@@ -148,13 +148,13 @@ public final class DefEq {
       case CallTerm.Con lhs && preRhs instanceof CallTerm.Con rhs ->
         lhs.ref() != rhs.ref() ? null : visitCall(lhs, rhs, lr, rl, lhs.ref(), lhs.ulift());
       case CallTerm.Con lhs && preRhs instanceof LitTerm.ShapedInt rhs ->
-        compareApprox(lhs, rhs.constructorForm(), lr, rl);
+        compareApprox(lhs, rhs.constructorForm(state), lr, rl);
       case LitTerm.ShapedInt lhs && preRhs instanceof CallTerm.Con rhs ->
-        compareApprox(lhs.constructorForm(), rhs, lr, rl);
+        compareApprox(lhs.constructorForm(state), rhs, lr, rl);
       case CallTerm.Prim lhs && preRhs instanceof CallTerm.Prim rhs ->
         lhs.ref() != rhs.ref() ? null : visitCall(lhs, rhs, lr, rl, lhs.ref(), lhs.ulift());
       case LitTerm.ShapedInt lhs && preRhs instanceof LitTerm.ShapedInt rhs -> {
-        if (!lhs.sameValue(rhs)) yield null;
+        if (!lhs.sameValue(state, rhs)) yield null;
         yield lhs.type(); // What about rhs.type()? A: sameValue implies same type
       }
       default -> null;

--- a/base/src/main/java/org/aya/tyck/unify/DefEq.java
+++ b/base/src/main/java/org/aya/tyck/unify/DefEq.java
@@ -154,9 +154,8 @@ public final class DefEq {
       case CallTerm.Prim lhs && preRhs instanceof CallTerm.Prim rhs ->
         lhs.ref() != rhs.ref() ? null : visitCall(lhs, rhs, lr, rl, lhs.ref(), lhs.ulift());
       case LitTerm.ShapedInt lhs && preRhs instanceof LitTerm.ShapedInt rhs -> {
-        if (lhs.shape() != rhs.shape()) yield null;
-        if (lhs.integer() != rhs.integer()) yield null;
-        yield lhs.type(); // TODO: what about rhs.type()? Does same shape imply same type?
+        if (!lhs.sameValue(rhs)) yield null;
+        yield lhs.type(); // What about rhs.type()? A: sameValue implies same type
       }
       default -> null;
     };

--- a/base/src/main/java/org/aya/tyck/unify/DefEq.java
+++ b/base/src/main/java/org/aya/tyck/unify/DefEq.java
@@ -147,16 +147,8 @@ public final class DefEq {
         lhs.ref() != rhs.ref() ? null : visitCall(lhs, rhs, lr, rl, lhs.ref(), lhs.ulift());
       case CallTerm.Con lhs && preRhs instanceof CallTerm.Con rhs ->
         lhs.ref() != rhs.ref() ? null : visitCall(lhs, rhs, lr, rl, lhs.ref(), lhs.ulift());
-      case CallTerm.Con lhs && preRhs instanceof LitTerm.ShapedInt rhs ->
-        compareApprox(lhs, rhs.constructorForm(state), lr, rl);
-      case LitTerm.ShapedInt lhs && preRhs instanceof CallTerm.Con rhs ->
-        compareApprox(lhs.constructorForm(state), rhs, lr, rl);
       case CallTerm.Prim lhs && preRhs instanceof CallTerm.Prim rhs ->
         lhs.ref() != rhs.ref() ? null : visitCall(lhs, rhs, lr, rl, lhs.ref(), lhs.ulift());
-      case LitTerm.ShapedInt lhs && preRhs instanceof LitTerm.ShapedInt rhs -> {
-        if (!lhs.sameValue(state, rhs)) yield null;
-        yield lhs.type(); // What about rhs.type()? A: sameValue implies same type
-      }
       default -> null;
     };
   }
@@ -377,14 +369,18 @@ public final class DefEq {
         var args = visitArgs(lhs.args(), rhs.args(), lr, rl, Term.Param.subst(Def.defTele(lhs.ref()), lhs.ulift()));
         yield args ? FormTerm.Univ.ZERO : null;
       }
-      case CallTerm.Con lhs -> {
-        if (!(preRhs instanceof CallTerm.Con rhs) || lhs.ref() != rhs.ref()) yield null;
-        var retType = getType(lhs, lhs.ref());
-        // Lossy comparison
-        if (visitArgs(lhs.conArgs(), rhs.conArgs(), lr, rl, Term.Param.subst(CtorDef.conTele(lhs.ref()), lhs.ulift())))
-          yield retType;
-        yield null;
-      }
+      case CallTerm.Con lhs -> switch (preRhs) {
+        case CallTerm.Con rhs -> {
+          if (lhs.ref() != rhs.ref()) yield null;
+          var retType = getType(lhs, lhs.ref());
+          // Lossy comparison
+          if (visitArgs(lhs.conArgs(), rhs.conArgs(), lr, rl, Term.Param.subst(CtorDef.conTele(lhs.ref()), lhs.ulift())))
+            yield retType;
+          yield null;
+        }
+        case LitTerm.ShapedInt rhs -> compareUntyped(lhs, rhs.constructorForm(state), lr, rl);
+        default -> null;
+      };
       case CallTerm.Prim lhs -> null;
       case CallTerm.Access lhs -> {
         if (!(preRhs instanceof CallTerm.Access rhs)) yield null;
@@ -393,6 +389,14 @@ public final class DefEq {
         if (lhs.ref() != rhs.ref()) yield null;
         yield Def.defResult(lhs.ref());
       }
+      case LitTerm.ShapedInt lhs -> switch (preRhs) {
+        case LitTerm.ShapedInt rhs -> {
+          if (!lhs.sameValue(state, rhs)) yield null;
+          yield lhs.type(); // What about rhs.type()? A: sameValue implies same type
+        }
+        case CallTerm.Con rhs -> compareUntyped(lhs.constructorForm(state), rhs, lr, rl);
+        default -> null;
+      };
       case CallTerm.Hole lhs -> solveMeta(preRhs, lr, rl, lhs);
     };
     traceExit();

--- a/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
+++ b/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
@@ -17,16 +17,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ShapeMatcherTest {
   @Test
   public void matchNat() {
-    match(true, AyaShape.DATA_NAT, "open data Nat | zero | suc Nat");
-    match(true, AyaShape.DATA_NAT, "open data Nat | suc Nat | zero");
-    match(true, AyaShape.DATA_NAT, "open data Nat | z | s Nat");
+    match(true, AyaShape.AyaIntLitShape.DATA_NAT, "open data Nat | zero | suc Nat");
+    match(true, AyaShape.AyaIntLitShape.DATA_NAT, "open data Nat | suc Nat | zero");
+    match(true, AyaShape.AyaIntLitShape.DATA_NAT, "open data Nat | z | s Nat");
 
-    match(ImmutableSeq.of(true, false), AyaShape.DATA_NAT, """
+    match(ImmutableSeq.of(true, false), AyaShape.AyaIntLitShape.DATA_NAT, """
     open data Nat | zero | suc Nat
     open data Fin (n : Nat) | suc n => fzero | suc n => fsuc (Fin n)
     """);
 
-    match(false, AyaShape.DATA_NAT, "open data Nat | s | z");
+    match(false, AyaShape.AyaIntLitShape.DATA_NAT, "open data Nat | s | z");
   }
 
   public void match(boolean should, @NotNull CodeShape shape, @Language("TEXT") @NonNls @NotNull String code) {

--- a/base/src/test/java/org/aya/tyck/TyckDeclTest.java
+++ b/base/src/test/java/org/aya/tyck/TyckDeclTest.java
@@ -11,6 +11,7 @@ import org.aya.concrete.stmt.Decl;
 import org.aya.concrete.stmt.Stmt;
 import org.aya.core.def.Def;
 import org.aya.core.def.PrimDef;
+import org.aya.core.repr.AyaShape;
 import org.aya.resolve.ResolveInfo;
 import org.aya.resolve.context.EmptyContext;
 import org.aya.resolve.context.ModuleContext;
@@ -31,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class TyckDeclTest {
   public static Def tyck(@NotNull PrimDef.Factory factory, @NotNull Decl decl, Trace.@Nullable Builder builder) {
     var tycker = new StmtTycker(ThrowingReporter.INSTANCE, builder);
-    return tycker.tyck(decl, tycker.newTycker(factory));
+    return tycker.tyck(decl, tycker.newTycker(factory, new AyaShape.Factory()));
   }
 
   public static @NotNull Tuple2<PrimDef.Factory, ImmutableSeq<Stmt>> successDesugarDecls(@Language("TEXT") @NonNls @NotNull String text) {

--- a/base/src/test/resources/failure/patterns/literal-bad.aya
+++ b/base/src/test/resources/failure/patterns/literal-bad.aya
@@ -1,0 +1,4 @@
+open data Test | t
+def not-conf Test : Test
+  | 1 => t
+

--- a/base/src/test/resources/failure/patterns/literal-bad.aya.txt
+++ b/base/src/test/resources/failure/patterns/literal-bad.aya.txt
@@ -1,0 +1,14 @@
+In file $FILE:3:4 ->
+
+  1 | open data Test | t
+  2 | def not-conf Test : Test
+  3 |   | 1 => t
+          ^^
+
+Error: The literal
+         1
+       cannot be encoded as a term of type:
+         Test
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/patterns/literal-conf.aya
+++ b/base/src/test/resources/failure/patterns/literal-conf.aya
@@ -1,0 +1,9 @@
+open data Nat | zero | suc Nat
+
+def overlap not-conf Nat
+  | zero => 1
+  | 0 => 0
+  | 1 => 1
+  | suc 1 => 1
+  | suc n => n
+

--- a/base/src/test/resources/failure/patterns/literal-conf.aya.txt
+++ b/base/src/test/resources/failure/patterns/literal-conf.aya.txt
@@ -1,0 +1,71 @@
+In file $FILE:5:4 ->
+
+  3 | def overlap not-conf Nat
+  4 |   | zero => 1
+  5 |   | 0 => 0
+          ^----^
+
+Warning: The 1st clause dominates the 2nd clause. The 2nd clause will be unreachable
+
+In file $FILE:4:4 ->
+
+  2 | 
+  3 | def overlap not-conf Nat
+  4 |   | zero => 1
+          ^-------^
+
+Warning: The 2nd clause dominates the 1st clause. The 1st clause will be unreachable
+
+In file $FILE:3:12 ->
+
+  1 | open data Nat | zero | suc Nat
+  2 | 
+  3 | def overlap not-conf Nat
+  4 |   | zero => 1
+          ^-------^ substituted to `1`
+  5 |   | 0 => 0
+          ^----^ substituted to `0`
+
+Error: The 1st and the 2nd clauses are not confluent because we failed to unify
+         1
+       and
+         0
+
+In file $FILE:6:4 ->
+
+  4 |   | zero => 1
+  5 |   | 0 => 0
+  6 |   | 1 => 1
+          ^----^
+
+Warning: The 5th clause dominates the 3rd clause. The 3rd clause will be unreachable
+
+In file $FILE:3:12 ->
+
+  1 | open data Nat | zero | suc Nat
+  2 | 
+  3 | def overlap not-conf Nat
+  4 |   | zero => 1
+  5 |   | 0 => 0
+  6 |   | 1 => 1
+          ^----^ substituted to `1`
+  7 |   | suc 1 => 1
+  8 |   | suc n => n
+          ^--------^ substituted to `0`
+
+Error: The 3rd and the 5th clauses are not confluent because we failed to unify
+         1
+       and
+         0
+
+In file $FILE:7:4 ->
+
+  5 |   | 0 => 0
+  6 |   | 1 => 1
+  7 |   | suc 1 => 1
+          ^--------^
+
+Warning: The 5th clause dominates the 4th clause. The 4th clause will be unreachable
+
+2 error(s), 4 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tyck/literal-ambiguous-1.aya
+++ b/base/src/test/resources/failure/tyck/literal-ambiguous-1.aya
@@ -1,0 +1,10 @@
+open data Nat1 | z1 | s1 Nat1
+open data Nat2 | z2 | s2 Nat2
+
+open data Option (A : Type)
+  | none
+  | some A
+
+def ok : Option Nat1 => some 114
+def lit1 => some 514
+

--- a/base/src/test/resources/failure/tyck/literal-ambiguous-1.aya.txt
+++ b/base/src/test/resources/failure/tyck/literal-ambiguous-1.aya.txt
@@ -1,0 +1,34 @@
+In file $FILE:9:17 ->
+
+  7 | 
+  8 | def ok : Option Nat1 => some 114
+  9 | def lit1 => some 514
+                       ^-^
+
+Error: Unsolved meta A'
+       in `Option A'`
+       in `Option A'`
+
+In file $FILE:9:17 ->
+
+  7 | 
+  8 | def ok : Option Nat1 => some 114
+  9 | def lit1 => some 514
+                       ^-^
+
+Error: Unsolved meta A'
+       in `some 514`
+
+In file $FILE:9:17 ->
+
+  7 | 
+  8 | def ok : Option Nat1 => some 114
+  9 | def lit1 => some 514
+                       ^-^
+
+Error: Unsolved meta A'
+       in `514`
+       in `some 514`
+
+3 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tyck/literal-ambiguous-2.aya
+++ b/base/src/test/resources/failure/tyck/literal-ambiguous-2.aya
@@ -1,0 +1,6 @@
+open data Nat1 | z1 | s1 Nat1
+open data Nat2 | z2 | s2 Nat2
+open data Empty
+
+def take Empty => Empty
+def test => take 0

--- a/base/src/test/resources/failure/tyck/literal-ambiguous-2.aya.txt
+++ b/base/src/test/resources/failure/tyck/literal-ambiguous-2.aya.txt
@@ -1,0 +1,15 @@
+In file $FILE:6:17 ->
+
+  4 | 
+  5 | def take Empty => Empty
+  6 | def test => take 0
+                       ^^
+
+Error: More than one types can be used to encode the literal:
+         0
+       Candidates are:
+         `Nat1`, `Nat2`
+note: Specify the type explicitly can resolve the ambiguity.
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tyck/literal-solving.aya
+++ b/base/src/test/resources/failure/tyck/literal-solving.aya
@@ -1,0 +1,5 @@
+open data Nat1 | z1 | s1 Nat1
+open data Empty
+
+def take Empty => Empty
+def test => take 0

--- a/base/src/test/resources/failure/tyck/literal-solving.aya.txt
+++ b/base/src/test/resources/failure/tyck/literal-solving.aya.txt
@@ -1,0 +1,16 @@
+In file $FILE:5:17 ->
+
+  3 | 
+  4 | def take Empty => Empty
+  5 | def test => take 0
+                       ^^
+
+Error: Cannot check the expression
+         0
+       of type
+         Nat1
+       against the type
+         Empty
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/cli/src/main/java/org/aya/cli/repl/ReplCompiler.java
+++ b/cli/src/main/java/org/aya/cli/repl/ReplCompiler.java
@@ -62,7 +62,7 @@ public class ReplCompiler {
     var resolvedExpr = expr.resolve(context);
     // in case we have un-messaged TyckException
     try (var delayedReporter = new DelayedReporter(reporter)) {
-      // TODO: literal shapes
+      // TODO[literal]: literal shapes
       var tycker = new ExprTycker(primFactory, new AyaShape.Factory(), delayedReporter, null);
       var desugar = desugarExpr(resolvedExpr, delayedReporter);
       return tycker.zonk(tycker.synthesize(desugar));

--- a/cli/src/main/java/org/aya/cli/repl/ReplCompiler.java
+++ b/cli/src/main/java/org/aya/cli/repl/ReplCompiler.java
@@ -16,6 +16,7 @@ import org.aya.concrete.desugar.Desugarer;
 import org.aya.concrete.stmt.Stmt;
 import org.aya.core.def.Def;
 import org.aya.core.def.PrimDef;
+import org.aya.core.repr.AyaShape;
 import org.aya.core.term.Term;
 import org.aya.generic.util.InterruptException;
 import org.aya.generic.util.NormalizeMode;
@@ -61,7 +62,8 @@ public class ReplCompiler {
     var resolvedExpr = expr.resolve(context);
     // in case we have un-messaged TyckException
     try (var delayedReporter = new DelayedReporter(reporter)) {
-      var tycker = new ExprTycker(primFactory, delayedReporter, null);
+      // TODO: literal shapes
+      var tycker = new ExprTycker(primFactory, new AyaShape.Factory(), delayedReporter, null);
       var desugar = desugarExpr(resolvedExpr, delayedReporter);
       return tycker.zonk(tycker.synthesize(desugar));
     }


### PR DESCRIPTION
This PR implements literal numbers for Aya with the following features:
- Recognize representable datatypes like `Nat` with a flexible code shape matcher
- Meta-solving-based literal type decision for optimizing multiple datatypes at the same time.
- Pattern matching on literal

Future work:
- Recognize functions that operate on literal and replace them with Java backed operations (with pragma?)
- Polish the unification
- Tyck order for literal and data defs, the following code does not tyck
  ```
  def lit => 0
  data Nat | zero | suc Nat
  ```

For reviewers:
- Pay attention to `ExprTycker#doInherit`, not sure if the hole was generated in an ideal way.
- The `type` field of `LitTerm.ShapedInt` and `Pat.ShapedInt` looks annoying, but I failed to remove it :sob: 