### PR TITLE
Making `I`, and `Partial` a primitive

### DIFF
--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -170,8 +170,8 @@ public final class PrimDef extends TopLevelDef {
       public final @NotNull PrimDef.PrimSeed PARTIAL =
         new PrimSeed(ID.PARTIAL,
           (prim, state) -> {
-            var ty = prim.args().get(0).term().normalize(state, NormalizeMode.WHNF);
-            var iExp = prim.args().get(1).term().normalize(state, NormalizeMode.WHNF);
+            var iExp = prim.args().get(0).term().normalize(state, NormalizeMode.WHNF);
+            var ty = prim.args().get(1).term().normalize(state, NormalizeMode.WHNF);
 
             return new FormTerm.PartTy(ty, isOne(iExp));
           },

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -167,7 +167,7 @@ public final class PrimDef extends TopLevelDef {
 
       public final @NotNull PrimDef.PrimSeed PARTIAL =
         new PrimSeed(ID.PARTIAL,
-          ((prim, state) -> {
+          (prim, state) -> {
             var ty = prim.args().get(0).term().normalize(state, NormalizeMode.WHNF);
             var iExp = prim.args().get(1).term().normalize(state, NormalizeMode.WHNF);
 
@@ -175,12 +175,12 @@ public final class PrimDef extends TopLevelDef {
               return new FormTerm.PartTy(ty, formula.toRestr());
             }
             throw new InternalException("TODO: make an error about illegal formula");
-          }),
+          },
           ref -> new PrimDef(
             ref,
             ImmutableSeq.of(
-              new Term.Param(new LocalVar("ty"), FormTerm.Univ.ZERO, true),
-              new Term.Param(new LocalVar("i"), PrimTerm.Interval.INSTANCE, true)
+              new Term.Param(new LocalVar("phi"), PrimTerm.Interval.INSTANCE, true),
+              new Term.Param(new LocalVar("A"), FormTerm.Univ.ZERO, true)
             ),
             FormTerm.Univ.ZERO, ID.PARTIAL),
           ImmutableSeq.of(ID.I));

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static org.aya.guest0x0.cubical.CofThy.isOne;
+
 /**
  * @author ice1000
  */
@@ -171,10 +173,7 @@ public final class PrimDef extends TopLevelDef {
             var ty = prim.args().get(0).term().normalize(state, NormalizeMode.WHNF);
             var iExp = prim.args().get(1).term().normalize(state, NormalizeMode.WHNF);
 
-            if (iExp instanceof PrimTerm.Mula formula) {
-              return new FormTerm.PartTy(ty, formula.toRestr());
-            }
-            throw new InternalException("TODO: make an error about illegal formula");
+            return new FormTerm.PartTy(ty, isOne(iExp));
           },
           ref -> new PrimDef(
             ref,

--- a/base/src/main/java/org/aya/core/serde/SerTerm.java
+++ b/base/src/main/java/org/aya/core/serde/SerTerm.java
@@ -208,7 +208,7 @@ public sealed interface SerTerm extends Serializable {
 
   record Interval() implements SerTerm {
     @Override public @NotNull Term de(@NotNull DeState state) {
-      return FormTerm.Interval.INSTANCE;
+      return PrimTerm.Interval.INSTANCE;
     }
   }
 

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -83,7 +83,7 @@ public record Serializer(@NotNull Serializer.State state) {
       case PrimTerm.Str str -> new SerTerm.Str(str.string());
       case RefTerm ref -> new SerTerm.Ref(state.local(ref.var()));
       case RefTerm.Field ref -> new SerTerm.FieldRef(state.def(ref.ref()));
-      case FormTerm.Interval interval -> new SerTerm.Interval();
+      case PrimTerm.Interval interval -> new SerTerm.Interval();
       case FormTerm.Pi pi -> new SerTerm.Pi(serialize(pi.param()), serialize(pi.body()));
       case FormTerm.Sigma sigma -> new SerTerm.Sigma(serializeParams(sigma.params()));
       case FormTerm.Univ univ -> new SerTerm.Univ(univ.lift());

--- a/base/src/main/java/org/aya/core/term/CallTerm.java
+++ b/base/src/main/java/org/aya/core/term/CallTerm.java
@@ -28,6 +28,7 @@ public sealed interface CallTerm extends Term {
     int ulift();
   }
 
+  /** This exists solely for simplifying code in the tycker. */
   @FunctionalInterface
   interface Factory<D extends Def, S extends Decl> {
     @Contract(pure = true, value = "_,_,_->new") @NotNull CallTerm make(

--- a/base/src/main/java/org/aya/core/term/FormTerm.java
+++ b/base/src/main/java/org/aya/core/term/FormTerm.java
@@ -60,13 +60,6 @@ public sealed interface FormTerm extends Term {
     public static final @NotNull FormTerm.Univ ZERO = new Univ(0);
   }
 
-  final class Interval implements FormTerm {
-    public static final Interval INSTANCE = new Interval();
-
-    private Interval() {
-    }
-  }
-
   /** partial type */
   record PartTy(@NotNull Term type, @NotNull Restr<Term> restr) implements FormTerm {}
 

--- a/base/src/main/java/org/aya/core/term/PrimTerm.java
+++ b/base/src/main/java/org/aya/core/term/PrimTerm.java
@@ -3,9 +3,7 @@
 package org.aya.core.term;
 
 import kala.collection.SeqView;
-import org.aya.generic.util.InternalException;
 import org.aya.guest0x0.cubical.Formula;
-import org.aya.guest0x0.cubical.Restr;
 import org.jetbrains.annotations.NotNull;
 
 public sealed interface PrimTerm extends Term {
@@ -32,10 +30,6 @@ public sealed interface PrimTerm extends Term {
         case Formula.Inv<Term> inv -> SeqView.of(inv.i());
         case Formula.Lit<Term> lit -> SeqView.empty();
       };
-    }
-
-    public Restr<Term> toRestr() {
-      throw new InternalException("toRestr() is not yet implemented");
     }
   }
 

--- a/base/src/main/java/org/aya/core/term/PrimTerm.java
+++ b/base/src/main/java/org/aya/core/term/PrimTerm.java
@@ -3,10 +3,13 @@
 package org.aya.core.term;
 
 import kala.collection.SeqView;
+import org.aya.generic.util.InternalException;
 import org.aya.guest0x0.cubical.Formula;
+import org.aya.guest0x0.cubical.Restr;
 import org.jetbrains.annotations.NotNull;
 
 public sealed interface PrimTerm extends Term {
+
   record Mula(@NotNull Formula<Term> asFormula) implements PrimTerm {
     public static final @NotNull Mula LEFT = new Mula(new Formula.Lit<>(true));
     public static final @NotNull Mula RIGHT = new Mula(new Formula.Lit<>(false));
@@ -30,8 +33,19 @@ public sealed interface PrimTerm extends Term {
         case Formula.Lit<Term> lit -> SeqView.empty();
       };
     }
+
+    public Restr<Term> toRestr() {
+      throw new InternalException("toRestr() is not yet implemented");
+    }
   }
 
-  record Str(@NotNull String string) implements PrimTerm {
+  record Str(@NotNull String string) implements PrimTerm {}
+
+  final class Interval implements PrimTerm {
+    public static final PrimTerm.Interval INSTANCE = new Interval();
+
+    private Interval() {
+
+    }
   }
 }

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -122,15 +122,8 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits Cal
       }
       case CallTerm.Prim prim -> {
         var args = prim.args().map(arg -> arg.descent(f));
-        yield switch (prim.id()) {
-          case IMIN -> PrimTerm.Mula.and(args.first().term(), args.last().term());
-          case IMAX -> PrimTerm.Mula.or(args.first().term(), args.last().term());
-          case INVOL -> PrimTerm.Mula.inv(args.first().term());
-          default -> {
-            if (args.sameElements(prim.args(), true)) yield prim;
-            yield new CallTerm.Prim(prim.ref(), prim.ulift(), args);
-          }
-        };
+        if (args.sameElements(prim.args(), true)) yield prim;
+        yield new CallTerm.Prim(prim.ref(), prim.ulift(), args);
       }
       case CallTerm.Hole hole -> {
         var contextArgs = hole.contextArgs().map(arg -> arg.descent(f));

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -54,7 +54,7 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits Cal
         yield new FormTerm.Sigma(params);
       }
       case FormTerm.Univ univ -> univ;
-      case FormTerm.Interval interval -> interval;
+      case PrimTerm.Interval interval -> interval;
       case PrimTerm.Mula mula -> {
         var formula = mula.asFormula().fmap(f);
         if (formula == mula.asFormula()) yield mula;

--- a/base/src/main/java/org/aya/core/visitor/EndoFunctor.java
+++ b/base/src/main/java/org/aya/core/visitor/EndoFunctor.java
@@ -85,6 +85,7 @@ public interface EndoFunctor extends Function<Term, Term> {
         case PrimTerm.Mula mula -> Expander.simplFormula(mula);
         case IntroTerm.PartEl par -> Expander.partial(par);
         case ElimTerm.PathApp app -> Expander.pathApp(app, Function.identity());
+        case FormTerm.PartTy ty -> Expander.partialType(ty);
         case Term misc -> misc;
       };
     }

--- a/base/src/main/java/org/aya/core/visitor/Expander.java
+++ b/base/src/main/java/org/aya/core/visitor/Expander.java
@@ -78,6 +78,7 @@ public interface Expander extends EndoFunctor {
       }
       case RefTerm.MetaPat metaPat -> metaPat.inline();
       case PrimTerm.Mula mula -> simplFormula(mula);
+      case FormTerm.PartTy ty -> partialType(ty);
       default -> term;
     };
   }
@@ -121,17 +122,21 @@ public interface Expander extends EndoFunctor {
         default -> Expander.super.post(term);
       };
     }
-
-    public @NotNull Restr<Term> applyRestr(@NotNull Restr<Term> restr) {
-      return switch (restr.fmap(this)) {
-        case Restr.Vary<Term> vary -> CofThy.normalizeRestr(vary);
-        case Restr.Const<Term> c -> c;
-      };
-    }
   }
 
   static @NotNull IntroTerm.PartEl partial(@NotNull IntroTerm.PartEl el) {
     return new IntroTerm.PartEl(partial(el.partial()), el.rhsType());
+  }
+
+  static @NotNull FormTerm.PartTy partialType(@NotNull FormTerm.PartTy ty) {
+    return new FormTerm.PartTy(ty.type(), restr(ty.restr()));
+  }
+
+  static @NotNull Restr<Term> restr(@NotNull Restr<Term> restr) {
+    return switch (restr) {
+      case Restr.Vary<Term> vary -> CofThy.normalizeRestr(vary);
+      case Restr.Const<Term> c -> c;
+    };
   }
 
   private static @NotNull Partial<Term> partial(@NotNull Partial<Term> partial) {

--- a/base/src/main/java/org/aya/core/visitor/Expander.java
+++ b/base/src/main/java/org/aya/core/visitor/Expander.java
@@ -169,6 +169,7 @@ public interface Expander extends EndoFunctor {
       return switch (term) {
         case ElimTerm.App app -> applyThoroughly(CallTerm::make, app);
         case ElimTerm.Proj proj -> ElimTerm.proj(proj);
+        case PrimTerm.Mula mula -> simplFormula(mula);
         default -> Expander.super.post(term);
       };
     }

--- a/base/src/main/java/org/aya/core/visitor/Subst.java
+++ b/base/src/main/java/org/aya/core/visitor/Subst.java
@@ -11,6 +11,7 @@ import org.aya.core.term.RefTerm;
 import org.aya.core.term.Term;
 import org.aya.distill.BaseDistiller;
 import org.aya.generic.AyaDocile;
+import org.aya.generic.util.NormalizeMode;
 import org.aya.guest0x0.cubical.CofThy;
 import org.aya.guest0x0.cubical.Formula;
 import org.aya.guest0x0.cubical.Restr;
@@ -106,7 +107,7 @@ public record Subst(
   }
 
   public @NotNull Restr<Term> restr(@NotNull TyckState state, @NotNull Restr<Term> restr) {
-    return Expander.restr(restr.fmap(t -> t.subst(this)));
+    return Expander.restr(restr.fmap(t -> t.subst(this).normalize(state, NormalizeMode.WHNF)));
   }
 
   @Override public @NotNull Doc toDoc(@NotNull DistillerOptions options) {

--- a/base/src/main/java/org/aya/core/visitor/Subst.java
+++ b/base/src/main/java/org/aya/core/visitor/Subst.java
@@ -106,7 +106,7 @@ public record Subst(
   }
 
   public @NotNull Restr<Term> restr(@NotNull TyckState state, @NotNull Restr<Term> restr) {
-    return new Expander.Normalizer(state).applyRestr(restr.fmap(t -> t.subst(this)));
+    return Expander.restr(restr.fmap(t -> t.subst(this)));
   }
 
   @Override public @NotNull Doc toDoc(@NotNull DistillerOptions options) {

--- a/base/src/main/java/org/aya/distill/BaseDistiller.java
+++ b/base/src/main/java/org/aya/distill/BaseDistiller.java
@@ -295,7 +295,7 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
   public static <T extends Restr.TermLike<T> & AyaDocile> @NotNull Doc
   cofib(@NotNull DistillerOptions options, @NotNull Restr.Cofib<T> cofib) {
     return Doc.join(Doc.spaced(Doc.symbol("/\\")), cofib.ands().view().map(and ->
-      Doc.sep(and.inst().toDoc(options), Doc.symbol(and.isLeft() ? "0" : "1"))));
+      Doc.sepNonEmpty(and.isLeft() ? Doc.symbol("~") : Doc.empty(), and.inst().toDoc(options))));
   }
 
   protected static @Nullable Style chooseStyle(Object concrete) {

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -161,7 +161,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
         () -> Doc.plain(String.valueOf(shaped.repr())));
       case PrimTerm.Str str -> Doc.plain("\"" + StringEscapeUtil.escapeStringCharacters(str.string()) + "\"");
       case FormTerm.PartTy ty -> Doc.sep(Doc.styled(KEYWORD, "Partial"),
-        term(Outer.AppSpine, ty.type()), Doc.braced(restr(options, ty.restr())));
+        term(Outer.AppSpine, ty.type()), Doc.parened(restr(options, ty.restr())));
       case IntroTerm.PartEl el -> partial(options, el.partial());
       case PrimTerm.Mula mula -> formula(options, mula.asFormula());
       case FormTerm.Path path -> cube(options, path.cube());

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -102,7 +102,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
           options.map.get(DistillerOptions.Key.ShowImplicitArgs)
         );
       }
