### PR TITLE
Optimize `PatClassifier` for literals

### DIFF
--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -280,14 +280,15 @@ public record PatClassifier(
             continue;
           }
           MCT<Term, PatErr> classified;
-          // The base case of classifying literals together with other patterns is that:
-          // the `matches` only has two kinds of patterns: bind and literal.
+          // The base case of classifying literals together with other patterns:
+          // variable `nonEmpty` only has two kinds of patterns: bind and literal.
           // We should put all bind patterns altogether and check overlapping of literals, which avoids
           // converting them to constructor forms and preventing possible stack overflow
           // (because literal overlapping check is simple).
-          var hasLit = matches.filter(subPats -> subPats.pats().isNotEmpty() && head(subPats) instanceof Pat.ShapedInt);
-          var hasBind = matches.filter(subPats -> subPats.pats().isNotEmpty() && head(subPats) instanceof Pat.Bind);
-          if (hasLit.isNotEmpty() && hasBind.isNotEmpty() && hasLit.size() + hasBind.size() == matches.size()) {
+          var nonEmpty = matches.filter(subPats -> subPats.pats().isNotEmpty());
+          var hasLit = nonEmpty.filter(subPats -> head(subPats) instanceof Pat.ShapedInt);
+          var hasBind = nonEmpty.filter(subPats -> head(subPats) instanceof Pat.Bind);
+          if (hasLit.isNotEmpty() && hasBind.isNotEmpty() && hasLit.size() + hasBind.size() == nonEmpty.size()) {
             // We are in the base case.
             var bindsIx = hasBind.map(MCT.SubPats::ix);
             // classify all literals

--- a/base/src/test/resources/failure/patterns/confl-literal.aya
+++ b/base/src/test/resources/failure/patterns/confl-literal.aya
@@ -1,0 +1,10 @@
+open data Nat | zero | suc Nat
+
+def overlap test Nat : Nat
+  | 0 => 0
+  | a => a
+  | suc a => suc a
+  | suc (suc a) => a
+  | 2147483647 => 3
+  | 2147483647 => 4
+  | 114514 => 1919

--- a/base/src/test/resources/failure/patterns/confl-literal.aya.txt
+++ b/base/src/test/resources/failure/patterns/confl-literal.aya.txt
@@ -1,0 +1,184 @@
+In file $FILE:4:4 ->
+
+  2 | 
+  3 | def overlap test Nat : Nat
+  4 |   | 0 => 0
+          ^----^
+
+Warning: The 2nd clause dominates the 1st clause. The 1st clause will be unreachable
+
+In file $FILE:6:4 ->
+
+  4 |   | 0 => 0
+  5 |   | a => a
+  6 |   | suc a => suc a
+          ^------------^
+
+Warning: The 2nd clause dominates the 3rd clause. The 3rd clause will be unreachable
+
+In file $FILE:10:4 ->
+
+   8 |   | 2147483647 => 3
+   9 |   | 2147483647 => 4
+  10 |   | 114514 => 1919
+           ^------------^
+
+Warning: The 2nd clause dominates the 7th clause. The 7th clause will be unreachable
+
+In file $FILE:3:12 ->
+
+   1 | open data Nat | zero | suc Nat
+   2 | 
+   3 | def overlap test Nat : Nat
+   4 |   | 0 => 0
+   5 |   | a => a
+           ^----^ substituted to `114514`
+   6 |   | suc a => suc a
+   7 |   | suc (suc a) => a
+   8 |   | 2147483647 => 3
+   9 |   | 2147483647 => 4
+  10 |   | 114514 => 1919
+           ^------------^ substituted to `1919`
+
+Error: The 7th and the 2nd clauses are not confluent because we failed to unify
+         1919
+       and
+         114514
+
+In file $FILE:6:4 ->
+
+  4 |   | 0 => 0
+  5 |   | a => a
+  6 |   | suc a => suc a
+          ^------------^
+
+Warning: The 2nd clause dominates the 3rd clause. The 3rd clause will be unreachable
+
+In file $FILE:7:4 ->
+
+  5 |   | a => a
+  6 |   | suc a => suc a
+  7 |   | suc (suc a) => a
+          ^--------------^
+
+Warning: The 3rd clause dominates the 4th clause. The 4th clause will be unreachable
+
+In file $FILE:3:12 ->
+
+  1 | open data Nat | zero | suc Nat
+  2 | 
+  3 | def overlap test Nat : Nat
+  4 |   | 0 => 0
+  5 |   | a => a
+  6 |   | suc a => suc a
+          ^------------^ substituted to `suc (suc a)`
+  7 |   | suc (suc a) => a
+          ^--------------^ substituted to `a`
+
+Error: The 3rd and the 4th clauses are not confluent because we failed to unify
+         suc (suc a)
+       and
+         a
+
+In file $FILE:9:4 ->
+
+  7 |   | suc (suc a) => a
+  8 |   | 2147483647 => 3
+  9 |   | 2147483647 => 4
+          ^-------------^
+
+Warning: The 5th clause dominates the 6th clause. The 6th clause will be unreachable
+
+In file $FILE:8:4 ->
+
+  6 |   | suc a => suc a
+  7 |   | suc (suc a) => a
+  8 |   | 2147483647 => 3
+          ^-------------^
+
+Warning: The 6th clause dominates the 5th clause. The 5th clause will be unreachable
+
+In file $FILE:3:12 ->
+
+  1 | open data Nat | zero | suc Nat
+  2 | 
+  3 | def overlap test Nat : Nat
+  4 |   | 0 => 0
+  5 |   | a => a
+  6 |   | suc a => suc a
+  7 |   | suc (suc a) => a
+  8 |   | 2147483647 => 3
+          ^-------------^ substituted to `3`
+  9 |   | 2147483647 => 4
+          ^-------------^ substituted to `4`
+
+Error: The 5th and the 6th clauses are not confluent because we failed to unify
+         3
+       and
+         4
+
+In file $FILE:9:4 ->
+
+  7 |   | suc (suc a) => a
+  8 |   | 2147483647 => 3
+  9 |   | 2147483647 => 4
+          ^-------------^
+
+Warning: The 2nd clause dominates the 6th clause. The 6th clause will be unreachable
+
+In file $FILE:3:12 ->
+
+  1 | open data Nat | zero | suc Nat
+  2 | 
+  3 | def overlap test Nat : Nat
+  4 |   | 0 => 0
+  5 |   | a => a
+          ^----^ substituted to `2147483647`
+  6 |   | suc a => suc a
+  7 |   | suc (suc a) => a
+  8 |   | 2147483647 => 3
+  9 |   | 2147483647 => 4
+          ^-------------^ substituted to `4`
+
+Error: The 6th and the 2nd clauses are not confluent because we failed to unify
+         4
+       and
+         2147483647
+
+In file $FILE:6:4 ->
+
+  4 |   | 0 => 0
+  5 |   | a => a
+  6 |   | suc a => suc a
+          ^------------^
+
+Warning: The 2nd clause dominates the 3rd clause. The 3rd clause will be unreachable
+
+In file $FILE:7:4 ->
+
+  5 |   | a => a
+  6 |   | suc a => suc a
+  7 |   | suc (suc a) => a
+          ^--------------^
+
+Warning: The 3rd clause dominates the 4th clause. The 4th clause will be unreachable
+
+In file $FILE:3:12 ->
+
+  1 | open data Nat | zero | suc Nat
+  2 | 
+  3 | def overlap test Nat : Nat
+  4 |   | 0 => 0
+  5 |   | a => a
+  6 |   | suc a => suc a
+          ^------------^ substituted to `suc (suc a)`
+  7 |   | suc (suc a) => a
+          ^--------------^ substituted to `a`
+
+Error: The 3rd and the 4th clauses are not confluent because we failed to unify
+         suc (suc a)
+       and
+         a
+
+5 error(s), 10 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/patterns/confl-literal2.aya
+++ b/base/src/test/resources/failure/patterns/confl-literal2.aya
@@ -1,0 +1,35 @@
+open data Nat | zero | suc Nat
+
+def overlap largeInt1 Nat Nat : Nat
+  | a, b => a
+  | 114514, 1919810 => 1
+
+def overlap largeInt2 Nat Nat : Nat
+  | a, b => b
+  | a, 1919810 => 1
+
+def overlap largeInt3 Nat Nat : Nat
+  | a, b => b
+  | a, suc b => b
+  | a, 1919810 => 1
+
+def overlap largeInt1-inv Nat Nat : Nat
+  | a, b => a
+  | 114514, 1919810 => 1
+
+def overlap largeInt2-inv Nat Nat : Nat
+  | b, a => b
+  | 1919810, a => 1
+
+def overlap largeInt3-inv Nat Nat : Nat
+  | b, a => b
+  | suc b, a => b
+  | 1919810, a => 1
+
+def overlap multi-nodes Nat Nat : Nat
+  | 114, 0 => 0
+  | 114, suc b => suc b
+  | 114, 514 => 515
+  | 115, 514 => 514
+  | a, b => b
+--^ should be 3 groups: [0, 4], [1, 2, 4], [3, 4]

--- a/base/src/test/resources/failure/patterns/confl-literal2.aya.txt
+++ b/base/src/test/resources/failure/patterns/confl-literal2.aya.txt
@@ -1,0 +1,230 @@
+In file $FILE:5:4 ->
+
+  3 | def overlap largeInt1 Nat Nat : Nat
+  4 |   | a, b => a
+  5 |   | 114514, 1919810 => 1
+          ^------------------^
+
+Warning: The 1st clause dominates the 2nd clause. The 2nd clause will be unreachable
+
+In file $FILE:3:12 ->
+
+  1 | open data Nat | zero | suc Nat
+  2 | 
+  3 | def overlap largeInt1 Nat Nat : Nat
+  4 |   | a, b => a
+          ^-------^ substituted to `114514`
+  5 |   | 114514, 1919810 => 1
+          ^------------------^ substituted to `1`
+
+Error: The 2nd and the 1st clauses are not confluent because we failed to unify
+         1
+       and
+         114514
+
+In file $FILE:9:4 ->
+
+  7 | def overlap largeInt2 Nat Nat : Nat
+  8 |   | a, b => b
+  9 |   | a, 1919810 => 1
+          ^-------------^
+
+Warning: The 1st clause dominates the 2nd clause. The 2nd clause will be unreachable
+
+In file $FILE:7:12 ->
+
+  5 |   | 114514, 1919810 => 1
+  6 | 
+  7 | def overlap largeInt2 Nat Nat : Nat
+  8 |   | a, b => b
+          ^-------^ substituted to `1919810`
+  9 |   | a, 1919810 => 1
+          ^-------------^ substituted to `1`
+
+Error: The 2nd and the 1st clauses are not confluent because we failed to unify
+         1
+       and
+         1919810
+
+In file $FILE:14:4 ->
+
+  12 |   | a, b => b
+  13 |   | a, suc b => b
+  14 |   | a, 1919810 => 1
+           ^-------------^
+
+Warning: The 1st clause dominates the 3rd clause. The 3rd clause will be unreachable
+
+In file $FILE:11:12 ->
+
+   9 |   | a, 1919810 => 1
+  10 | 
+  11 | def overlap largeInt3 Nat Nat : Nat
+  12 |   | a, b => b
+           ^-------^ substituted to `1919810`
+  13 |   | a, suc b => b
+  14 |   | a, 1919810 => 1
+           ^-------------^ substituted to `1`
+
+Error: The 3rd and the 1st clauses are not confluent because we failed to unify
+         1
+       and
+         1919810
+
+In file $FILE:11:12 ->
+
+   9 |   | a, 1919810 => 1
+  10 | 
+  11 | def overlap largeInt3 Nat Nat : Nat
+  12 |   | a, b => b
+           ^-------^ substituted to `suc b`
+  13 |   | a, suc b => b
+           ^-----------^ substituted to `b`
+
+Error: The 1st and the 2nd clauses are not confluent because we failed to unify
+         suc b
+       and
+         b
+
+In file $FILE:18:4 ->
+
+  16 | def overlap largeInt1-inv Nat Nat : Nat
+  17 |   | a, b => a
+  18 |   | 114514, 1919810 => 1
+           ^------------------^
+
+Warning: The 1st clause dominates the 2nd clause. The 2nd clause will be unreachable
+
+In file $FILE:16:12 ->
+
+  14 |   | a, 1919810 => 1
+  15 | 
+  16 | def overlap largeInt1-inv Nat Nat : Nat
+  17 |   | a, b => a
+           ^-------^ substituted to `114514`
+  18 |   | 114514, 1919810 => 1
+           ^------------------^ substituted to `1`
+
+Error: The 2nd and the 1st clauses are not confluent because we failed to unify
+         1
+       and
+         114514
+
+In file $FILE:22:4 ->
+
+  20 | def overlap largeInt2-inv Nat Nat : Nat
+  21 |   | b, a => b
+  22 |   | 1919810, a => 1
+           ^-------------^
+
+Warning: The 1st clause dominates the 2nd clause. The 2nd clause will be unreachable
+
+In file $FILE:20:12 ->
+
+  18 |   | 114514, 1919810 => 1
+  19 | 
+  20 | def overlap largeInt2-inv Nat Nat : Nat
+  21 |   | b, a => b
+           ^-------^ substituted to `1919810`
+  22 |   | 1919810, a => 1
+           ^-------------^ substituted to `1`
+
+Error: The 2nd and the 1st clauses are not confluent because we failed to unify
+         1
+       and
+         1919810
+
+In file $FILE:27:4 ->
+
+  25 |   | b, a => b
+  26 |   | suc b, a => b
+  27 |   | 1919810, a => 1
+           ^-------------^
+
+Warning: The 1st clause dominates the 3rd clause. The 3rd clause will be unreachable
+
+In file $FILE:24:12 ->
+
+  22 |   | 1919810, a => 1
+  23 | 
+  24 | def overlap largeInt3-inv Nat Nat : Nat
+  25 |   | b, a => b
+           ^-------^ substituted to `1919810`
+  26 |   | suc b, a => b
+  27 |   | 1919810, a => 1
+           ^-------------^ substituted to `1`
+
+Error: The 3rd and the 1st clauses are not confluent because we failed to unify
+         1
+       and
+         1919810
+
+In file $FILE:24:12 ->
+
+  22 |   | 1919810, a => 1
+  23 | 
+  24 | def overlap largeInt3-inv Nat Nat : Nat
+  25 |   | b, a => b
+           ^-------^ substituted to `suc b`
+  26 |   | suc b, a => b
+           ^-----------^ substituted to `b`
+
+Error: The 1st and the 2nd clauses are not confluent because we failed to unify
+         suc b
+       and
+         b
+
+In file $FILE:30:4 ->
+
+  28 | 
+  29 | def overlap multi-nodes Nat Nat : Nat
+  30 |   | 114, 0 => 0
+           ^---------^
+
+Warning: The 5th clause dominates the 1st clause. The 1st clause will be unreachable
+
+In file $FILE:32:4 ->
+
+  30 |   | 114, 0 => 0
+  31 |   | 114, suc b => suc b
+  32 |   | 114, 514 => 515
+           ^-------------^
+
+Warning: The 2nd clause dominates the 3rd clause. The 3rd clause will be unreachable
+
+In file $FILE:29:12 ->
+
+  27 |   | 1919810, a => 1
+  28 | 
+  29 | def overlap multi-nodes Nat Nat : Nat
+  30 |   | 114, 0 => 0
+  31 |   | 114, suc b => suc b
+           ^-----------------^ substituted to `suc 513`
+  32 |   | 114, 514 => 515
+           ^-------------^ substituted to `515`
+
+Error: The 3rd and the 2nd clauses are not confluent because we failed to unify
+         515
+       and
+         suc 513
+
+In file $FILE:31:4 ->
+
+  29 | def overlap multi-nodes Nat Nat : Nat
+  30 |   | 114, 0 => 0
+  31 |   | 114, suc b => suc b
+           ^-----------------^
+
+Warning: The 5th clause dominates the 2nd clause. The 2nd clause will be unreachable
+
+In file $FILE:33:4 ->
+
+  31 |   | 114, suc b => suc b
+  32 |   | 114, 514 => 515
+  33 |   | 115, 514 => 514
+           ^-------------^
+
+Warning: The 5th clause dominates the 4th clause. The 4th clause will be unreachable
+
+9 error(s), 10 warning(s).
+What are you doing?

--- a/base/src/test/resources/success/src/Literal.aya
+++ b/base/src/test/resources/success/src/Literal.aya
@@ -68,3 +68,16 @@ def overlap largeInt Nat : Nat
   | 0 => 0
   | 2147483647 => 2147483647
   | suc a => suc a
+
+def overlap largeInt2 Nat Nat : Nat
+  | a, b => a
+  | 114514, 1919810 => 114514
+
+def overlap multi-nodes Nat Nat : Nat
+  | 114, 0 => 0
+  | 114, suc b => suc b
+  | 114, 514 => 514
+  | 115, 514 => 514
+  | a, b => b
+--^ should be 3 groups: [0, 4], [1, 2, 4], [3, 4]
+

--- a/base/src/test/resources/success/src/Literal.aya
+++ b/base/src/test/resources/success/src/Literal.aya
@@ -66,6 +66,5 @@ def even Nat : Bool
 
 def overlap largeInt Nat : Nat
   | 0 => 0
--- TODO: PatClassifier
---  | 2147483647 => 2147483647
+  | 2147483647 => 2147483647
   | suc a => suc a


### PR DESCRIPTION
We used to convert literals to constructor forms when classifying them, so it's possible to overflow the stack if the literal was too large. 

But when classifying literal patterns together with other patterns, literal patterns will be converted to constructor forms whenever there are remaining constructor patterns, for example, when calling `classify([20, suc a])`, the patterns below
```
20 => 
suc a =>
```
will be treated as
```
suc 19 =>
suc a =>
```

So we put them in an `MCT.Node` and remove their heads to form the next-step-patterns `[19, a]` and recursively call `classify([19, a])`, which may cause StackOverflow if the literal 19 becomes larger.

It's easy to find the optimizable case: there always exists a scenario that **the patterns to be classified in the next step has only two kinds of patterns: bind and literal**, like `[19, a]` or `[19, 19, 20, a]`.

This PR takes into account the situation described above and replaces the convert-then-match method with a  simple `groupingBy` to classify literals when possible.

note: this PR contains 502 addition, but don't panic because most of them are tests.

Sorry for my English