### PR TITLE
Distinguish unary from binary

### DIFF
--- a/base/src/main/java/org/aya/concrete/error/OperatorProblem.java
+++ b/base/src/main/java/org/aya/concrete/error/OperatorProblem.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.error;
 
@@ -81,8 +81,8 @@ public final class OperatorProblem {
 
     @Override public @NotNull Doc hint(@NotNull DistillerOptions options) {
       return Doc.sep(Doc.plain("Use"),
-        Doc.styled(BaseDistiller.KEYWORD.and().code(), Doc.plain("bind")),
-        Doc.english("statement or insert parentheses to make it clear."));
+        Doc.styled(BaseDistiller.KEYWORD.and().code(), Doc.plain("tighter/looser")),
+        Doc.english("clause or insert parentheses to make it clear."));
     }
   }
 

--- a/base/src/main/java/org/aya/core/serde/CompiledAya.java
+++ b/base/src/main/java/org/aya/core/serde/CompiledAya.java
@@ -95,8 +95,7 @@ public record CompiledAya(
       var concrete = def.ref().concrete;
       var opInfo = concrete.opInfo();
       if (opInfo != null) serOps.append(new SerDef.SerOp(
-        nameOf(serDef), opInfo.assoc(), opInfo.argc(),
-        serBind(concrete.bindBlock())));
+        nameOf(serDef), opInfo.assoc(), serBind(concrete.bindBlock())));
     }
 
     private @NotNull SerDef.SerBind serBind(@NotNull BindBlock bindBlock) {
@@ -150,7 +149,7 @@ public record CompiledAya(
   private void deOp(@NotNull SerTerm.DeState state, @NotNull AyaBinOpSet opSet) {
     serOps.forEach(serOp -> {
       var defVar = state.resolve(serOp.name());
-      var opInfo = new OpDecl.OpInfo(serOp.name().name(), serOp.assoc(), serOp.argc());
+      var opInfo = new OpDecl.OpInfo(serOp.name().name(), serOp.assoc());
       defVar.opDecl = new SerDef.SerOpDecl(opInfo);
     });
     serOps.view().forEach(serOp -> {

--- a/base/src/main/java/org/aya/core/serde/SerDef.java
+++ b/base/src/main/java/org/aya/core/serde/SerDef.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.serde;
 
@@ -135,7 +135,7 @@ public sealed interface SerDef extends Serializable {
   }
 
   /** Serialized version of {@link org.aya.util.binop.OpDecl.OpInfo} */
-  record SerOp(@NotNull QName name, @NotNull Assoc assoc, int argc, @NotNull SerBind bind) implements Serializable {
+  record SerOp(@NotNull QName name, @NotNull Assoc assoc, @NotNull SerBind bind) implements Serializable {
   }
 
   /** Serialized version of {@link org.aya.concrete.stmt.BindBlock} */

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -154,9 +154,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
       }
       case CallTerm.Struct structCall -> visitArgsCalls(structCall.ref(), STRUCT_CALL, structCall.args(), outer);
       case CallTerm.Data dataCall -> visitArgsCalls(dataCall.ref(), DATA_CALL, dataCall.args(), outer);
-      case LitTerm.ShapedInt shaped -> options.map.get(DistillerOptions.Key.ShowLiterals)
-        ? Doc.plain(String.valueOf(shaped.repr()))
-        : shaped.with(
+      case LitTerm.ShapedInt shaped -> shaped.with(
         (zero, suc) -> shaped.repr() == 0
           ? linkLit(0, zero.ref, CON_CALL)
           : linkLit(shaped.repr(), suc.ref, CON_CALL),
@@ -213,9 +211,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
       case Pat.Tuple tuple -> Doc.licit(tuple.explicit(),
         Doc.commaList(tuple.pats().view().map(sub -> pat(sub, Outer.Free))));
       case Pat.End end -> Doc.bracedUnless(Doc.styled(KEYWORD, end.isLeft() ? "0" : "1"), end.explicit());
-      case Pat.ShapedInt lit -> options.map.get(DistillerOptions.Key.ShowLiterals)
-        ? Doc.plain(String.valueOf(lit.repr()))
-        : Doc.bracedUnless(lit.with(
+      case Pat.ShapedInt lit -> Doc.bracedUnless(lit.with(
           (zero, suc) -> lit.repr() == 0
             ? linkLit(0, zero.ref, CON_CALL)
             : linkLit(lit.repr(), suc.ref, CON_CALL),

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -171,7 +171,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
         Doc.sep(lam.params().map(this::lambdaParam)),
         Doc.symbol("=>"),
         lam.body().toDoc(options));
-      case ElimTerm.PathApp app -> visitCalls(infix(app.of()), term(Outer.AppHead, app.of()),
+      case ElimTerm.PathApp app -> visitCalls(false, term(Outer.AppHead, app.of()),
         app.args().view(), outer, options.map.get(DistillerOptions.Key.ShowImplicitArgs));
     };
   }

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -29,6 +29,10 @@ public class CoreDistiller extends BaseDistiller<Term> {
     super(options);
   }
 
+  public boolean infix(@NotNull Term term) {
+    return term instanceof CallTerm call && call.ref() instanceof DefVar<?, ?> defVar && defVar.isInfix();
+  }
+
   @Override public @NotNull Doc term(@NotNull Outer outer, @NotNull Term preterm) {
     return switch (preterm) {
       case RefTerm term -> varDoc(term.var());
@@ -120,8 +124,8 @@ public class CoreDistiller extends BaseDistiller<Term> {
         var args = MutableList.of(term.arg());
         var head = ElimTerm.unapp(term.of(), args);
         if (head instanceof RefTerm.Field fieldRef) yield visitArgsCalls(fieldRef.ref(), FIELD_CALL, args, outer);
-        yield visitCalls(false, term(Outer.AppHead, head), args.view(), outer,
-          options.map.get(DistillerOptions.Key.ShowImplicitArgs));
+        var implicits = options.map.get(DistillerOptions.Key.ShowImplicitArgs);
+        yield visitCalls(!implicits && infix(head), term(Outer.AppHead, head), args.view(), outer, implicits);
       }
       case CallTerm.Prim prim -> visitArgsCalls(prim.ref(), PRIM_CALL, prim.args(), outer);
       case RefTerm.Field term -> linkRef(term.ref(), FIELD_CALL);
@@ -167,7 +171,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
         Doc.sep(lam.params().map(this::lambdaParam)),
         Doc.symbol("=>"),
         lam.body().toDoc(options));
-      case ElimTerm.PathApp app -> visitCalls(false, term(Outer.AppHead, app.of()),
+      case ElimTerm.PathApp app -> visitCalls(infix(app.of()), term(Outer.AppHead, app.of()),
         app.args().view(), outer, options.map.get(DistillerOptions.Key.ShowImplicitArgs));
     };
   }

--- a/base/src/main/java/org/aya/resolve/visitor/StmtShallowResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtShallowResolver.java
@@ -6,15 +6,11 @@ import kala.collection.SeqLike;
 import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableHashMap;
-import kala.control.primitive.IntOption;
 import kala.tuple.Tuple;
-import org.aya.concrete.Expr;
 import org.aya.concrete.remark.Remark;
 import org.aya.concrete.stmt.*;
-import org.aya.core.def.Def;
 import org.aya.core.def.PrimDef;
 import org.aya.generic.util.InternalException;
-import org.aya.ref.Bind;
 import org.aya.ref.DefVar;
 import org.aya.resolve.ResolveInfo;
 import org.aya.resolve.context.Context;
@@ -93,12 +89,7 @@ public record StmtShallowResolver(
           var symbol = ctx.getQualifiedLocalMaybe(mod, use.id(), SourcePos.NONE);
           assert symbol instanceof DefVar<?, ?>;
           var defVar = (DefVar<?, ?>) symbol;
-          var argc = computeArgc(defVar);
-          if (argc.isEmpty()) {
-            // TODO: report a problem that we need a telescope
-            throw new InternalException("not implemented yet");
-          }
-          OpDecl rename = () -> new OpDecl.OpInfo(use.asName(), use.asAssoc(), argc.get());
+          OpDecl rename = () -> new OpDecl.OpInfo(use.asName(), use.asAssoc());
           defVar.opDeclRename.put(resolveInfo.thisModule().moduleName(), rename);
           var bind = use.asBind();
           if (bind != BindBlock.EMPTY) {
@@ -158,12 +149,6 @@ public record StmtShallowResolver(
         resolveOpInfo(field, context);
       }
     }
-  }
-
-  private @NotNull IntOption computeArgc(@NotNull DefVar<?, ?> defVar) {
-    if (defVar.core instanceof Def def) return IntOption.some(def.telescope().count(Bind::explicit));
-    if (defVar.concrete instanceof Decl.Telescopic tele) return IntOption.some(tele.telescope().count(Expr.Param::explicit));
-    return IntOption.none();
   }
 
   private <D extends Decl, Child extends Decl> ModuleContext resolveChildren(

--- a/base/src/main/java/org/aya/tyck/unify/DefEq.java
+++ b/base/src/main/java/org/aya/tyck/unify/DefEq.java
@@ -333,7 +333,7 @@ public final class DefEq {
     });
     // TODO: let CofThy.propExt uses lr and rl?
     var lPar = (IntroTerm.PartEl) new IntroTerm.PartEl(lhs.partial(), lhs.type().subst(lr.map)).subst(lr.map);
-    var rPar = (IntroTerm.PartEl) new IntroTerm.PartEl(rhs.partial(), rhs.type());
+    var rPar = new IntroTerm.PartEl(rhs.partial(), rhs.type());
     var lType = new FormTerm.PartTy(lPar.rhsType(), lPar.partial().restr());
     var rType = new FormTerm.PartTy(rPar.rhsType(), rPar.partial().restr());
     if (compareUntyped(lType, rType, lr, rl) == null) return false;

--- a/base/src/test/java/org/aya/core/DistillerTest.java
+++ b/base/src/test/java/org/aya/core/DistillerTest.java
@@ -115,6 +115,38 @@ public class DistillerTest {
     assertEquals("zero (=) zero", t.toDoc(DistillerOptions.pretty()).debugRender());
   }
 
+  @Test public void pathApp() {
+    var decls = TyckDeclTest.successTyckDecls("""
+      def infix = {A : Type} (a b : A) : Type => [| i |] A {| i 0 := a | i 1 := b |}
+      def idp {A : Type} {a : A} : a = a => \\i => a
+      def test {A : Type} {a b : A} (p : a = b) : a = b => \\i => p i
+      """)._2;
+    var t = ((FnDef) decls.get(2)).body.getLeftValue();
+    assertEquals("\\ i => p i", t.toDoc(DistillerOptions.informative()).debugRender());
+  }
+
+  @Test public void literals() {
+    var decls = TyckDeclTest.successTyckDecls("""
+      open data Nat | zero | suc Nat
+      def test1 : Nat => 0
+      def test2 : Nat => 114514
+      def test3 Nat : Nat
+        | 0 => 1
+        | 1 => 2
+        | a => suc a
+      """)._2;
+    var t1 = ((FnDef) decls.get(1)).body.getLeftValue();
+    var t2 = ((FnDef) decls.get(2)).body.getLeftValue();
+    var t3 = ((FnDef) decls.get(3));
+    assertEquals("0", t1.toDoc(DistillerOptions.informative()).debugRender());
+    assertEquals("114514", t2.toDoc(DistillerOptions.informative()).debugRender());
+    assertEquals("""
+      def test3 (_7 : Nat) : Nat
+        |  0 => 1
+        |  1 => 2
+        |  a => suc a""", t3.toDoc(DistillerOptions.informative()).debugRender());
+  }
+
   private @NotNull Doc declDoc(@Language("TEXT") String text) {
     return Doc.vcat(TyckDeclTest.successTyckDecls(text)._2.map(d -> d.toDoc(DistillerOptions.debug())));
   }

--- a/base/src/test/java/org/aya/core/DistillerTest.java
+++ b/base/src/test/java/org/aya/core/DistillerTest.java
@@ -103,6 +103,18 @@ public class DistillerTest {
     assertEquals("g (n ·)", t.toDoc(DistillerOptions.informative()).debugRender());
   }
 
+  @Test public void elimBinOP() {
+    var decls = TyckDeclTest.successTyckDecls("""
+      def Eq (A : Type) (a b : A) : Type => [| i |] A {| i 0 := a | i 1 := b |}
+      def infix = {A : Type} => Eq A
+      open data Nat | zero | suc Nat
+      def test => zero = zero
+      """)._2;
+    var t = ((FnDef) decls.get(3)).body.getLeftValue();
+    assertEquals("(=) {Nat} zero zero", t.toDoc(DistillerOptions.informative()).debugRender());
+    assertEquals("zero (=) zero", t.toDoc(DistillerOptions.pretty()).debugRender());
+  }
+
   private @NotNull Doc declDoc(@Language("TEXT") String text) {
     return Doc.vcat(TyckDeclTest.successTyckDecls(text)._2.map(d -> d.toDoc(DistillerOptions.debug())));
   }

--- a/base/src/test/java/org/aya/core/DistillerTest.java
+++ b/base/src/test/java/org/aya/core/DistillerTest.java
@@ -78,8 +78,8 @@ public class DistillerTest {
   @Test public void nestedPi() {
     var decls = TyckDeclTest.successTyckDecls("""
       def infix = (A B : Type) => A
-      def infix == (A B : Type) => A bind looser =
-      def infix <= (A B : Type) => A bind tighter =
+      def infix == (A B : Type) => A looser =
+      def infix <= (A B : Type) => A tighter =
       def test1 (X : Type) => Pi (A : Type) -> A ulift = X
       def test2 (X : Type) => (Pi (A : Type) -> A) ulift = X
       """)._2;

--- a/base/src/test/java/org/aya/tyck/TracingTest.java
+++ b/base/src/test/java/org/aya/tyck/TracingTest.java
@@ -1,8 +1,9 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck;
 
 import org.aya.concrete.stmt.TeleDecl;
+import org.aya.core.repr.AyaShape;
 import org.aya.tyck.trace.MdUnicodeTrace;
 import org.aya.tyck.trace.Trace;
 import org.intellij.lang.annotations.Language;
@@ -31,11 +32,12 @@ public class TracingTest {
   }
 
   @NotNull private Trace.Builder mkBuilder(@Language("TEXT") String code) {
-    var res =  TyckDeclTest.successDesugarDecls(code);
+    var res = TyckDeclTest.successDesugarDecls(code);
     var decls = res._2;
     var builder = new Trace.Builder();
+    var shapes = new AyaShape.Factory();
     decls.forEach(decl -> {
-      if (decl instanceof TeleDecl signatured) TyckDeclTest.tyck(res._1, signatured, builder);
+      if (decl instanceof TeleDecl signatured) TyckDeclTest.tyck(res._1, signatured, builder, shapes);
     });
     return builder;
   }

--- a/base/src/test/java/org/aya/tyck/TyckDeclTest.java
+++ b/base/src/test/java/org/aya/tyck/TyckDeclTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck;
 
@@ -30,9 +30,11 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TyckDeclTest {
-  public static GenericDef tyck(@NotNull PrimDef.Factory factory, @NotNull TeleDecl decl, Trace.@Nullable Builder builder) {
+  public static GenericDef tyck(@NotNull PrimDef.Factory factory, @NotNull TeleDecl decl, Trace.@Nullable Builder builder, @NotNull AyaShape.Factory shapes) {
     var tycker = new StmtTycker(ThrowingReporter.INSTANCE, builder);
-    return tycker.tyck(decl, tycker.newTycker(factory, new AyaShape.Factory()));
+    var def = tycker.tyck(decl, tycker.newTycker(factory, shapes));
+    shapes.bonjour(def);
+    return def;
   }
 
   public static @NotNull Tuple2<PrimDef.Factory, ImmutableSeq<Stmt>> successDesugarDecls(@Language("TEXT") @NonNls @NotNull String text) {
@@ -51,8 +53,9 @@ public class TyckDeclTest {
 
   public static @NotNull Tuple2<PrimDef.Factory, ImmutableSeq<GenericDef>> successTyckDecls(@Language("TEXT") @NonNls @NotNull String text) {
     var res = successDesugarDecls(text);
+    var shapes = new AyaShape.Factory();
     return Tuple.of(res._1, res._2.view()
-      .map(i -> i instanceof TeleDecl s ? tyck(res._1, s, null) : null)
+      .map(i -> i instanceof TeleDecl s ? tyck(res._1, s, null, shapes) : null)
       .filter(Objects::nonNull).toImmutableSeq());
   }
 }

--- a/base/src/test/resources/failure/operator/ambiguous.aya.txt
+++ b/base/src/test/resources/failure/operator/ambiguous.aya.txt
@@ -6,7 +6,7 @@ In file $FILE:8:28 ->
                                   ^^
 
 Error: Ambiguous operator precedence detected between `=` and `+`
-note: Use `bind` statement or insert parentheses to make it clear.
+note: Use `tighter/looser` clause or insert parentheses to make it clear.
 
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/operator/cyclic.aya
+++ b/base/src/test/resources/failure/operator/cyclic.aya
@@ -1,10 +1,10 @@
 def infix a => a
-  bind tighter b
+  tighter b
 def infix b => b
-  bind tighter c
+  tighter c
 def infix c => c
-  bind tighter d
+  tighter d
 def infix d => d
-  bind tighter b
+  tighter b
 def infix e => e
 

--- a/base/src/test/resources/failure/operator/cyclic.aya.txt
+++ b/base/src/test/resources/failure/operator/cyclic.aya.txt
@@ -1,9 +1,9 @@
-In file $FILE:6:15 ->
+In file $FILE:6:10 ->
 
-  4 |   bind tighter c
+  4 |   tighter c
   5 | def infix c => c
-  6 |   bind tighter d
-                     ^^
+  6 |   tighter d
+                ^^
 
 Error: Circular precedence found between b, c, d
 

--- a/base/src/test/resources/failure/operator/self-bind.aya
+++ b/base/src/test/resources/failure/operator/self-bind.aya
@@ -1,2 +1,2 @@
 def infix + : Type => +
-  bind looser +
+  looser +

--- a/base/src/test/resources/failure/operator/self-bind.aya.txt
+++ b/base/src/test/resources/failure/operator/self-bind.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:2:14 ->
+In file $FILE:2:9 ->
 
   1 | def infix + : Type => +
-  2 |   bind looser +
-                    ^^
+  2 |   looser +
+               ^^
 
 Error: Self bind is not allowed
 

--- a/base/src/test/resources/failure/patterns/issues/issue681.aya
+++ b/base/src/test/resources/failure/patterns/issues/issue681.aya
@@ -20,7 +20,7 @@ def overlap infix + (n m : Nat) : Nat
   | n, zero => n
   | suc m, n => suc (m + n)
   | m, suc n => suc (m + n)
-  bind tighter =
+  tighter =
 
 def +-assoc : Pi (x y z : Nat) -> x + (y + z) = (x + y) + z
   | zero, y, z => idp

--- a/base/src/test/resources/failure/syntax/issue165.aya.txt
+++ b/base/src/test/resources/failure/syntax/issue165.aya.txt
@@ -2,7 +2,7 @@ In file $FILE:2:0 ->
 
   1 | def
 
-Error: Parser error: mismatched input '<EOF>' expecting {'infix', 'infixl', 'infixr', 'opaque', 'inline', 'overlap', LAND, LOR, REPL_COMMAND, ID}
+Error: Parser error: mismatched input '<EOF>' expecting {'infix', 'infixl', 'infixr', 'fixl', 'fixr', 'opaque', 'inline', 'overlap', LAND, LOR, REPL_COMMAND, ID}
 
 Parsing interrupted due to:
 1 error(s), 0 warning(s).

--- a/base/src/test/resources/success/common/src/Arith/Nat.aya
+++ b/base/src/test/resources/success/common/src/Arith/Nat.aya
@@ -9,7 +9,7 @@ def overlap infixl + (a b : Nat) : Nat
 | a, 0 => a
 | suc a, b => suc (a + b)
 | a, suc b => suc (a + b)
-bind tighter =
+tighter =
 
 def overlap +-assoc-lemma (a b c : Nat) : (a + b) + c = a + (b + c)
 | 0, b, c => idp
@@ -30,13 +30,13 @@ def overlap infixl *' (m n : Nat) : Nat
 | 0, n => 0
 | m, 0 => 0
 | suc m, suc n => suc (m + n + m *' n)
-bind tighter +
+tighter +
 
 def overlap infixl * (m n : Nat) : Nat
 | 0, n => 0
 | m, 0 => 0
 | suc m, n => n + m * n
-bind tighter +
+tighter +
 
 def *-suc (m n : Nat) : m * suc n = m + m * n
 | 0, n => idp

--- a/base/src/test/resources/success/common/src/Data/List.aya
+++ b/base/src/test/resources/success/common/src/Data/List.aya
@@ -5,7 +5,7 @@ open import Data::Fin
 public open data List (A : Type) : Type
 | nil
 | infixr :< A (List A)
-bind tighter =
+tighter =
 
 variable A B C : Type
 
@@ -21,7 +21,7 @@ def overlap infixr ++ (xs ys : List A) : List A
 | nil, ys => ys
 | xs, nil => xs
 | a :< xs, ys => a :< (xs ++ ys)
-bind tighter =
+tighter =
 
 def concat (l : List (List A)) : List A
 | nil => nil
@@ -91,14 +91,14 @@ def pure (x : A) : List A => x :< nil
 def infixl <*> (fs : List (A -> B)) (xs : List A) : List B
 | nil, _ => nil
 | f :< fs, xs => (fmap f xs) ++ (fs <*> xs)
-bind { tighter =
-       looser  + }
+  tighter =
+  looser  +
 
 def empty {A : Type} : List A => nil
 
 def infixl <|> (l1 l2 : List A) : List A => l1 ++ l2
-bind { tighter =
-       looser  <*> }
+  tighter =
+  looser  <*>
 
 ----- monadic -----
 def return {A : Type} => pure {A}
@@ -106,10 +106,10 @@ def return {A : Type} => pure {A}
 def join {A : Type} => concat {A}
 
 def infix >>= (l : List A) (f : A -> List B) : List B => join (fmap f l)
-bind tighter =
+tighter =
 
 def infix >> (l1 : List A) (l2 : List B) : List B => do l1, l2
-bind tighter =
+tighter =
 
 def liftM (f : A -> B) (l : List A) : List B =>
   do x <- l,
@@ -121,4 +121,4 @@ def ap (fs : List (A -> B)) (xs : List A) : List B =>
      return (f x)
 
 def infix >=> (f : A -> List B) (g : B -> List C) : A -> List C => \x => f x >>= g
-bind tighter =
+tighter =

--- a/base/src/test/resources/success/common/src/Data/Vec.aya
+++ b/base/src/test/resources/success/common/src/Data/Vec.aya
@@ -18,7 +18,7 @@ def overlap infix ++v (xs : Vec A n) (ys : Vec A m) : Vec A (n + m)
 | vnil, ys => ys
 | xs, vnil => xs
 | x :> xs, ys => x :> (xs ++v ys)
-bind tighter =
+tighter =
 
 def overlap ++v-assoc (xs : Vec A n) (ys : Vec A m) (zs : Vec A o)
   : Path (\i => Vec A (+-assoc.at i)) ((xs ++v ys) ++v zs) (xs ++v (ys ++v zs))

--- a/base/src/test/resources/success/src/Assoc.aya
+++ b/base/src/test/resources/success/src/Assoc.aya
@@ -29,7 +29,7 @@ def infixr >== {A : Type} {a b c : A} (p : a = b) (q : b = c) => p <==> q
   bind looser qed, ==<
 def infix  ==< {A : Type} (a : A) {b : A} (p : a = b) => p
 
-def infix qed {A : Type} (a : A) : a = a => idp {A} {a}
+def fixr qed {A : Type} (a : A) : a = a => idp {A} {a}
 
 -----------------------------------------
 
@@ -56,7 +56,7 @@ def +'-comm (a b : Nat) : a +' b = b +' a
 -----------------------------------------
 
 def a (b : Nat) : Nat => suc b
-def infix suc' (a : Nat) : Term => Atom a
+def fixl suc' (a : Nat) : Term => Atom a
 
 def what-if-they're-prefixed : (suc' a 0) = (suc' (a 0))  => idp
 def what-if-they're-prefixed' : (suc' a 0) = (Atom (suc 0))  => idp

--- a/base/src/test/resources/success/src/Assoc.aya
+++ b/base/src/test/resources/success/src/Assoc.aya
@@ -26,7 +26,7 @@ def test2 : term2 = term2Ast => idp
 -----------------------------------------
 
 def infixr >== {A : Type} {a b c : A} (p : a = b) (q : b = c) => p <==> q
-  bind looser qed, ==<
+  looser qed, ==<
 def infix  ==< {A : Type} (a : A) {b : A} (p : a = b) => p
 
 def fixr qed {A : Type} (a : A) : a = a => idp {A} {a}
@@ -36,7 +36,7 @@ def fixr qed {A : Type} (a : A) : a = a => idp {A} {a}
 def overlap infix +' (a b : Nat) : Nat
  | a, 0 => a
  | a, suc b => suc (a +' b)
- bind tighter =, ==<, qed
+ tighter =, ==<, qed
 
 def +'-comm (a b : Nat) : a +' b = b +' a
   | 0, 0 => idp

--- a/base/src/test/resources/success/src/CubicalBasics.aya
+++ b/base/src/test/resources/success/src/CubicalBasics.aya
@@ -1,5 +1,5 @@
 open import Primitives using
-  ( invol as ~
+  ( invol as fixl ~
   , intervalMin as infix /\
   , intervalMax as infix \/
   )

--- a/base/src/test/resources/success/src/CubicalBasics.aya
+++ b/base/src/test/resources/success/src/CubicalBasics.aya
@@ -5,7 +5,7 @@ open import Primitives using
   )
 
 def Eq (A : Type) (a b : A) : Type => [| i |] A {| i 0 := a | i 1 := b |}
-def infix = {A : Type} (a b : A) => Eq A a b
+def infix = {A : Type} => Eq A
 def idp {A : Type} {a : A} : a = a => \i => a
 def funExt {A B : Type} (f g : A -> B)
      (p : Pi (a : A) -> f a = g a) : f = g => \i a => p a i

--- a/base/src/test/resources/success/src/ImportOpPrecedence.aya
+++ b/base/src/test/resources/success/src/ImportOpPrecedence.aya
@@ -3,5 +3,5 @@ open import Paths
 open import Primitives using (
   intervalMin as infix /\        ,
   intervalMax as infix \/        ,
-  invol as infix ~ bind tighter =, \/, /\,
+  invol as fixl ~ bind tighter =, \/, /\,
 )

--- a/base/src/test/resources/success/src/ImportOpPrecedence.aya
+++ b/base/src/test/resources/success/src/ImportOpPrecedence.aya
@@ -3,5 +3,5 @@ open import Paths
 open import Primitives using (
   intervalMin as infix /\        ,
   intervalMax as infix \/        ,
-  invol as fixl ~ bind tighter =, \/, /\,
+  invol as fixl ~ tighter =, \/, /\,
 )

--- a/base/src/test/resources/success/src/Issues/152.aya
+++ b/base/src/test/resources/success/src/Issues/152.aya
@@ -4,6 +4,6 @@ open import Paths
 open struct Monoid : Type
 | infix <> (a b : Nat) : Nat {
   | 0, n => n
-} bind tighter =
+} tighter =
 | r-id (a : Nat) : a <> 0 = a
 | assoc (a b c : Nat) : (a <> b) <> c = a <> (b <> c)

--- a/base/src/test/resources/success/src/Issues/289.aya
+++ b/base/src/test/resources/success/src/Issues/289.aya
@@ -6,12 +6,12 @@ def two => S Z add S Z
 def two-is-two : two = S (S Z) => idp
 
 open import Primitives using (
-  invol as infix ~ bind tighter =,
+  invol as fixl ~ bind tighter =,
   intervalMin as infix /\        ,
   intervalMax as infix \/        ,
 )
 
-def invol-infix : ~ 0 = 1 => idp
+def invol-prefix : ~ 0 = 1 => idp
 
 def psqueeze-infix {A : Type} {a b : A} (p : a = b) (i : I)
  : a = p.at i => path (\j => p.at (i /\ j))

--- a/base/src/test/resources/success/src/Issues/289.aya
+++ b/base/src/test/resources/success/src/Issues/289.aya
@@ -6,7 +6,7 @@ def two => S Z add S Z
 def two-is-two : two = S (S Z) => idp
 
 open import Primitives using (
-  invol as fixl ~ bind tighter =,
+  invol as fixl ~ tighter =,
   intervalMin as infix /\        ,
   intervalMax as infix \/        ,
 )

--- a/base/src/test/resources/success/src/ProtoIssues/726.aya
+++ b/base/src/test/resources/success/src/ProtoIssues/726.aya
@@ -2,7 +2,7 @@ open import Paths
 
 def infix ∘ { A B C : Type } ( g : B -> C ) ( f : A -> B ) : A -> C
  => \ x => g (f x)
-  bind tighter =
+  tighter =
 
 open struct Isomorphism { A B : Type } : Type
   | to : A -> B

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
@@ -39,7 +39,6 @@ OPAQUE : 'opaque';
 INLINE : 'inline';
 OVERLAP : 'overlap';
 MODULE_KW : 'module';
-BIND_KW : 'bind';
 MATCH : 'match';
 // ABSURD : 'impossible';
 VARIABLE : 'variable';

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
@@ -9,6 +9,8 @@ lexer grammar AyaLexer;
 INFIX  : 'infix';
 INFIXL : 'infixl';
 INFIXR : 'infixr';
+FIXL : 'fixl';
+FIXR : 'fixr';
 
 // operator precedence
 TIGHTER : 'tighter';

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -43,7 +43,7 @@ decl : PRIVATE?
      | primDecl
      );
 
-assoc : INFIX | INFIXL | INFIXR;
+assoc : INFIX | INFIXL | INFIXR | FIXL | FIXR;
 
 declNameOrInfix : weakId | assoc weakId;
 

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -47,8 +47,7 @@ assoc : INFIX | INFIXL | INFIXR | FIXL | FIXR;
 
 declNameOrInfix : weakId | assoc weakId;
 
-bindBlock : BIND_KW (TIGHTER | LOOSER) qIdsComma
-          | BIND_KW LBRACE (tighters | loosers)* RBRACE ;
+bindBlock : (tighters | loosers)+;
 tighters : TIGHTER qIdsComma;
 loosers : LOOSER qIdsComma;
 

--- a/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
@@ -162,13 +162,13 @@ public record AyaProducer(
     return unreachable(ctx);
   }
 
-  public Tuple2<@NotNull WithPos<String>, OpDecl.@Nullable OpInfo> visitDeclNameOrInfix(@NotNull AyaParser.DeclNameOrInfixContext ctx, int argc) {
+  public Tuple2<@NotNull WithPos<String>, OpDecl.@Nullable OpInfo> visitDeclNameOrInfix(@NotNull AyaParser.DeclNameOrInfixContext ctx) {
     var assoc = ctx.assoc();
     var id = ctx.weakId();
     var txt = id.getText();
     var pos = sourcePosOf(id);
     if (assoc == null) return Tuple.of(new WithPos<>(pos, txt), null);
-    var infix = new OpDecl.OpInfo(txt, visitAssoc(assoc), argc);
+    var infix = new OpDecl.OpInfo(txt, visitAssoc(assoc));
     return Tuple.of(new WithPos<>(pos, infix.name()), infix);
   }
 
@@ -176,11 +176,9 @@ public record AyaProducer(
     if (assoc.INFIX() != null) return Assoc.Infix;
     if (assoc.INFIXL() != null) return Assoc.InfixL;
     if (assoc.INFIXR() != null) return Assoc.InfixR;
+    if (assoc.FIXL() != null) return Assoc.FixL;
+    if (assoc.FIXR() != null) return Assoc.FixR;
     throw new InternalException("Unknown assoc: " + assoc.getText());
-  }
-
-  private int countExplicit(@NotNull ImmutableSeq<Expr.Param> tele) {
-    return tele.count(Expr.Param::explicit);
   }
 
   public TeleDecl.@NotNull FnDecl visitFnDecl(AyaParser.FnDeclContext ctx, Stmt.Accessibility accessibility) {
@@ -197,7 +195,7 @@ public record AyaProducer(
 
     var tele = visitTelescope(ctx.tele());
     var bind = ctx.bindBlock();
-    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix(), countExplicit(tele));
+    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix());
 
     var dynamite = visitFnBody(ctx.fnBody());
     if (dynamite.isRight() && inline.isDefined()) {
@@ -628,7 +626,7 @@ public record AyaProducer(
     var openAccessibility = ctx.PUBLIC() != null ? Stmt.Accessibility.Public : Stmt.Accessibility.Private;
     var body = ctx.dataBody().stream().map(this::visitDataBody).collect(ImmutableSeq.factory());
     var tele = visitTelescope(ctx.tele());
-    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix(), countExplicit(tele));
+    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix());
     var data = new TeleDecl.DataDecl(
       nameOrInfix._1.sourcePos(),
       sourcePosOf(ctx),
@@ -666,7 +664,7 @@ public record AyaProducer(
 
   public TeleDecl.DataCtor visitDataCtor(@NotNull ImmutableSeq<Pattern> patterns, AyaParser.DataCtorContext ctx) {
     var tele = visitTelescope(ctx.tele());
-    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix(), countExplicit(tele));
+    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix());
     var bind = ctx.bindBlock();
     return new TeleDecl.DataCtor(
       nameOrInfix._1.sourcePos(),
@@ -749,7 +747,7 @@ public record AyaProducer(
     var openAccessibility = ctx.PUBLIC() != null ? Stmt.Accessibility.Public : Stmt.Accessibility.Private;
     var fields = visitFields(ctx.field());
     var tele = visitTelescope(ctx.tele());
-    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix(), countExplicit(tele));
+    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix());
     var struct = new TeleDecl.StructDecl(
       nameOrInfix._1.sourcePos(),
       sourcePosOf(ctx),
@@ -783,7 +781,7 @@ public record AyaProducer(
 
   public TeleDecl.StructField visitFieldImpl(AyaParser.FieldImplContext ctx) {
     var tele = visitTelescope(ctx.tele());
-    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix(), countExplicit(tele));
+    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix());
     var bind = ctx.bindBlock();
     return new TeleDecl.StructField(
       nameOrInfix._1.sourcePos(),
@@ -801,7 +799,7 @@ public record AyaProducer(
 
   public TeleDecl.StructField visitFieldDecl(AyaParser.FieldDeclContext ctx) {
     var tele = visitTelescope(ctx.tele());
-    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix(), countExplicit(tele));
+    var nameOrInfix = visitDeclNameOrInfix(ctx.declNameOrInfix());
     var bind = ctx.bindBlock();
     return new TeleDecl.StructField(
       nameOrInfix._1.sourcePos(),

--- a/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
@@ -122,15 +122,9 @@ public record AyaProducer(
   }
 
   public @NotNull BindBlock visitBind(AyaParser.BindBlockContext ctx) {
-    if (ctx.LOOSER() != null) return new BindBlock(sourcePosOf(ctx), MutableValue.create(),
-      visitQIdsComma(ctx.qIdsComma()).collect(ImmutableSeq.factory()), ImmutableSeq.empty(),
+    return new BindBlock(sourcePosOf(ctx), MutableValue.create(),
+      visitLoosers(ctx.loosers()), visitTighters(ctx.tighters()),
       MutableValue.create(), MutableValue.create());
-    else if (ctx.TIGHTER() != null) return new BindBlock(sourcePosOf(ctx), MutableValue.create(),
-      ImmutableSeq.empty(), visitQIdsComma(ctx.qIdsComma()).collect(ImmutableSeq.factory()),
-      MutableValue.create(), MutableValue.create());
-    else return new BindBlock(sourcePosOf(ctx), MutableValue.create(),
-        visitLoosers(ctx.loosers()), visitTighters(ctx.tighters()),
-        MutableValue.create(), MutableValue.create());
   }
 
   public @NotNull ImmutableSeq<QualifiedID> visitLoosers(List<AyaParser.LoosersContext> ctx) {

--- a/tools/src/main/java/org/aya/util/binop/Assoc.java
+++ b/tools/src/main/java/org/aya/util/binop/Assoc.java
@@ -8,9 +8,9 @@ package org.aya.util.binop;
 public enum Assoc {
   /** infix */
   Infix,
-  /** infix, but associates leftly */
+  /** infix, left-associative */
   InfixL,
-  /** infix, but associates rightly */
+  /** infix, right-associative */
   InfixR,
   /** prefix operators */
   FixL,

--- a/tools/src/main/java/org/aya/util/binop/Assoc.java
+++ b/tools/src/main/java/org/aya/util/binop/Assoc.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.util.binop;
 
@@ -6,20 +6,37 @@ package org.aya.util.binop;
  * @author ice1000
  */
 public enum Assoc {
-  /**
-   * Parenthesis operator fixity.
-   */
-  Infix(true),
-  InfixL(true),
-  InfixR(true),
-  Invalid(false);
+  /** infix */
+  Infix,
+  /** infix, but associates leftly */
+  InfixL,
+  /** infix, but associates rightly */
+  InfixR,
+  /** prefix operators */
+  FixL,
+  /** postfix operators */
+  FixR,
 
-  /**
-   * That this fixity is infix.
-   */
-  public final boolean infix;
+  Invalid;
 
-  Assoc(boolean infix) {
-    this.infix = infix;
+  public boolean isBinary() {
+    return this == Infix || this == InfixL || this == InfixR;
+  }
+
+  public boolean isUnary() {
+    return this == FixL || this == FixR;
+  }
+
+  public boolean leftAssoc() {
+    return this == InfixL || this == FixL;
+  }
+
+  public boolean noAssoc() {
+    return this == Infix;
+  }
+
+  public static boolean assocAmbitious(Assoc a, Assoc b) {
+    //noinspection ConstantConditions: I know, I know. But we should also plan for the future.
+    return a != b || a.noAssoc() || b.noAssoc();
   }
 }

--- a/tools/src/main/java/org/aya/util/binop/BinOpSet.java
+++ b/tools/src/main/java/org/aya/util/binop/BinOpSet.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.util.binop;
 
@@ -84,8 +84,7 @@ public abstract class BinOpSet {
     @NotNull SourcePos firstBind,
     @NotNull OpDecl op,
     @NotNull String name,
-    @NotNull Assoc assoc,
-    int argc
+    @NotNull Assoc assoc
   ) {
     private static @NotNull OpDecl.OpInfo ensureOperator(@NotNull OpDecl opDecl) {
       var op = opDecl.opInfo();
@@ -95,7 +94,7 @@ public abstract class BinOpSet {
 
     private static @NotNull BinOpSet.BinOP from(@NotNull SourcePos sourcePos, @NotNull OpDecl opDecl) {
       var op = ensureOperator(opDecl);
-      return new BinOpSet.BinOP(sourcePos, opDecl, op.name(), op.assoc(), op.argc());
+      return new BinOpSet.BinOP(sourcePos, opDecl, op.name(), op.assoc());
     }
 
     @Override public String toString() {

--- a/tools/src/main/java/org/aya/util/binop/OpDecl.java
+++ b/tools/src/main/java/org/aya/util/binop/OpDecl.java
@@ -12,8 +12,8 @@ public interface OpDecl {
 
   @Nullable OpInfo opInfo();
 
-  record OpInfo(@NotNull String name, @NotNull Assoc assoc, int argc) {
+  record OpInfo(@NotNull String name, @NotNull Assoc assoc) {
   }
 
-  @NotNull OpDecl APPLICATION = () -> new OpInfo("application", Assoc.InfixL, 2);
+  @NotNull OpDecl APPLICATION = () -> new OpInfo("application", Assoc.InfixL);
 }

--- a/tools/src/main/java/org/aya/util/distill/DistillerOptions.java
+++ b/tools/src/main/java/org/aya/util/distill/DistillerOptions.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.util.distill;
 
@@ -29,7 +29,6 @@ public final class DistillerOptions {
     ShowImplicitPats,
     ShowLambdaTypes,
     ShowLevels,
-    ShowLiterals,
   }
 
   @Contract(pure = true, value = "->new") public static @NotNull DistillerOptions debug() {
@@ -48,7 +47,6 @@ public final class DistillerOptions {
     var map = new DistillerOptions();
     map.map.put(Key.ShowImplicitPats, true);
     map.map.put(Key.ShowLevels, true);
-    map.map.put(Key.ShowLiterals, true);
     return map;
   }
 }


### PR DESCRIPTION
Fix #462 and removed `bind` keyword

before: `def x => {??} bind looser +` => now: `def x => {??} looser +`
before: `def x => {??} bind { looser a tighter b }` => now: `def x => {??} looser a tighter b`