### PR TITLE
IntelliJ theme

### DIFF
--- a/base/src/main/java/org/aya/distill/BaseDistiller.java
+++ b/base/src/main/java/org/aya/distill/BaseDistiller.java
@@ -220,7 +220,7 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
   }
 
   static @NotNull Doc primDoc(AnyVar ref) {
-    return Doc.sep(Doc.styled(KEYWORD, "prim"), linkDef(ref, FN_CALL));
+    return Doc.sep(Doc.styled(KEYWORD, "prim"), linkDef(ref, PRIM_CALL));
   }
 
   public static @NotNull Doc linkDef(@NotNull AnyVar ref, @NotNull Style color) {
@@ -305,7 +305,7 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
       case TeleDecl.DataCtor d -> CON_CALL;
       case TeleDecl.StructDecl d -> STRUCT_CALL;
       case TeleDecl.StructField d -> FIELD_CALL;
-      case TeleDecl.PrimDecl d -> FN_CALL;
+      case TeleDecl.PrimDecl d -> PRIM_CALL;
       case null, default -> null;
     };
   }

--- a/base/src/main/java/org/aya/distill/BaseDistiller.java
+++ b/base/src/main/java/org/aya/distill/BaseDistiller.java
@@ -36,6 +36,7 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
   }
 
   public static final @NotNull Style KEYWORD = Style.preset("aya:Keyword");
+  public static final @NotNull Style PRIM_CALL = Style.preset("aya:PrimCall");
   public static final @NotNull Style FN_CALL = Style.preset("aya:FnCall");
   public static final @NotNull Style DATA_CALL = Style.preset("aya:DataCall");
   public static final @NotNull Style STRUCT_CALL = Style.preset("aya:StructCall");

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -123,7 +123,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
         yield visitCalls(false, term(Outer.AppHead, head), args.view(), outer,
           options.map.get(DistillerOptions.Key.ShowImplicitArgs));
       }
-      case CallTerm.Prim prim -> visitArgsCalls(prim.ref(), FN_CALL, prim.args(), outer);
+      case CallTerm.Prim prim -> visitArgsCalls(prim.ref(), PRIM_CALL, prim.args(), outer);
       case RefTerm.Field term -> linkRef(term.ref(), FIELD_CALL);
       case ElimTerm.Proj term ->
         Doc.cat(term(Outer.ProjHead, term.of()), Doc.symbol("."), Doc.plain(String.valueOf(term.ix())));

--- a/gradle/deps.properties
+++ b/gradle/deps.properties
@@ -10,7 +10,7 @@ version.annotations=23.0.0
 # https://github.com/antlr/antlr4/
 version.antlr=4.10.1
 version.kala=0.47.0
-version.guest0x0=0.16.2
+version.guest0x0=0.16.1
 version.build-util=0.0.3
 version.hamcrest=2.2
 version.junit=5.8.2

--- a/gradle/deps.properties
+++ b/gradle/deps.properties
@@ -10,7 +10,7 @@ version.annotations=23.0.0
 # https://github.com/antlr/antlr4/
 version.antlr=4.10.1
 version.kala=0.47.0
-version.guest0x0=0.16.1
+version.guest0x0=0.16.2
 version.build-util=0.0.3
 version.hamcrest=2.2
 version.junit=5.8.2

--- a/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.html;
 
@@ -6,6 +6,8 @@ import org.aya.pretty.backend.string.Cursor;
 import org.aya.pretty.backend.string.StringPrinter;
 import org.aya.pretty.backend.string.StringPrinterConfig;
 import org.aya.pretty.doc.Doc;
+import org.aya.pretty.style.AyaColorScheme;
+import org.aya.pretty.style.AyaStyleFamily;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
 
@@ -79,7 +81,7 @@ public class DocHtmlPrinter extends StringPrinter<DocHtmlPrinter.Config> {
     public final boolean withHeader;
 
     public Config(boolean withHeader) {
-      super(new Html5Stylist(), INFINITE_SIZE, true);
+      super(new Html5Stylist(AyaColorScheme.EMACS, AyaStyleFamily.DEFAULT), INFINITE_SIZE, true);
       this.withHeader = withHeader;
     }
   }

--- a/pretty/src/main/java/org/aya/pretty/backend/html/Html5Stylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/Html5Stylist.java
@@ -1,12 +1,18 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.html;
 
 import org.aya.pretty.backend.string.style.ClosingStylist;
 import org.aya.pretty.doc.Style;
