### PR TITLE
Redo lift

### DIFF
--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -97,7 +97,7 @@ public final class PrimDef extends TopLevelDef {
         var paramI = new LocalVar("i");
         var result = new FormTerm.Univ(0);
         var paramATy = new FormTerm.Pi(paramIToATy, result);
-        var aRef = new RefTerm(paramA, 0);
+        var aRef = new RefTerm(paramA);
         var baseAtLeft = new ElimTerm.App(aRef, new Arg<>(PrimTerm.End.LEFT, true));
         return new PrimDef(
           ref,
@@ -106,7 +106,7 @@ public final class PrimDef extends TopLevelDef {
             new Term.Param(new LocalVar("base"), baseAtLeft, true),
             new Term.Param(paramI, FormTerm.Interval.INSTANCE, true)
           ),
-          new ElimTerm.App(aRef, new Arg<>(new RefTerm(paramI, 0), true)),
+          new ElimTerm.App(aRef, new Arg<>(new RefTerm(paramI), true)),
           ID.ARCOE
         );
       }, ImmutableSeq.empty());

--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -76,7 +76,7 @@ public sealed interface Pat extends AyaDocile {
     public @NotNull Pat rename(@NotNull Subst subst, @NotNull LocalCtx localCtx, boolean explicit) {
       var newName = new LocalVar(bind.name(), bind.definition());
       var newBind = new Bind(explicit, newName, type.subst(subst));
-      subst.addDirectly(bind, new RefTerm(newName, 0));
+      subst.addDirectly(bind, new RefTerm(newName));
       localCtx.put(newName, type);
       return newBind;
     }

--- a/base/src/main/java/org/aya/core/pat/PatToTerm.java
+++ b/base/src/main/java/org/aya/core/pat/PatToTerm.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.pat;
 
@@ -20,9 +20,9 @@ public class PatToTerm {
   public Term visit(@NotNull Pat pat) {
     return switch (pat) {
       // [ice]: this code is reachable (to substitute a telescope), but the telescope will be dropped anyway.
-      case Pat.Absurd absurd -> new RefTerm(new LocalVar("()"), 0);
+      case Pat.Absurd absurd -> new RefTerm(new LocalVar("()"));
       case Pat.Ctor ctor -> visitCtor(ctor);
-      case Pat.Bind bind -> new RefTerm(bind.bind(), 0);
+      case Pat.Bind bind -> new RefTerm(bind.bind());
       case Pat.Tuple tuple -> new IntroTerm.Tuple(tuple.pats().map(this::visit));
       case Pat.Meta meta -> new RefTerm.MetaPat(meta, 0);
       case Pat.End end -> end.isRight() ? PrimTerm.End.RIGHT : PrimTerm.End.LEFT;

--- a/base/src/main/java/org/aya/core/pat/PatToTerm.java
+++ b/base/src/main/java/org/aya/core/pat/PatToTerm.java
@@ -24,7 +24,7 @@ public class PatToTerm {
       case Pat.Ctor ctor -> visitCtor(ctor);
       case Pat.Bind bind -> new RefTerm(bind.bind());
       case Pat.Tuple tuple -> new IntroTerm.Tuple(tuple.pats().map(this::visit));
-      case Pat.Meta meta -> new RefTerm.MetaPat(meta, 0);
+      case Pat.Meta meta -> new RefTerm.MetaPat(meta);
       case Pat.End end -> end.isRight() ? PrimTerm.End.RIGHT : PrimTerm.End.LEFT;
       case Pat.ShapedInt lit -> new LitTerm.ShapedInt(lit.repr(), lit.shape(), lit.type());
     };

--- a/base/src/main/java/org/aya/core/serde/SerTerm.java
+++ b/base/src/main/java/org/aya/core/serde/SerTerm.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.serde;
 
@@ -101,7 +101,7 @@ public sealed interface SerTerm extends Serializable {
 
   record Ref(@NotNull SimpVar var, int ulift) implements SerTerm {
     @Override public @NotNull Term de(@NotNull DeState state) {
-      return new RefTerm(state.var(var), ulift);
+      return new RefTerm(state.var(var));
     }
   }
 

--- a/base/src/main/java/org/aya/core/serde/SerTerm.java
+++ b/base/src/main/java/org/aya/core/serde/SerTerm.java
@@ -99,7 +99,7 @@ public sealed interface SerTerm extends Serializable {
     }
   }
 
-  record Ref(@NotNull SimpVar var, int ulift) implements SerTerm {
+  record Ref(@NotNull SimpVar var) implements SerTerm {
     @Override public @NotNull Term de(@NotNull DeState state) {
       return new RefTerm(state.var(var));
     }
@@ -201,9 +201,9 @@ public sealed interface SerTerm extends Serializable {
     }
   }
 
-  record FieldRef(@NotNull SerDef.QName name, int ulift) implements SerTerm {
+  record FieldRef(@NotNull SerDef.QName name) implements SerTerm {
     @Override public @NotNull Term de(@NotNull DeState state) {
-      return new RefTerm.Field(state.resolve(name), ulift);
+      return new RefTerm.Field(state.resolve(name));
     }
   }
 

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -76,8 +76,8 @@ public record Serializer(@NotNull Serializer.State state) {
         new SerTerm.ShapedInt(lit.repr(), SerDef.SerAyaShape.serialize(lit.shape()), serialize(lit.type()));
       case PrimTerm.End end -> new SerTerm.End(end.isRight());
       case PrimTerm.Str str -> new SerTerm.Str(str.string());
-      case RefTerm ref -> new SerTerm.Ref(state.local(ref.var()), ref.lift());
-      case RefTerm.Field ref -> new SerTerm.FieldRef(state.def(ref.ref()), ref.lift());
+      case RefTerm ref -> new SerTerm.Ref(state.local(ref.var()));
+      case RefTerm.Field ref -> new SerTerm.FieldRef(state.def(ref.ref()));
       case FormTerm.Interval interval -> new SerTerm.Interval();
       case FormTerm.Pi pi -> new SerTerm.Pi(serialize(pi.param()), serialize(pi.body()));
       case FormTerm.Sigma sigma -> new SerTerm.Sigma(serializeParams(sigma.params()));

--- a/base/src/main/java/org/aya/core/term/RefTerm.java
+++ b/base/src/main/java/org/aya/core/term/RefTerm.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.term;
 
@@ -12,13 +12,11 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author ice1000
  */
-public record RefTerm(@NotNull LocalVar var, int lift) implements Term {
-
-  public record Field(@NotNull DefVar<FieldDef, TeleDecl.StructField> ref, int lift) implements Term {
+public record RefTerm(@NotNull LocalVar var) implements Term {
+  public record Field(@NotNull DefVar<FieldDef, TeleDecl.StructField> ref) implements Term {
   }
 
-  public record MetaPat(@NotNull Pat.Meta ref, int lift) implements Term {
-
+  public record MetaPat(@NotNull Pat.Meta ref) implements Term {
     public @NotNull Term inline() {
       var sol = ref.solution().get();
       return sol != null ? sol.toTerm() : this;

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -246,7 +246,7 @@ public sealed interface Term extends AyaDocile permits CallTerm, ElimTerm, Error
     }
 
     @Contract(" -> new") public @NotNull RefTerm toTerm() {
-      return new RefTerm(ref, 0);
+      return new RefTerm(ref);
     }
 
     public @NotNull Pat toPat() {

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -495,7 +495,7 @@ public final class ExprTycker extends Tycker {
       //  - check the definition's correctness: happens here
       //  - check the field value's correctness: happens in `visitNew` after the body was instantiated
       var field = (DefVar<FieldDef, TeleDecl.StructField>) var;
-      return new Result(new RefTerm.Field(field, 0), Def.defType(field));
+      return new Result(new RefTerm.Field(field), Def.defType(field));
     } else {
       final var msg = "Def var `" + var.name() + "` has core `" + var.core + "` which we don't know.";
       throw new InternalException(msg);

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -65,7 +65,7 @@ public final class ExprTycker extends Tycker {
       case Expr.RefExpr ref -> switch (ref.resolvedVar()) {
         case LocalVar loc -> {
           var ty = localCtx.get(loc);
-          yield new Result(new RefTerm(loc, 0), ty);
+          yield new Result(new RefTerm(loc), ty);
         }
         case DefVar<?, ?> defVar -> inferRef(ref.sourcePos(), defVar);
         default -> throw new InternalException("Unknown var: " + ref.resolvedVar().getClass());

--- a/base/src/main/java/org/aya/tyck/unify/DefEq.java
+++ b/base/src/main/java/org/aya/tyck/unify/DefEq.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck.unify;
 
@@ -257,7 +257,7 @@ public final class DefEq {
           var dummyVars = fieldSig.selfTele.map(par ->
             new LocalVar(par.ref().name(), par.ref().definition()));
           var dummy = dummyVars.zip(fieldSig.selfTele).map(vpa ->
-            new Arg<Term>(new RefTerm(vpa._1, 0), vpa._2.explicit()));
+            new Arg<Term>(new RefTerm(vpa._1), vpa._2.explicit()));
           var l = new CallTerm.Access(lhs, fieldSig.ref(), type1.args(), dummy);
           var r = new CallTerm.Access(rhs, fieldSig.ref(), type1.args(), dummy);
           fieldSubst.add(fieldSig.ref(), l);

--- a/base/src/test/java/org/aya/core/EtaTest.java
+++ b/base/src/test/java/org/aya/core/EtaTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core;
 
@@ -29,10 +29,10 @@ public class EtaTest {
   // \ x -> f x
   @Test public void oneLambdaUneta() {
     var xParamTerm = new Term.Param(X, FormTerm.Univ.ZERO, false);
-    var xRefTerm = new RefTerm(X, 0);
+    var xRefTerm = new RefTerm(X);
     // It's rather tedious to construct a Fn here
     // So let's be lazy here as the type of f doesn't really matter
-    var fRefTerm = new RefTerm(new LocalVar("f"), 0);
+    var fRefTerm = new RefTerm(new LocalVar("f"));
     var lambda = IntroTerm.Lambda.make(
       // Params
       ImmutableSeq.of(xParamTerm),
@@ -46,9 +46,9 @@ public class EtaTest {
   @Test public void twoLambdaUneta() {
     var xParamTerm = new Term.Param(X, FormTerm.Univ.ZERO, false);
     var yParamTerm = new Term.Param(Y, FormTerm.Univ.ZERO, false);
-    var xRefTerm = new RefTerm(X, 0);
-    var yRefTerm = new RefTerm(Y, 0);
-    var fRefTerm = new RefTerm(new LocalVar("f"), 0);
+    var xRefTerm = new RefTerm(X);
+    var yRefTerm = new RefTerm(Y);
+    var fRefTerm = new RefTerm(new LocalVar("f"));
     var lambda = IntroTerm.Lambda.make(
       // Params
       ImmutableSeq.of(xParamTerm, yParamTerm),
@@ -62,7 +62,7 @@ public class EtaTest {
 
   // (x.1, x.2)
   @Test public void tupleUneta() {
-    var xRefTerm = new RefTerm(X, 0);
+    var xRefTerm = new RefTerm(X);
     var firstTerm = new ElimTerm.Proj(xRefTerm, 1);
     var secondTerm = new ElimTerm.Proj(xRefTerm, 2);
     var tuple = new IntroTerm.Tuple(ImmutableSeq.of(firstTerm, secondTerm));
@@ -71,7 +71,7 @@ public class EtaTest {
 
   // (x.1, (x.1, x.2).2)
   @Test public void nestTupleUneta() {
-    var xRefTerm = new RefTerm(X, 0);
+    var xRefTerm = new RefTerm(X);
     var firstTerm = new ElimTerm.Proj(xRefTerm, 1);
     var secondTerm = new ElimTerm.Proj(xRefTerm, 2);
     var tuple = new IntroTerm.Tuple(ImmutableSeq.of(firstTerm, secondTerm));
@@ -82,8 +82,8 @@ public class EtaTest {
   // \x -> f (x.1, x.2)
   @Test public void tupleAndLambdaUneta() {
     var xParamTerm = new Term.Param(X, SIGMA, false);
-    var xRefTerm = new RefTerm(X, 0);
-    var fRefTerm = new RefTerm(new LocalVar("f"), 0);
+    var xRefTerm = new RefTerm(X);
+    var fRefTerm = new RefTerm(new LocalVar("f"));
     // construct lambda body: tuple term
     var firstTerm = new ElimTerm.Proj(xRefTerm, 1);
     var secondTerm = new ElimTerm.Proj(xRefTerm, 2);


### PR DESCRIPTION
Removed `RefTerm::lift`. I'm not yet sure if my changes are complete, cus in concrete there's gonna be invalid 'lift local var' and we want to report errors (now lift is restricted to defcalls).
