### PR TITLE
Remove check of string literal from ExprTycker and add test output

### DIFF
--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -374,12 +374,6 @@ public final class ExprTycker extends Tycker {
         }
         yield unifyTyMaybeInsert(term, synthesize(expr), expr);
       }
-      case Expr.LitStringExpr litStr -> {
-        if (term instanceof CallTerm.Prim prim && prim.id() == PrimDef.ID.STR)
-          yield new Result(new PrimTerm.Str(litStr.string()), term);
-
-        yield fail(expr, new NoRuleError(expr, term));
-      }
       default -> unifyTyMaybeInsert(term, synthesize(expr), expr);
     };
   }

--- a/base/src/test/resources/failure/tyck/stringlit-1.aya.txt
+++ b/base/src/test/resources/failure/tyck/stringlit-1.aya.txt
@@ -1,0 +1,9 @@
+In file $FILE:1:9 ->
+
+  1 | def a => "123"
+               ^---^
+
+Error: No rule inferring the type of "123"
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tyck/stringlit-2.aya.txt
+++ b/base/src/test/resources/failure/tyck/stringlit-2.aya.txt
@@ -1,0 +1,9 @@
+In file $FILE:1:16 ->
+
+  1 | def a : Type => "123"
+                      ^---^
+
+Error: No rule inferring the type of "123"
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tyck/stringlit-3.aya.txt
+++ b/base/src/test/resources/failure/tyck/stringlit-3.aya.txt
@@ -1,0 +1,16 @@
+In file $FILE:5:19 ->
+
+  3 | open data Unit : Type | unit
+  4 | 
+  5 | def test : Unit => "123"
+                         ^---^
+
+Error: Cannot check the expression
+         "123"
+       of type
+         String
+       against the type
+         Unit
+
+1 error(s), 0 warning(s).
+What are you doing?


### PR DESCRIPTION
The `default -> unifyTyMaybeInsert(term, synthesize(expr), expr);` is eligible for:
- checking the string literal
- solving the meta to string type (allowing this code `def a => "hello"`)

so,
bors merge