### PR TITLE
Properly configure the inputs of prepareMergedJarsDir

### DIFF
--- a/buildSrc/src/main/groovy/org/aya/gradle/GenerateVersionTask.groovy
+++ b/buildSrc/src/main/groovy/org/aya/gradle/GenerateVersionTask.groovy
@@ -17,7 +17,7 @@ class GenerateVersionTask extends DefaultTask {
   final @InputDirectory File inputDir = project.rootProject.file(".git")
   @OutputDirectory File outputDir
   @Input String className
-  @Input final def basePackage = project.group
+  @Input def basePackage = project.group
   @Input final def taskVersion = project.version
 
   @TaskAction def run() {

--- a/buildSrc/src/main/groovy/org/aya/gradle/GenerateVersionTask.groovy
+++ b/buildSrc/src/main/groovy/org/aya/gradle/GenerateVersionTask.groovy
@@ -4,6 +4,7 @@ package org.aya.gradle
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
@@ -13,10 +14,11 @@ class GenerateVersionTask extends DefaultTask {
     group = "build setup"
   }
 
+  final @InputDirectory File inputDir = project.rootProject.file(".git")
   @OutputDirectory File outputDir
   @Input String className
-  @Input def basePackage = project.group
-  @Input def taskVersion = project.version
+  @Input final def basePackage = project.group
+  @Input final def taskVersion = project.version
 
   @TaskAction def run() {
     def stdout = BuildUtil.gitRev(project.rootDir)
@@ -32,7 +34,11 @@ class GenerateVersionTask extends DefaultTask {
       }""".stripIndent()
     outputDir.mkdirs()
     def outFile = new File(outputDir, "${className}.java")
-    if (!outFile.exists()) assert outFile.createNewFile()
+    if (!outFile.exists()) {
+      // Side effects
+      def result = outFile.createNewFile()
+      assert result
+    }
     outFile.write(code)
   }
 }

--- a/lsp/build.gradle.kts
+++ b/lsp/build.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 import org.aya.gradle.CommonTasks
 
@@ -67,8 +67,10 @@ jlinkTask.configure {
 }
 val prepareMergedJarsDirTask = tasks.named("prepareMergedJarsDir")
 prepareMergedJarsDirTask.configure {
-  dependsOn(":cli:jar")
-  dependsOn(":base:jar")
+  listOf(":cli:jar", ":base:jar").mapNotNull(tasks::findByPath).forEach {
+    dependsOn(it)
+    inputs.files(it.outputs.files)
+  }
 }
 
 tasks.withType<AbstractCopyTask>().configureEach {

--- a/lsp/build.gradle.kts
+++ b/lsp/build.gradle.kts
@@ -67,7 +67,8 @@ jlinkTask.configure {
 }
 val prepareMergedJarsDirTask = tasks.named("prepareMergedJarsDir")
 prepareMergedJarsDirTask.configure {
-  listOf(":cli:jar", ":base:jar").mapNotNull(tasks::findByPath).forEach {
+  val libs = listOf("cli", "base", "pretty", "tools", "tools-repl", "parser")
+  libs.map { ":$it:jar" }.mapNotNull(tasks::findByPath).forEach {
     dependsOn(it)
     inputs.files(it.outputs.files)
   }


### PR DESCRIPTION
So that `jlink` is reexecuted when base or cli are recompiled.