### PR TITLE
Fix #345

### DIFF
--- a/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
@@ -138,10 +138,10 @@ public interface StmtResolver {
     var resolver = new ExprResolver(options);
     resolver.enterHead();
     var local = resolver.resolveParams(decl.telescope, decl.ctx);
+    decl.result = resolver.resolve(decl.result, local._2);
     decl.telescope = local._1
       .prependedAll(resolver.allowedGeneralizes().valuesView())
       .toImmutableSeq();
-    decl.result = resolver.resolve(decl.result, local._2);
     return Tuple.of(resolver, local._2);
   }
 

--- a/base/src/test/resources/success/src/Issues/345.aya
+++ b/base/src/test/resources/success/src/Issues/345.aya
@@ -1,0 +1,8 @@
+open data Unit : Type | unit
+
+open struct Wrapped (A : Type) : Type
+
+variable B : Type
+
+def test Unit : Wrapped B -> Unit
+  | unit => \(x : Wrapped B) => unit


### PR DESCRIPTION
Changed `resolveDeclSignature()` to generate telescope at the last step.

This closes #345.