-      case FormTerm.Interval term -> Doc.styled(KEYWORD, "I");
+      case PrimTerm.Interval term -> Doc.styled(KEYWORD, "I");
       case IntroTerm.New newTerm -> Doc.cblock(Doc.styled(KEYWORD, "new"), 2,
         Doc.vcat(newTerm.params().view()
           .map((k, v) -> Doc.sep(Doc.symbol("|"),

--- a/base/src/main/java/org/aya/resolve/context/ModuleContext.java
+++ b/base/src/main/java/org/aya/resolve/context/ModuleContext.java
@@ -37,12 +37,10 @@ public sealed interface ModuleContext extends Context permits NoExportContext, P
   @Override default @Nullable AnyVar getUnqualifiedLocalMaybe(@NotNull String name, @NotNull SourcePos sourcePos) {
     var result = definitions().getOrNull(name);
     if (result == null) return null;
-    else if (result.size() == 1) return result.iterator().next().getValue();
-    else {
-      var disamb = MutableList.<Seq<String>>create();
-      result.forEach((k, v) -> disamb.append(k));
-      return reportAndThrow(new AmbiguousNameError(name, disamb.toImmutableSeq(), sourcePos));
-    }
+    if (result.size() == 1) return result.iterator().next().getValue();
+    var disamb = MutableList.<Seq<String>>create();
+    result.forEach((k, v) -> disamb.append(k));
+    return reportAndThrow(new AmbiguousNameError(name, disamb.toImmutableSeq(), sourcePos));
   }
 
   @Override default @Nullable AnyVar

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -573,7 +573,10 @@ public final class ExprTycker extends Tycker {
       var lam = xi.foldRight((Term) elim, IntroTerm.Lambda::new).rename();
       // ^ the cast is necessary, see https://bugs.openjdk.org/browse/JDK-8292975
       var pi = xi.foldRight(path.cube().type(), FormTerm.Pi::new);
-      return new TermResult(lam, pi);
+      res = new TermResult(lam, pi);
+    }
+    if (res.wellTyped() instanceof FormTerm.PartTy ty) {
+      res = new TermResult(res.wellTyped().normalize(state, NormalizeMode.WHNF), res.type());
     }
     traceExit(res, expr);
     return res;

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -482,8 +482,7 @@ public final class ExprTycker extends Tycker {
         if (hole.explicit()) reporter.report(new Goal(state, freshHole._1, hole.accessibleLocal().get()));
         yield new UnivResult(freshHole._2, univ.lift());
       }
-      case Expr.UnivExpr univExpr ->
-        new UnivResult(new FormTerm.Univ(univExpr.lift()), univExpr.lift() + 1);
+      case Expr.UnivExpr univExpr -> new UnivResult(new FormTerm.Univ(univExpr.lift()), univExpr.lift() + 1);
       case Expr.LamExpr lam -> failUniv(lam, BadTypeError.pi(state, lam, univ));
       case Expr.PartEl el -> failUniv(el, BadTypeError.partTy(state, el, univ));
       case Expr.PiExpr pi -> {
@@ -667,7 +666,8 @@ public final class ExprTycker extends Tycker {
     // unbound these abstracted variables
     Term body = function.make(defVar, 0, teleRenamed.map(Term.Param::toArg));
     var type = FormTerm.Pi.make(tele, Def.defResult(defVar));
-    if (defVar.core instanceof FnDef fn && fn.modifiers.contains(Modifier.Inline)) {
+    if ((defVar.core instanceof FnDef fn && fn.modifiers.contains(Modifier.Inline))
+      || defVar.core instanceof PrimDef) {
       body = body.normalize(state, NormalizeMode.WHNF);
     }
     return new TermResult(IntroTerm.Lambda.make(teleRenamed, body), type);

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -573,10 +573,7 @@ public final class ExprTycker extends Tycker {
       var lam = xi.foldRight((Term) elim, IntroTerm.Lambda::new).rename();
       // ^ the cast is necessary, see https://bugs.openjdk.org/browse/JDK-8292975
       var pi = xi.foldRight(path.cube().type(), FormTerm.Pi::new);
-      res = new TermResult(lam, pi);
-    }
-    if (res.wellTyped() instanceof FormTerm.PartTy ty) {
-      res = new TermResult(res.wellTyped().normalize(state, NormalizeMode.WHNF), res.type());
+      return new TermResult(lam, pi);
     }
     traceExit(res, expr);
     return res;

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -573,7 +573,7 @@ public final class ExprTycker extends Tycker {
       var lam = xi.foldRight((Term) elim, IntroTerm.Lambda::new).rename();
       // ^ the cast is necessary, see https://bugs.openjdk.org/browse/JDK-8292975
       var pi = xi.foldRight(path.cube().type(), FormTerm.Pi::new);
-      return new TermResult(lam, pi);
+      res = new TermResult(lam, pi); // we need `traceExit`
     }
     traceExit(res, expr);
     return res;

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -74,8 +74,8 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
         yield piRaw instanceof FormTerm.Pi pi ? pi.substBody(app.arg().term()) : ErrorTerm.typeOf(app);
       }
       case FormTerm.Univ univ -> new FormTerm.Univ(univ.lift() + 1);
-      case FormTerm.Interval interval -> FormTerm.Univ.ZERO;
-      case PrimTerm.Mula end -> FormTerm.Interval.INSTANCE;
+      case PrimTerm.Interval interval -> FormTerm.Univ.ZERO;
+      case PrimTerm.Mula end -> PrimTerm.Interval.INSTANCE;
       case PrimTerm.Str str -> state.primFactory().getCall(PrimDef.ID.STR);
       case LitTerm.ShapedInt shaped -> shaped.type();
       case FormTerm.PartTy ty -> FormTerm.Univ.ZERO;

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -189,7 +189,7 @@ public record PatClassifier(
             classifySub(newTele, MCT.extract(pat, subPatsSeq).map(MCT.SubPats<Pat>::drop), coverage, fuelCopy)));
         }
       }
-      case FormTerm.Interval interval -> {
+      case PrimTerm.Interval interval -> {
         var lrSplit = subPatsSeq
           .mapNotNull(subPats -> head(subPats) instanceof Pat.End end ? end : null)
           .firstOption();

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -198,7 +198,7 @@ public final class PatTycker {
         new LocalVar(Constants.ANONYMOUS_PREFIX, face.sourcePos()), term);
       case Pattern.Number num -> {
         var ty = term.normalize(exprTycker.state, NormalizeMode.WHNF);
-        if (ty instanceof FormTerm.Interval) {
+        if (ty instanceof PrimTerm.Interval) {
           var end = num.number();
           if (end == 0 || end == 1) yield new Pat.End(num.number() == 0, num.explicit());
           yield withError(new NotAnIntervalError(num.sourcePos(), end), num, term);

--- a/base/src/main/java/org/aya/tyck/unify/DefEq.java
+++ b/base/src/main/java/org/aya/tyck/unify/DefEq.java
@@ -423,7 +423,7 @@ public final class DefEq {
         if (!(preRhs instanceof FormTerm.Path rhs)) yield null;
         yield compareCube(lhs.cube(), rhs.cube(), lr, rl) ? FormTerm.Univ.ZERO : null;
       }
-      case FormTerm.Interval lhs -> preRhs instanceof FormTerm.Interval ? FormTerm.Univ.ZERO : null;
+      case PrimTerm.Interval lhs -> preRhs instanceof PrimTerm.Interval ? FormTerm.Univ.ZERO : null;
       case PrimTerm.Mula lhs -> {
         if (!(preRhs instanceof PrimTerm.Mula rhs)) yield null;
         var happy = switch (lhs.asFormula()) {
@@ -435,7 +435,7 @@ public final class DefEq {
             && compareUntyped(ll.r(), rr.r(), lr, rl) != null;
           default -> false;
         };
-        yield happy ? FormTerm.Interval.INSTANCE : null;
+        yield happy ? PrimTerm.Interval.INSTANCE : null;
       }
       // See compareApprox for why we don't compare these
       case CallTerm.Fn lhs -> null;

--- a/base/src/test/java/org/aya/core/DistillerTest.java
+++ b/base/src/test/java/org/aya/core/DistillerTest.java
@@ -40,6 +40,7 @@ public class DistillerTest {
 
   @Test public void neo() {
     assertFalse(declDoc("""
+      prim I
       struct Pair (A : Type) (B : Type) : Type
         | fst : A
         | snd : B
@@ -57,6 +58,7 @@ public class DistillerTest {
 
   @Test public void path() {
     @Language("TEXT") var code = """
+      prim I : Type
       struct Path (A : Pi I -> Type) (a : A 0) (b : A 1) : Type
        | at (i : I) : A i {
          | 0 => a

--- a/base/src/test/java/org/aya/core/NormalizeTest.java
+++ b/base/src/test/java/org/aya/core/NormalizeTest.java
@@ -46,6 +46,7 @@ public class NormalizeTest {
 
   @Test public void unfoldPrim() {
     var res = TyckDeclTest.successTyckDecls("""
+      prim I
       data Nat : Type 0 | zero | suc Nat
       prim arcoe
       def xyr : Nat => arcoe (\\ i => Nat) Nat::zero 0
@@ -53,10 +54,10 @@ public class NormalizeTest {
     var state = new TyckState(res._1);
     var defs = res._2;
     IntFunction<Term> normalizer = i -> ((FnDef) defs.get(i)).body.getLeftValue().normalize(state, NormalizeMode.NF);
-    assertTrue(normalizer.apply(2) instanceof CallTerm.Con conCall
+    assertTrue(normalizer.apply(3) instanceof CallTerm.Con conCall
       && Objects.equals(conCall.ref().name(), "zero")
       && conCall.conArgs().isEmpty());
-    assertTrue(normalizer.apply(3) instanceof CallTerm.Con conCall
+    assertTrue(normalizer.apply(4) instanceof CallTerm.Con conCall
       && Objects.equals(conCall.ref().name(), "suc"));
   }
 

--- a/base/src/test/java/org/aya/core/SuedeTest.java
+++ b/base/src/test/java/org/aya/core/SuedeTest.java
@@ -41,6 +41,7 @@ public class SuedeTest {
 
   @Test public void path() {
     suedeAll("""
+      prim I
       open struct Path (A : Pi I -> Type) (a : A 0) (b : A 1) : Type
        | at (i : I) : A i {
          | 0 => a

--- a/base/src/test/java/org/aya/cubical/PartialTest.java
+++ b/base/src/test/java/org/aya/cubical/PartialTest.java
@@ -44,7 +44,7 @@ public class PartialTest {
       """);
     IntFunction<Doc> distiller = i -> res._2.get(i).toDoc(DistillerOptions.debug());
     assertEquals("""
-      def t (A : Type 0) (i : I) (a : A) : Partial (~ i) A => {| i 0 := a |}
+      def t (A : Type 0) (i : I) (a : A) : Partial A (~ i) => {| ~ i := a |}
       """.strip(), distiller.apply(8).debugRender());
   }
 }

--- a/base/src/test/java/org/aya/cubical/PartialTest.java
+++ b/base/src/test/java/org/aya/cubical/PartialTest.java
@@ -22,14 +22,14 @@ public class PartialTest {
             
       def infix /\\ => intervalMin
       tighter \\/
-            
+
       def infix \\/ => intervalMax
-            
+
       def ~ => invol
-            
+
       def t (A : Type) (i : I) (a : A) : Partial (~ i) A
         => {| i 0 := a |}
-          
+
       def t2 (A : Type) (a : A) (i : I) : Partial (~ i) A
         => {| i 0 := a | i 1 := a |}
           

--- a/base/src/test/java/org/aya/cubical/PartialTest.java
+++ b/base/src/test/java/org/aya/cubical/PartialTest.java
@@ -15,25 +15,36 @@ public class PartialTest {
   @Test public void partial() {
     var res = TyckDeclTest.successTyckDecls("""
       prim I
+      prim Partial
+      prim intervalMin
+      prim intervalMax
+      prim invol
             
-      def t (A : Type) (i : I) (a : A) : Partial A { i 0 }
+      def infix /\\ => intervalMin
+      tighter \\/
+            
+      def infix \\/ => intervalMax
+            
+      def ~ => invol
+            
+      def t (A : Type) (i : I) (a : A) : Partial (~ i) A
         => {| i 0 := a |}
           
-      def t2 (A : Type) (a : A) (i : I) : Partial A { i 0 }
+      def t2 (A : Type) (a : A) (i : I) : Partial (~ i) A
         => {| i 0 := a | i 1 := a |}
           
-      def t3 (A : Type) (i : I) (a : A) (b : A) : Partial A { i 0 \\/ i 1 } =>
+      def t3 (A : Type) (i : I) (a : A) (b : A) : Partial (~ i \\/ i) A =>
         {| i 0 := a | i 1 := b |}
           
-      def t4 (A : Type) (i : I) (j : I) (a : A) (b : A) : Partial A { i 0 \\/ i 1 /\\ j 0 } =>
+      def t4 (A : Type) (i : I) (j : I) (a : A) (b : A) : Partial (~ i \\/ i /\\ ~ j) A =>
         {| i 0 := a | i 1 /\\ j 0 := b |}
           
-      def t5 (A : Type) (i : I) (j : I) (a : A) (b : A) : Partial A { i 0 \\/ i 1 /\\ j 0 } =>
+      def t5 (A : Type) (i : I) (j : I) (a : A) (b : A) : Partial (~ i \\/ i /\\ ~ j) A =>
         {| i 0 := a | i 1 := b |}
       """);
     IntFunction<Doc> distiller = i -> res._2.get(i).toDoc(DistillerOptions.debug());
     assertEquals("""
-      def t (A : Type 0) (i : I) (a : A) : Partial A {i 0} => {| i 0 := a |}
-      """.strip(), distiller.apply(1).debugRender());
+      def t (A : Type 0) (i : I) (a : A) : Partial (~ i) A => {| i 0 := a |}
+      """.strip(), distiller.apply(8).debugRender());
   }
 }

--- a/base/src/test/java/org/aya/cubical/PartialTest.java
+++ b/base/src/test/java/org/aya/cubical/PartialTest.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PartialTest {
   @Test public void partial() {
     var res = TyckDeclTest.successTyckDecls("""
+      prim I
+            
       def t (A : Type) (i : I) (a : A) : Partial A { i 0 }
         => {| i 0 := a |}
           
@@ -32,6 +34,6 @@ public class PartialTest {
     IntFunction<Doc> distiller = i -> res._2.get(i).toDoc(DistillerOptions.debug());
     assertEquals("""
       def t (A : Type 0) (i : I) (a : A) : Partial A {i 0} => {| i 0 := a |}
-      """.strip(), distiller.apply(0).debugRender());
+      """.strip(), distiller.apply(1).debugRender());
   }
 }

--- a/base/src/test/java/org/aya/cubical/PartialTest.java
+++ b/base/src/test/java/org/aya/cubical/PartialTest.java
@@ -20,12 +20,12 @@ public class PartialTest {
       prim intervalMax
       prim invol
             
-      def infix /\\ => intervalMin
+      def inline infix /\\ => intervalMin
       tighter \\/
 
-      def infix \\/ => intervalMax
+      def inline infix \\/ => intervalMax
 
-      def ~ => invol
+      def inline ~ => invol
 
       def t (A : Type) (i : I) (a : A) : Partial (~ i) A
         => {| i 0 := a |}

--- a/base/src/test/java/org/aya/cubical/PathTest.java
+++ b/base/src/test/java/org/aya/cubical/PathTest.java
@@ -22,7 +22,7 @@ public class PathTest {
       """);
     IntFunction<Doc> distiller = i -> res._2.get(i).toDoc(DistillerOptions.debug());
     assertEquals("""
-      def = {A : Type 0} (a b : A) : Type 0 => [| i |] A {| i 0 := a | i 1 := b |}
+      def = {A : Type 0} (a b : A) : Type 0 => [| i |] A {| ~ i := a | i := b |}
       """.strip(), distiller.apply(0).debugRender());
     assertEquals("""
       def idp {A : Type 0} {a : A} : (=) {A} a a => \\ (i : I) => a

--- a/base/src/test/java/org/aya/cubical/PathTest.java
+++ b/base/src/test/java/org/aya/cubical/PathTest.java
@@ -21,12 +21,10 @@ public class PathTest {
         \\i => a
       """);
     IntFunction<Doc> distiller = i -> res._2.get(i).toDoc(DistillerOptions.debug());
-    assertEquals("""
-      def = {A : Type 0} (a b : A) : Type 0 => [| i |] A {| ~ i := a | i := b |}
-      """.strip(), distiller.apply(0).debugRender());
-    assertEquals("""
-      def idp {A : Type 0} {a : A} : (=) {A} a a => \\ (i : I) => a
-      """.strip(), distiller.apply(1).debugRender());
+    assertEquals("def = {A : Type 0} (a b : A) : Type 0 => [| i |] A {| ~ i := a | i := b |}",
+      distiller.apply(0).debugRender());
+    assertEquals("def idp {A : Type 0} {a : A} : (=) {A} a a => \\ (i : I) => a",
+      distiller.apply(1).debugRender());
   }
 
   @Test public void cong() {

--- a/base/src/test/java/org/aya/cubical/PathTest.java
+++ b/base/src/test/java/org/aya/cubical/PathTest.java
@@ -68,6 +68,7 @@ public class PathTest {
 
   @Test public void partialConv() {
     TyckDeclTest.successTyckDecls("""
+      prim I
       def infix = {A : Type} (a b : A) : Type =>
         [| i |] A {| i 0 := a | i 1 := b |}
           

--- a/base/src/test/java/org/aya/cubical/PathTest.java
+++ b/base/src/test/java/org/aya/cubical/PathTest.java
@@ -69,21 +69,26 @@ public class PathTest {
   @Test public void partialConv() {
     TyckDeclTest.successTyckDecls("""
       prim I
+      prim Partial
+      prim invol
+            
+      def ~ => invol
+            
       def infix = {A : Type} (a b : A) : Type =>
         [| i |] A {| i 0 := a | i 1 := b |}
           
       def idp {A : Type} {a : A} : a = a =>
         \\i => a
         
-      def p1 (A : Type) (a : A) (i : I) : Partial A {i 0} =>
+      def p1 (A : Type) (a : A) (i : I) : Partial (~ i) A =>
         {| i 0 := a |}
-      def p2 (A : Type) (b : A) (j : I) : Partial A {j 0} =>
+      def p2 (A : Type) (b : A) (j : I) : Partial (~ j) A =>
         {| j 0 := b |}
       def p1=p2 (A : Type) (a : A) (i : I) : p1 A a i = p2 A a i =>
         idp
           
       def cmp {A : Type} (x : A)
-        : [| i j |] (Partial A {j 0}) {| i 0 := p1 A x j |}
+        : [| i j |] (Partial (~ j) A) {| i 0 := p1 A x j |}
         => \\i j => p2 A x j
       """);
   }

--- a/base/src/test/resources/failure/cubical/boundary-disagrees.aya
+++ b/base/src/test/resources/failure/cubical/boundary-disagrees.aya
@@ -1,3 +1,15 @@
 prim I
-def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial A { i 0 /\ j 0 } =>
+prim Partial
+prim intervalMin
+prim intervalMax
+prim invol
+
+def infix /\ => intervalMin
+tighter \/
+
+def infix \/ => intervalMax
+
+def ~ => invol
+
+def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial (~ i /\ ~ j) A =>
   {| i 0 := u | i 0 /\ j 0 := v |}

--- a/base/src/test/resources/failure/cubical/boundary-disagrees.aya
+++ b/base/src/test/resources/failure/cubical/boundary-disagrees.aya
@@ -1,2 +1,3 @@
+prim I
 def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial A { i 0 /\ j 0 } =>
   {| i 0 := u | i 0 /\ j 0 := v |}

--- a/base/src/test/resources/failure/cubical/boundary-disagrees.aya.txt
+++ b/base/src/test/resources/failure/cubical/boundary-disagrees.aya.txt
@@ -1,7 +1,8 @@
-In file $FILE:2:2 ->
+In file $FILE:3:2 ->
 
-  1 | def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial A { i 0 /\ j 0 } =>
-  2 |   {| i 0 := u | i 0 /\ j 0 := v |}
+  1 | prim I
+  2 | def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial A { i 0 /\ j 0 } =>
+  3 |   {| i 0 := u | i 0 /\ j 0 := v |}
         ^------------------------------^
 
 Error: The boundary

--- a/base/src/test/resources/failure/cubical/boundary-disagrees.aya.txt
+++ b/base/src/test/resources/failure/cubical/boundary-disagrees.aya.txt
@@ -1,9 +1,9 @@
-In file $FILE:3:2 ->
+In file $FILE:15:2 ->
 
-  1 | prim I
-  2 | def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial A { i 0 /\ j 0 } =>
-  3 |   {| i 0 := u | i 0 /\ j 0 := v |}
-        ^------------------------------^
+  13 | 
+  14 | def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial (~ i /\ ~ j) A =>
+  15 |   {| i 0 := u | i 0 /\ j 0 := v |}
+         ^------------------------------^
 
 Error: The boundary
          v

--- a/base/src/test/resources/failure/cubical/dim-mismatch.aya
+++ b/base/src/test/resources/failure/cubical/dim-mismatch.aya
@@ -1,9 +1,21 @@
 prim I
-def p1 (A : Type) (a : A) (i : I) : Partial A {i 0} =>
+prim Partial
+prim intervalMin
+prim intervalMax
+prim invol
+
+def infix /\ => intervalMin
+tighter \/
+
+def infix \/ => intervalMax
+
+def ~ => invol
+
+def p1 (A : Type) (a : A) (i : I) : Partial (~ i) A =>
   {| i 0 := a |}
-def p2 (A : Type) (b : A) (j : I) : Partial A {j 0} =>
+def p2 (A : Type) (b : A) (j : I) : Partial (~ j) A =>
   {| j 0 := b |}
 
 def cmp {A : Type} (x : A)
-  : [| i j |] (Partial A {j 0}) {| i 0 := p1 A x j |}
+  : [| i j |] (Partial (~ j) A) {| i 0 := p1 A x j |}
   => \i => p2 A x i

--- a/base/src/test/resources/failure/cubical/dim-mismatch.aya
+++ b/base/src/test/resources/failure/cubical/dim-mismatch.aya
@@ -1,3 +1,4 @@
+prim I
 def p1 (A : Type) (a : A) (i : I) : Partial A {i 0} =>
   {| i 0 := a |}
 def p2 (A : Type) (b : A) (j : I) : Partial A {j 0} =>

--- a/base/src/test/resources/failure/cubical/dim-mismatch.aya.txt
+++ b/base/src/test/resources/failure/cubical/dim-mismatch.aya.txt
@@ -1,9 +1,9 @@
-In file $FILE:9:5 ->
+In file $FILE:21:5 ->
 
-  7 | def cmp {A : Type} (x : A)
-  8 |   : [| i j |] (Partial A {j 0}) {| i 0 := p1 A x j |}
-  9 |   => \i => p2 A x i
-           ^------------^
+  19 | def cmp {A : Type} (x : A)
+  20 |   : [| i j |] (Partial (~ j) A) {| i 0 := p1 A x j |}
+  21 |   => \i => p2 A x i
+            ^------------^
 
 Error: This path lambda expects 2 parameters, but it has only 1
 

--- a/base/src/test/resources/failure/cubical/dim-mismatch.aya.txt
+++ b/base/src/test/resources/failure/cubical/dim-mismatch.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:8:5 ->
+In file $FILE:9:5 ->
 
-  6 | def cmp {A : Type} (x : A)
-  7 |   : [| i j |] (Partial A {j 0}) {| i 0 := p1 A x j |}
-  8 |   => \i => p2 A x i
+  7 | def cmp {A : Type} (x : A)
+  8 |   : [| i j |] (Partial A {j 0}) {| i 0 := p1 A x j |}
+  9 |   => \i => p2 A x i
            ^------------^
 
 Error: This path lambda expects 2 parameters, but it has only 1

--- a/base/src/test/resources/failure/cubical/face-mismatch.aya
+++ b/base/src/test/resources/failure/cubical/face-mismatch.aya
@@ -1,2 +1,3 @@
+prim I
 def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial A {i 0 \/ i 1} =>
   {| i 0 := u | i 1 /\ j 0 := v |}

--- a/base/src/test/resources/failure/cubical/face-mismatch.aya
+++ b/base/src/test/resources/failure/cubical/face-mismatch.aya
@@ -1,3 +1,15 @@
 prim I
-def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial A {i 0 \/ i 1} =>
+prim Partial
+prim intervalMin
+prim intervalMax
+prim invol
+
+def infix /\ => intervalMin
+tighter \/
+
+def infix \/ => intervalMax
+
+def ~ => invol
+
+def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial (~ i \/ i) A =>
   {| i 0 := u | i 1 /\ j 0 := v |}

--- a/base/src/test/resources/failure/cubical/face-mismatch.aya.txt
+++ b/base/src/test/resources/failure/cubical/face-mismatch.aya.txt
@@ -1,9 +1,9 @@
-In file $FILE:3:2 ->
+In file $FILE:15:2 ->
 
-  1 | prim I
-  2 | def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial A {i 0 \/ i 1} =>
-  3 |   {| i 0 := u | i 1 /\ j 0 := v |}
-        ^------------------------------^
+  13 | 
+  14 | def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial (~ i \/ i) A =>
+  15 |   {| i 0 := u | i 1 /\ j 0 := v |}
+         ^------------------------------^
 
 Error: The face(s) in the partial element:
          i 0 \/ (i 1 /\ j 0)

--- a/base/src/test/resources/failure/cubical/face-mismatch.aya.txt
+++ b/base/src/test/resources/failure/cubical/face-mismatch.aya.txt
@@ -6,9 +6,9 @@ In file $FILE:15:2 ->
          ^------------------------------^
 
 Error: The face(s) in the partial element:
-         i 0 \/ (i 1 /\ j 0)
+         ~ i \/ (i /\ ~ j)
        must cover the face(s) specified in type:
-         i 0 \/ i 1
+         ~ i \/ i
 
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/cubical/face-mismatch.aya.txt
+++ b/base/src/test/resources/failure/cubical/face-mismatch.aya.txt
@@ -1,7 +1,8 @@
-In file $FILE:2:2 ->
+In file $FILE:3:2 ->
 
-  1 | def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial A {i 0 \/ i 1} =>
-  2 |   {| i 0 := u | i 1 /\ j 0 := v |}
+  1 | prim I
+  2 | def counter (A : Type) (u : A) (v : A) (i : I) (j : I) : Partial A {i 0 \/ i 1} =>
+  3 |   {| i 0 := u | i 1 /\ j 0 := v |}
         ^------------------------------^
 
 Error: The face(s) in the partial element:

--- a/base/src/test/resources/failure/holes/issue420.aya
+++ b/base/src/test/resources/failure/holes/issue420.aya
@@ -1,3 +1,4 @@
+prim I
 open struct Path (A : Pi I -> Type) (a : A 0) (b : A 1) : Type
  | at (i : I) : A i {
    | 0 => a

--- a/base/src/test/resources/failure/holes/issue420.aya.txt
+++ b/base/src/test/resources/failure/holes/issue420.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:38:56 ->
+In file $FILE:39:56 ->
 
-  36 |  | a, suc b => suc (addN a b)
-  37 | 
-  38 | def addN-identity (a : Nat) : Eq (addN a zero) a => idp {? ?}
+  37 |  | a, suc b => suc (addN a b)
+  38 | 
+  39 | def addN-identity (a : Nat) : Eq (addN a zero) a => idp {? ?}
                                                                ^---^
 
 Goal: Candidate exists:

--- a/base/src/test/resources/failure/holes/scope-check.aya
+++ b/base/src/test/resources/failure/holes/scope-check.aya
@@ -1,3 +1,4 @@
+prim I
 open struct Path (A : I -> Type) (a : A 0) (b : A 1) : Type
  | at (i : I) : A i {
    | 0 => a

--- a/base/src/test/resources/failure/holes/scope-check.aya.txt
+++ b/base/src/test/resources/failure/holes/scope-check.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:12:46 ->
+In file $FILE:13:46 ->
 
-  10 | 
-  11 | -- https://cstheory.stackexchange.com/a/49160/50892
-  12 | def test (a : _) (B : Type) (b : B) (p : Eq a b) : I => 0
+  11 | 
+  12 | -- https://cstheory.stackexchange.com/a/49160/50892
+  13 | def test (a : _) (B : Type) (b : B) (p : Eq a b) : I => 0
                                                      ^^
 
 Error: The solution
@@ -10,20 +10,20 @@ Error: The solution
        is not well-scoped
        In particular, these variables are not in scope: `B`
 
-In file $FILE:12:14 ->
+In file $FILE:13:14 ->
 
-  10 | 
-  11 | -- https://cstheory.stackexchange.com/a/49160/50892
-  12 | def test (a : _) (B : Type) (b : B) (p : Eq a b) : I => 0
+  11 | 
+  12 | -- https://cstheory.stackexchange.com/a/49160/50892
+  13 | def test (a : _) (B : Type) (b : B) (p : Eq a b) : I => 0
                      ^^
 
 Error: Unsolved meta _
 
-In file $FILE:12:14 ->
+In file $FILE:13:14 ->
 
-  10 | 
-  11 | -- https://cstheory.stackexchange.com/a/49160/50892
-  12 | def test (a : _) (B : Type) (b : B) (p : Eq a b) : I => 0
+  11 | 
+  12 | -- https://cstheory.stackexchange.com/a/49160/50892
+  13 | def test (a : _) (B : Type) (b : B) (p : Eq a b) : I => 0
                      ^^
 
 Error: Unsolved meta _

--- a/base/src/test/resources/failure/patterns/issues/issue355.aya
+++ b/base/src/test/resources/failure/patterns/issues/issue355.aya
@@ -1,3 +1,4 @@
+prim I
 open data Nat : Type 0
  | zero
  | suc Nat

--- a/base/src/test/resources/failure/patterns/issues/issue355.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues/issue355.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:5:4 ->
+In file $FILE:6:4 ->
 
-  3 |  | suc Nat
-  4 | 
-  5 | def addN (a : I) : Nat
+  4 |  | suc Nat
+  5 | 
+  6 | def addN (a : I) : Nat
           ^--^
 
 Error: Cannot perform pattern matching `0`

--- a/base/src/test/resources/failure/patterns/issues/issue681.aya
+++ b/base/src/test/resources/failure/patterns/issues/issue681.aya
@@ -1,3 +1,4 @@
+prim I
 open struct Path (A : I -> Type) (a : A 0) (b : A 1) : Type
   | at (i : I) : A i {
     | 0 => a

--- a/base/src/test/resources/failure/patterns/issues/issue681.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues/issue681.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:26:4 ->
+In file $FILE:27:4 ->
 
-  24 | 
-  25 | def +-assoc : Pi (x y z : Nat) -> x + (y + z) = (x + y) + z
-  26 |   | zero, y, z => idp
+  25 | 
+  26 | def +-assoc : Pi (x y z : Nat) -> x + (y + z) = (x + y) + z
+  27 |   | zero, y, z => idp
            ^--^
 
 Error: There is no parameter for the pattern
@@ -12,11 +12,11 @@ Error: There is no parameter for the pattern
        (and in case it's a function type, you may want to move its parameters before
        the `:` in the signature)
 
-In file $FILE:27:4 ->
+In file $FILE:28:4 ->
 
-  25 | def +-assoc : Pi (x y z : Nat) -> x + (y + z) = (x + y) + z
-  26 |   | zero, y, z => idp
-  27 |   | suc x, y, z => pmap suc (+-assoc x y z)
+  26 | def +-assoc : Pi (x y z : Nat) -> x + (y + z) = (x + y) + z
+  27 |   | zero, y, z => idp
+  28 |   | suc x, y, z => pmap suc (+-assoc x y z)
            ^---^
 
 Error: There is no parameter for the pattern

--- a/base/src/test/resources/failure/patterns/issues2/issue352.aya
+++ b/base/src/test/resources/failure/patterns/issues2/issue352.aya
@@ -1,3 +1,4 @@
+prim I
 open struct Path (A : I -> Type) (a : A 0) (b : A 1) : Type
   | at (i : I) : A i {
     | 0 => a

--- a/base/src/test/resources/failure/patterns/issues2/issue352.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues2/issue352.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:12:4 ->
+In file $FILE:13:4 ->
 
-  10 | def infix = (a b : A) => Path (\x => A) a b
-  11 | def idp {a : A} : a = a => path (\x => a)
-  12 | def funExt (f g : A -> B) (p : forall a -> f a = g a) : f = g
+  11 | def infix = (a b : A) => Path (\x => A) a b
+  12 | def idp {a : A} : a = a => path (\x => a)
+  13 | def funExt (f g : A -> B) (p : forall a -> f a = g a) : f = g
            ^----^
 
 Error: The parameter:
@@ -10,11 +10,11 @@ Error: The parameter:
          (Normalized: Type 0)
        requires a binding in the patterns
 
-In file $FILE:12:4 ->
+In file $FILE:13:4 ->
 
-  10 | def infix = (a b : A) => Path (\x => A) a b
-  11 | def idp {a : A} : a = a => path (\x => a)
-  12 | def funExt (f g : A -> B) (p : forall a -> f a = g a) : f = g
+  11 | def infix = (a b : A) => Path (\x => A) a b
+  12 | def idp {a : A} : a = a => path (\x => a)
+  13 | def funExt (f g : A -> B) (p : forall a -> f a = g a) : f = g
            ^----^
 
 Error: The parameter:
@@ -22,11 +22,11 @@ Error: The parameter:
          (Normalized: Type 0)
        requires a binding in the patterns
 
-In file $FILE:12:4 ->
+In file $FILE:13:4 ->
 
-  10 | def infix = (a b : A) => Path (\x => A) a b
-  11 | def idp {a : A} : a = a => path (\x => a)
-  12 | def funExt (f g : A -> B) (p : forall a -> f a = g a) : f = g
+  11 | def infix = (a b : A) => Path (\x => A) a b
+  12 | def idp {a : A} : a = a => path (\x => a)
+  13 | def funExt (f g : A -> B) (p : forall a -> f a = g a) : f = g
            ^----^
 
 Error: The parameter:
@@ -34,11 +34,11 @@ Error: The parameter:
          (Normalized: A -> B)
        requires a binding in the patterns
 
-In file $FILE:12:4 ->
+In file $FILE:13:4 ->
 
-  10 | def infix = (a b : A) => Path (\x => A) a b
-  11 | def idp {a : A} : a = a => path (\x => a)
-  12 | def funExt (f g : A -> B) (p : forall a -> f a = g a) : f = g
+  11 | def infix = (a b : A) => Path (\x => A) a b
+  12 | def idp {a : A} : a = a => path (\x => a)
+  13 | def funExt (f g : A -> B) (p : forall a -> f a = g a) : f = g
            ^----^
 
 Error: The parameter:
@@ -46,11 +46,11 @@ Error: The parameter:
          (Normalized: A -> B)
        requires a binding in the patterns
 
-In file $FILE:12:4 ->
+In file $FILE:13:4 ->
 
-  10 | def infix = (a b : A) => Path (\x => A) a b
-  11 | def idp {a : A} : a = a => path (\x => a)
-  12 | def funExt (f g : A -> B) (p : forall a -> f a = g a) : f = g
+  11 | def infix = (a b : A) => Path (\x => A) a b
+  12 | def idp {a : A} : a = a => path (\x => a)
+  13 | def funExt (f g : A -> B) (p : forall a -> f a = g a) : f = g
            ^----^
 
 Error: The parameter:

--- a/base/src/test/resources/failure/patterns/unexpected-end-pat.aya
+++ b/base/src/test/resources/failure/patterns/unexpected-end-pat.aya
@@ -1,3 +1,4 @@
+prim I
 def test(i: I): I
   | 3 => 0
   | 4 => 1

--- a/base/src/test/resources/failure/patterns/unexpected-end-pat.aya.txt
+++ b/base/src/test/resources/failure/patterns/unexpected-end-pat.aya.txt
@@ -1,18 +1,18 @@
-In file $FILE:2:4 ->
+In file $FILE:3:4 ->
 
-  1 | def test(i: I): I
-  2 |   | 3 => 0
+  1 | prim I
+  2 | def test(i: I): I
+  3 |   | 3 => 0
           ^^
-  3 |   | 4 => 1
 
 Error: The point `3` does not live in interval
 note: Did you mean:  `0` or `1`
 
-In file $FILE:3:4 ->
+In file $FILE:4:4 ->
 
-  1 | def test(i: I): I
-  2 |   | 3 => 0
-  3 |   | 4 => 1
+  2 | def test(i: I): I
+  3 |   | 3 => 0
+  4 |   | 4 => 1
           ^^
 
 Error: The point `4` does not live in interval

--- a/base/src/test/resources/failure/projection/issues2/issue151.aya
+++ b/base/src/test/resources/failure/projection/issues2/issue151.aya
@@ -1,3 +1,4 @@
+prim I
 prim arcoe
 open struct Path (A : I -> Type) (a : A 0) (b : A 1) : Type
   | at (i : I) : A i {

--- a/base/src/test/resources/failure/projection/issues2/issue151.aya.txt
+++ b/base/src/test/resources/failure/projection/issues2/issue151.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:21:38 ->
+In file $FILE:22:38 ->
 
-  19 |   | assoc (a b c : Nat) : Eq (op (op a b) c) (op a (op b c))
-  20 | 
-  21 | def l-id (M : Monoid) (a : Nat) : Eq (M.add zero a) a => refl
+  20 |   | assoc (a b c : Nat) : Eq (op (op a b) c) (op a (op b c))
+  21 | 
+  22 | def l-id (M : Monoid) (a : Nat) : Eq (M.add zero a) a => refl
                                              ^---^
 
 Error: Unknown field `add` projected

--- a/base/src/test/resources/failure/projection/issues2/issue34.aya
+++ b/base/src/test/resources/failure/projection/issues2/issue34.aya
@@ -1,3 +1,4 @@
+prim I
 open struct Path (A : I -> Type) (a : A 0) (b : A 1) : Type
   | at (i : I) : A i {
     | 0 => a

--- a/base/src/test/resources/failure/projection/issues2/issue34.aya.txt
+++ b/base/src/test/resources/failure/projection/issues2/issue34.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:10:90 ->
+In file $FILE:11:90 ->
 
-   8 | def infix = {A : Type} (a b : A) : Type => Path (\ i => A) a b
-   9 | 
-  10 | def psqueeze {A : Type} {a a' : A} (p : a = a') (i : I) : a = p.at i => path (\j => p.at (I.squeeze i j))
+   9 | def infix = {A : Type} (a b : A) : Type => Path (\ i => A) a b
+  10 | 
+  11 | def psqueeze {A : Type} {a a' : A} (p : a = a') (i : I) : a = p.at i => path (\j => p.at (I.squeeze i j))
                                                                                                  ^-------^
 
 Error: Unknown field `squeeze` projected

--- a/base/src/test/resources/failure/scope/re-prim.aya
+++ b/base/src/test/resources/failure/scope/re-prim.aya
@@ -1,2 +1,3 @@
+prim I
 prim arcoe
 prim arcoe

--- a/base/src/test/resources/failure/scope/re-prim.aya.txt
+++ b/base/src/test/resources/failure/scope/re-prim.aya.txt
@@ -1,7 +1,8 @@
-In file $FILE:2:5 ->
+In file $FILE:3:5 ->
 
-  1 | prim arcoe
+  1 | prim I
   2 | prim arcoe
+  3 | prim arcoe
            ^---^
 
 Error: Redefinition of primitive `arcoe`

--- a/base/src/test/resources/failure/struct/arg-num-mismatch.aya
+++ b/base/src/test/resources/failure/struct/arg-num-mismatch.aya
@@ -1,3 +1,4 @@
+prim I
 open struct Path (A : I -> Type) (a : A 0) (b : A 1) : Type
  | at (i : I) : A i {
    | 0 => a

--- a/base/src/test/resources/failure/struct/arg-num-mismatch.aya.txt
+++ b/base/src/test/resources/failure/struct/arg-num-mismatch.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:8:5 ->
+In file $FILE:9:5 ->
 
-  6 | 
-  7 | def path {A : I -> Type} (p : Pi (i : I) -> A i)
-  8 |   => new Path A (p 0) (p 1) { | at i j => p i}
+  7 | 
+  8 | def path {A : I -> Type} (p : Pi (i : I) -> A i)
+  9 |   => new Path A (p 0) (p 1) { | at i j => p i}
            ^---------------------------------------^
 
 Error: Expected 1 arguments, but found 2 arguments for field at

--- a/base/src/test/resources/failure/struct/universe.aya
+++ b/base/src/test/resources/failure/struct/universe.aya
@@ -1,1 +1,2 @@
+prim I
 struct Test : I

--- a/base/src/test/resources/failure/struct/universe.aya.txt
+++ b/base/src/test/resources/failure/struct/universe.aya.txt
@@ -1,6 +1,7 @@
-In file $FILE:1:14 ->
+In file $FILE:2:14 ->
 
-  1 | struct Test : I
+  1 | prim I
+  2 | struct Test : I
                     ^^
 
 Error: Unable to make sense of the expression

--- a/base/src/test/resources/failure/syntax/issue164.aya.txt
+++ b/base/src/test/resources/failure/syntax/issue164.aya.txt
@@ -5,7 +5,7 @@ In file $FILE:3:26 ->
   3 |              (p : Sig A  B) : C
                                 ^^
 
-Error: Parser error: extraneous input ')' expecting {'Type', 'I', LAND, LOR, '**', '{', '(', '{?', NUMBER, '_', STRING, REPL_COMMAND, ID}
+Error: Parser error: extraneous input ')' expecting {'Type', LAND, LOR, '**', '{', '(', '{?', NUMBER, '_', STRING, REPL_COMMAND, ID, I}
 
 Parsing interrupted due to:
 1 error(s), 0 warning(s).

--- a/base/src/test/resources/failure/syntax/literate-unresolved.aya
+++ b/base/src/test/resources/failure/syntax/literate-unresolved.aya
@@ -1,3 +1,4 @@
+prim I
 prim arcoe
 --| test `arcoe`
 --| test `unresolved`

--- a/base/src/test/resources/failure/syntax/literate-unresolved.aya.txt
+++ b/base/src/test/resources/failure/syntax/literate-unresolved.aya.txt
@@ -1,9 +1,10 @@
-In file $FILE:2:0 ->
+In file $FILE:3:0 ->
 
-  1 | prim arcoe
-  2 | --| test `arcoe`
+  1 | prim I
+  2 | prim arcoe
+  3 | --| test `arcoe`
       ^-------------------^
-  3 | --| test `unresolved`
+  4 | --| test `unresolved`
 
 Error: The name `unresolved` is not defined in the current scope
 

--- a/base/src/test/resources/failure/tyck/issues/issue697.aya
+++ b/base/src/test/resources/failure/tyck/issues/issue697.aya
@@ -1,3 +1,4 @@
+prim I
 prim arcoe
 open struct Path (A : I -> Type) (a : A 0) (b : A 1) : Type
   | at (i : I) : A i {

--- a/base/src/test/resources/failure/tyck/issues/issue697.aya.txt
+++ b/base/src/test/resources/failure/tyck/issues/issue697.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:26:61 ->
+In file $FILE:27:61 ->
 
-  24 |   => path (hfill2d p q r 1)
-  25 | 
-  26 | def sym {A : Type} {a b : A} (p : a = b) : b = a => hcomp2d (idp a) idp p
+  25 |   => path (hfill2d p q r 1)
+  26 | 
+  27 | def sym {A : Type} {a b : A} (p : a = b) : b = a => hcomp2d (idp a) idp p
                                                                     ^---^
 
 Error: Unable to apply the expression

--- a/base/src/test/resources/failure/tyck/tele-prim-no-type.aya
+++ b/base/src/test/resources/failure/tyck/tele-prim-no-type.aya
@@ -1,1 +1,2 @@
+prim I
 prim invol (i : I)

--- a/base/src/test/resources/failure/tyck/tele-prim-no-type.aya.txt
+++ b/base/src/test/resources/failure/tyck/tele-prim-no-type.aya.txt
@@ -1,6 +1,7 @@
-In file $FILE:1:5 ->
+In file $FILE:2:5 ->
 
-  1 | prim invol (i : I)
+  1 | prim I
+  2 | prim invol (i : I)
            ^---^
 
 Error: prim invol is expected to have a type

--- a/base/src/test/resources/failure/tyck/unexpected-end.aya
+++ b/base/src/test/resources/failure/tyck/unexpected-end.aya
@@ -1,3 +1,4 @@
+prim I
 public open struct Path (A : I -> Type) (a : A 0) (b : A 1) : Type
   | at (i : I) : A i {
     | 0 => a

--- a/base/src/test/resources/failure/tyck/unexpected-end.aya.txt
+++ b/base/src/test/resources/failure/tyck/unexpected-end.aya.txt
@@ -1,18 +1,18 @@
-In file $FILE:7:19 ->
+In file $FILE:8:19 ->
 
-  5 |   }
-  6 | def path {A : I -> Type} (p : Pi (i : I) -> A i)
-  7 |   => new Path A (p 3) (p 4) { | at i => p i }
+  6 |   }
+  7 | def path {A : I -> Type} (p : Pi (i : I) -> A i)
+  8 |   => new Path A (p 3) (p 4) { | at i => p i }
                          ^^
 
 Error: The point `3` does not live in interval
 note: Did you mean:  `0` or `1`
 
-In file $FILE:7:25 ->
+In file $FILE:8:25 ->
 
-  5 |   }
-  6 | def path {A : I -> Type} (p : Pi (i : I) -> A i)
-  7 |   => new Path A (p 3) (p 4) { | at i => p i }
+  6 |   }
+  7 | def path {A : I -> Type} (p : Pi (i : I) -> A i)
+  8 |   => new Path A (p 3) (p 4) { | at i => p i }
                                ^^
 
 Error: The point `4` does not live in interval

--- a/base/src/test/resources/success/common/src/Primitives.aya
+++ b/base/src/test/resources/success/common/src/Primitives.aya
@@ -1,4 +1,5 @@
 prim I
+prim Partial
 prim arcoe (A : I -> Type) (A 0) (i : I) : A i
 prim invol (i : I) : I
 prim intervalMin (i j : I) : I

--- a/base/src/test/resources/success/common/src/Primitives.aya
+++ b/base/src/test/resources/success/common/src/Primitives.aya
@@ -1,3 +1,4 @@
+prim I
 prim arcoe (A : I -> Type) (A 0) (i : I) : A i
 prim invol (i : I) : I
 prim intervalMin (i j : I) : I

--- a/base/src/test/resources/success/src/CubicalBasics.aya
+++ b/base/src/test/resources/success/src/CubicalBasics.aya
@@ -1,5 +1,6 @@
 open import Primitives using
-  ( invol as fixl ~
+  ( I
+  , invol as fixl ~
   , intervalMin as infix /\
   , intervalMax as infix \/
   )

--- a/base/src/test/resources/success/src/CubicalBasics.aya
+++ b/base/src/test/resources/success/src/CubicalBasics.aya
@@ -1,5 +1,6 @@
 open import Primitives using
   ( I
+  , Partial
   , invol as fixl ~
   , intervalMin as infix /\
   , intervalMax as infix \/
@@ -14,17 +15,17 @@ def pmap {A B : Type} (f : A -> B) {a b : A}
      (p : a = b) : f a = f b => \i => f (p i)
 def sym {A : Type} {a b : A} (p : a = b) : b = a => \i => p (~ i)
 
-def par1 (A : Type) (u : A) (i : I) : Partial A {i 0} =>
+def par1 (A : Type) (u : A) (i : I) : Partial (~ i) A =>
   {| i 0 := u |}
 
 -- By @imkiva, in PR
-def p1 (A : Type) (a : A) (i : I) : Partial A {i 0} =>
+def p1 (A : Type) (a : A) (i : I) : Partial (~ i) A =>
   {| i 0 := a |}
-def p2 (A : Type) (b : A) (j : I) : Partial A {j 0} =>
+def p2 (A : Type) (b : A) (j : I) : Partial (~ j) A =>
   {| j 0 := b |}
 def p1=p2 (A : Type) (a : A) (i : I) : p1 A a i = p2 A a i =>
   idp
 
 def cmp {A : Type} (x : A)
-  : [| i j |] (Partial A {j 0}) {| i 0 := p1 A x j |}
+  : [| i j |] (Partial (~ j) A) {| i 0 := p1 A x j |}
   => \i => \j => p2 A x j

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,6 +174,7 @@ subprojects {
           dev("re-xyr", "Xy Ren", "xy.r@outlook.com")
           dev("dark-flames", "Darkflames", "dark_flames@outlook.com")
           dev("tsao-chi", "tsao-chi", "tsao-chi@the-lingo.org")
+          dev("lunalunaa", "Luna Xin", "luna.xin@outlook.com")
         }
         scm {
           connection.set("scm:git:$githubUrl")

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
@@ -49,7 +49,7 @@ PRIM : 'prim';
 EXTENDS : 'extends';
 NEW_KW : 'new';
 PATTERN_KW : 'pattern';
-I: 'I';
+//I: 'I';
 DO_KW : 'do';
 THIS_KW : 'this';
 OVERRIDE : 'override';

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
@@ -52,7 +52,6 @@ PATTERN_KW : 'pattern';
 DO_KW : 'do';
 THIS_KW : 'this';
 OVERRIDE : 'override';
-PARTIAL_KW : 'Partial';
 
 // Unimplemented but reserved
 CODATA_KW : 'codata';

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaLexer.g4
@@ -49,7 +49,6 @@ PRIM : 'prim';
 EXTENDS : 'extends';
 NEW_KW : 'new';
 PATTERN_KW : 'pattern';
-//I: 'I';
 DO_KW : 'do';
 THIS_KW : 'this';
 OVERRIDE : 'override';

--- a/lsp/src/test/resources/lsp-test-lib/src/Path.aya
+++ b/lsp/src/test/resources/lsp-test-lib/src/Path.aya
@@ -1,4 +1,4 @@
-import PathPrims
+public open import PathPrims
 
 public open struct Path (A : I -> Type) (a : A 0) (b : A 1) : Type
   | at (i : I) : A i {

--- a/lsp/src/test/resources/lsp-test-lib/src/PathPrims.aya
+++ b/lsp/src/test/resources/lsp-test-lib/src/PathPrims.aya
@@ -1,3 +1,3 @@
+prim I
 prim intervalMin (i : I) (j : I) : I
 prim arcoe (A : I -> Type) (A 0) (i : I) : A i
-


### PR DESCRIPTION
`I` and `Partial` are now a primitive instead of a keyword.

## What still needs to be done
- [x] Modifying test cases
- [ ] ~~Elaborate primitives at `CallTerm.make`~~

Edit (@ice1000): we no longer hack `CallTerm.make`, but we instead hack `ExprTycker::defCall`, and we eagerly reduce primCalls.

In the future, we will ban functions that takes `Type` types into `ISet` types, and we only allow pure `ISet` functions. Those functions will be marked as always-inline.