### PR TITLE
Be strict when comparing constructors for termination

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -37,8 +37,6 @@ However, we can share some cool stuffs here:
   (instead of a number, such as in Haskell or Agda)
   which is useful for [equation reasoning][assoc].
 + Termination checker inspired from foetus.
-  We adapted some code from Agda's implementation to accept
-  [more definitions][foetus] (which are rejected by, e.g. Arend).
 + Inference of type checking order. That is to say,
   no syntax for forward-declarations is needed for [mutual recursions][mutual].
 
@@ -99,7 +97,6 @@ check out [how to][proxy] let gradle use a proxy.
 [funExt]: ../base/src/test/resources/success/common/src/Paths.aya
 [rbtree]: ../base/src/test/resources/success/common/src/Data/RedBlack.aya
 [assoc]: ../base/src/test/resources/success/src/Assoc.aya
-[foetus]: ../base/src/test/resources/success/src/FoetusLimitation.aya
 [mutual]: ../base/src/test/resources/success/src/Order.aya
 [maven-repo]: https://repo1.maven.org/maven2/org/aya-prover
 [Guest0x0]: https://github.com/ice1000/Guest0x0

--- a/base/src/main/java/org/aya/terck/CallResolver.java
+++ b/base/src/main/java/org/aya/terck/CallResolver.java
@@ -61,9 +61,7 @@ public record CallResolver(
           var subCompare = con.conArgs()
             .zipView(ctor.params())
             .map(sub -> compare(sub._1.term(), sub._2));
-          // compare one level deeper for sub-ctor-patterns like `cons (suc x) xs`, see FoetusLimitation.aya
-          // return subCompare.anyMatch(r -> r != Relation.Unknown) ? Relation.Equal : Relation.Unknown;
-          yield subCompare.max();
+          yield subCompare.anyMatch(r -> r != Relation.Unknown) ? Relation.Equal : Relation.Unknown;
         }
         // TODO[literal]: We may convert constructor call to literals to avoid possible stack overflow?
         case LitTerm.ShapedInt lit -> compare(lit.constructorForm(), ctor);

--- a/base/src/test/resources/success/src/FoetusLimitation.aya
+++ b/base/src/test/resources/success/src/FoetusLimitation.aya
@@ -1,7 +1,0 @@
-open data Nat | zero | suc Nat
-open data List (A : Type) : Type | nil | infixr :< A (List A)
-
-def sum (List Nat) : Nat
-  | nil => 0
-  | suc x :< xs => suc (sum (x :< xs))
-  | 0 :< xs => sum xs


### PR DESCRIPTION
fix #471

After days of digging into agda's codebase (most of the time was spent on setting up a haskell ide) I finally know the differences between foetus in paper and foetus in agda. I decide to bring them to aya after composing some conclusion notes.

The `FoetusLimitation.aya` test is only removed temporarily. We will see it back sooner or later 😉 