+import org.aya.pretty.printer.ColorScheme;
+import org.aya.pretty.printer.StyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 public class Html5Stylist extends ClosingStylist {
+  public Html5Stylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
+    super(colorScheme, styleFamily);
+  }
+
   @Override protected @NotNull StyleToken formatItalic() {
     return new StyleToken("<i>", "</i>", false);
   }

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.latex;
 
@@ -7,6 +7,8 @@ import kala.tuple.Tuple;
 import org.aya.pretty.backend.string.Cursor;
 import org.aya.pretty.backend.string.StringPrinter;
 import org.aya.pretty.backend.string.StringPrinterConfig;
+import org.aya.pretty.style.AyaColorScheme;
+import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -60,7 +62,7 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
    */
   public static class Config extends StringPrinterConfig {
     public Config() {
-      super(new TeXStylist(), INFINITE_SIZE, false);
+      super(new TeXStylist(AyaColorScheme.INTELLIJ, AyaStyleFamily.DEFAULT), INFINITE_SIZE, false);
     }
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/TeXStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/TeXStylist.java
@@ -1,12 +1,18 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.latex;
 
 import org.aya.pretty.backend.string.style.ClosingStylist;
 import org.aya.pretty.doc.Style;
+import org.aya.pretty.printer.ColorScheme;
+import org.aya.pretty.printer.StyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 public class TeXStylist extends ClosingStylist {
+  public TeXStylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
+    super(colorScheme, styleFamily);
+  }
+
   @Override protected @NotNull StyleToken formatItalic() {
     return new StyleToken("\\textit{", "}", false);
   }

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinterConfig.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinterConfig.java
@@ -1,10 +1,11 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.string;
 
 import org.aya.pretty.backend.string.style.UnixTermStylist;
 import org.aya.pretty.printer.PrinterConfig;
 import org.aya.pretty.printer.StyleFamily;
+import org.aya.pretty.style.AyaColorScheme;
 import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,7 +25,7 @@ public class StringPrinterConfig extends PrinterConfig.Basic {
   }
 
   public static @NotNull StringPrinterConfig unixTerminal(@NotNull StyleFamily styleFamily, int pageWidth, boolean unicode) {
-    return new StringPrinterConfig(new UnixTermStylist(styleFamily), pageWidth, unicode);
+    return new StringPrinterConfig(new UnixTermStylist(AyaColorScheme.EMACS, styleFamily), pageWidth, unicode);
   }
 
   public static @NotNull StringPrinterConfig unixTerminal(int pageWidth) {

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinterConfig.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinterConfig.java
@@ -10,18 +10,15 @@ import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 public class StringPrinterConfig extends PrinterConfig.Basic {
-  public final @NotNull StringStylist stylist;
   public final boolean unicode;
 
   public StringPrinterConfig(@NotNull StringStylist stylist, int pageWidth, boolean unicode) {
-    super(pageWidth, INFINITE_SIZE);
-    this.stylist = stylist;
+    super(pageWidth, INFINITE_SIZE, stylist);
     this.unicode = unicode;
   }
 
-  @Override
-  public @NotNull StringStylist getStylist() {
-    return stylist;
+  @Override public @NotNull StringStylist getStylist() {
+    return (StringStylist) super.getStylist();
   }
 
   public static @NotNull StringPrinterConfig unixTerminal(@NotNull StyleFamily styleFamily, int pageWidth, boolean unicode) {

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringStylist.java
@@ -1,12 +1,18 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.string;
 
 import kala.collection.Seq;
 import org.aya.pretty.doc.Style;
+import org.aya.pretty.printer.ColorScheme;
+import org.aya.pretty.printer.StyleFamily;
 import org.aya.pretty.printer.Stylist;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class StringStylist extends Stylist {
+  public StringStylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
+    super(colorScheme, styleFamily);
+  }
+
   public abstract void format(@NotNull Seq<Style> style, @NotNull Cursor cursor, @NotNull Runnable inside);
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/string/style/ClosingStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/style/ClosingStylist.java
@@ -8,11 +8,17 @@ import kala.control.Option;
 import org.aya.pretty.backend.string.Cursor;
 import org.aya.pretty.backend.string.StringStylist;
 import org.aya.pretty.doc.Style;
+import org.aya.pretty.printer.ColorScheme;
+import org.aya.pretty.printer.StyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
 
 public abstract class ClosingStylist extends StringStylist {
+  public ClosingStylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
+    super(colorScheme, styleFamily);
+  }
+
   public record StyleToken(@NotNull CharSequence start, @NotNull CharSequence end, boolean visible) {
     public static final @NotNull StyleToken NULL = new StyleToken("", "", false);
 

--- a/pretty/src/main/java/org/aya/pretty/backend/string/style/DebugStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/style/DebugStylist.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.string.style;
 
@@ -6,6 +6,8 @@ import kala.collection.Seq;
 import org.aya.pretty.backend.string.Cursor;
 import org.aya.pretty.backend.string.StringStylist;
 import org.aya.pretty.doc.Style;
+import org.aya.pretty.style.AyaColorScheme;
+import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -15,6 +17,7 @@ public class DebugStylist extends StringStylist {
   public static final DebugStylist INSTANCE = new DebugStylist();
 
   private DebugStylist() {
+    super(AyaColorScheme.INTELLIJ, AyaStyleFamily.DEFAULT);
   }
 
   @Override public void format(@NotNull Seq<Style> style, @NotNull Cursor cursor, @NotNull Runnable inside) {

--- a/pretty/src/main/java/org/aya/pretty/backend/string/style/UnixTermStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/style/UnixTermStylist.java
@@ -1,15 +1,16 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.string.style;
 
 import org.aya.pretty.backend.string.custom.UnixTermStyle;
 import org.aya.pretty.doc.Style;
+import org.aya.pretty.printer.ColorScheme;
 import org.aya.pretty.printer.StyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 public class UnixTermStylist extends ClosingStylist {
-  public UnixTermStylist(@NotNull StyleFamily styleFamily) {
-    setStyleFamily(styleFamily);
+  public UnixTermStylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
+    super(colorScheme, styleFamily);
   }
 
   @Override protected @NotNull StyleToken formatItalic() {

--- a/pretty/src/main/java/org/aya/pretty/printer/PrinterConfig.java
+++ b/pretty/src/main/java/org/aya/pretty/printer/PrinterConfig.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.printer;
 
@@ -39,10 +39,7 @@ public interface PrinterConfig {
     return INFINITE_SIZE;
   }
 
-  default @NotNull Stylist getStylist() {
-    return new Stylist() {
-    };
-  }
+  @NotNull Stylist getStylist();
 
   /**
    * Basic configure for other configs to easily extend config flags.
@@ -50,19 +47,23 @@ public interface PrinterConfig {
   class Basic implements PrinterConfig {
     private final int pageWidth;
     private final int pageHeight;
+    private final @NotNull Stylist stylist;
 
-    public Basic(int pageWidth, int pageHeight) {
+    public Basic(int pageWidth, int pageHeight, @NotNull Stylist stylist) {
       this.pageWidth = pageWidth;
       this.pageHeight = pageHeight;
+      this.stylist = stylist;
     }
 
-    @Override
-    public int getPageWidth() {
+    @Override public @NotNull Stylist getStylist() {
+      return stylist;
+    }
+
+    @Override public int getPageWidth() {
       return pageWidth;
     }
 
-    @Override
-    public int getPageHeight() {
+    @Override public int getPageHeight() {
       return pageHeight;
     }
   }

--- a/pretty/src/main/java/org/aya/pretty/printer/Stylist.java
+++ b/pretty/src/main/java/org/aya/pretty/printer/Stylist.java
@@ -1,9 +1,9 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.printer;
 
+import org.aya.pretty.style.AyaColorScheme;
 import org.aya.pretty.style.AyaStyleFamily;
-import org.aya.pretty.style.EmacsColorScheme;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -14,7 +14,7 @@ public abstract class Stylist {
   protected @NotNull StyleFamily styleFamily;
 
   public Stylist() {
-    this(EmacsColorScheme.INSTANCE, AyaStyleFamily.DEFAULT);
+    this(AyaColorScheme.EMACS, AyaStyleFamily.DEFAULT);
   }
 
   public Stylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {

--- a/pretty/src/main/java/org/aya/pretty/style/AyaColorScheme.java
+++ b/pretty/src/main/java/org/aya/pretty/style/AyaColorScheme.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.style;
 
@@ -10,10 +10,10 @@ import org.jetbrains.annotations.NotNull;
 /**
  * The colors are from Emacs.
  */
-public record EmacsColorScheme(
+public record AyaColorScheme(
   @NotNull MutableMap<String, Integer> definedColors
 ) implements ColorScheme {
-  public static final EmacsColorScheme INSTANCE = new EmacsColorScheme(MutableMap.ofEntries(
+  public static final AyaColorScheme EMACS = new AyaColorScheme(MutableMap.ofEntries(
     Tuple.of("aya:Keyword", ColorScheme.colorOf(1.0f, 0.43f, 0)),
     Tuple.of("aya:FnCall", ColorScheme.colorOf(0, 0, 1f)),
     Tuple.of("aya:Generalized", ColorScheme.colorOf(0, 0, 1f)),

--- a/pretty/src/main/java/org/aya/pretty/style/AyaColorScheme.java
+++ b/pretty/src/main/java/org/aya/pretty/style/AyaColorScheme.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 public record AyaColorScheme(
   @NotNull MutableMap<String, Integer> definedColors
 ) implements ColorScheme {
-  public static final AyaColorScheme EMACS = new AyaColorScheme(MutableMap.ofEntries(
+  public static final @NotNull AyaColorScheme EMACS = new AyaColorScheme(MutableMap.ofEntries(
     Tuple.of("aya:Keyword", ColorScheme.colorOf(1.0f, 0.43f, 0)),
     Tuple.of("aya:FnCall", ColorScheme.colorOf(0, 0, 1f)),
     Tuple.of("aya:Generalized", ColorScheme.colorOf(0, 0, 1f)),
@@ -21,5 +21,15 @@ public record AyaColorScheme(
     Tuple.of("aya:StructCall", ColorScheme.colorOf(0.13f, 0.55f, 0.13f)),
     Tuple.of("aya:ConCall", ColorScheme.colorOf(0.63f, 0.13f, 0.94f)),
     Tuple.of("aya:FieldCall", ColorScheme.colorOf(0, 0.55f, 0.55f))
+  ));
+
+  public static final @NotNull AyaColorScheme INTELLIJ = new AyaColorScheme(MutableMap.ofEntries(
+    Tuple.of("aya:Keyword", 0x0033B3),
+    Tuple.of("aya:FnCall", 0x00627A),
+    Tuple.of("aya:Generalized", 0x00627A),
+    Tuple.of("aya:DataCall", 0x000000),
+    Tuple.of("aya:StructCall", 0x000000),
+    Tuple.of("aya:ConCall", 0x067D17),
+    Tuple.of("aya:FieldCall", 0x871094)
   ));
 }

--- a/pretty/src/main/java/org/aya/pretty/style/AyaStyleFamily.java
+++ b/pretty/src/main/java/org/aya/pretty/style/AyaStyleFamily.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.style;
 
@@ -15,6 +15,7 @@ public record AyaStyleFamily(
 ) implements StyleFamily {
   public static final @NotNull AyaStyleFamily DEFAULT = new AyaStyleFamily(MutableMap.ofEntries(
     Tuple.of("aya:Keyword", Style.bold().and().color("aya:Keyword")),
+    Tuple.of("aya:PrimCall", Style.color("aya:Keyword").and()),
     Tuple.of("aya:FnCall", Style.color("aya:FnCall").and()),
     Tuple.of("aya:DataCall", Style.color("aya:DataCall").and()),
     Tuple.of("aya:StructCall", Style.color("aya:StructCall").and()),
@@ -26,6 +27,7 @@ public record AyaStyleFamily(
   /** use colors from terminal instead of absolute colors to protect eyes */
   public static final @NotNull StyleFamily ADAPTIVE_CLI = new AyaStyleFamily(MutableMap.ofEntries(
     Tuple.of("aya:Keyword", Style.color("aya:Keyword").and()),
+    Tuple.of("aya:PrimCall", Style.color("aya:Keyword").and()),
     Tuple.of("aya:FnCall", UnixTermStyle.TerminalYellow.and()),
     Tuple.of("aya:DataCall", UnixTermStyle.TerminalGreen.and()),
     Tuple.of("aya:StructCall", UnixTermStyle.TerminalGreen.and()),


### PR DESCRIPTION
As said in the commit messages, I've added a new theme and it's randomly used in the codebase now.

I've refactored `PrinterConfig` and inheritors so that color schemes and styles are now taken from some constructor calls instead of in the deepest constructor overload of `Stylist`.

Anybody wanna make the color themes configurable?

bors r+