### PR TITLE
Refactor: Separate delta and beta reduction.

### DIFF
--- a/base/src/main/java/org/aya/core/term/CallTerm.java
+++ b/base/src/main/java/org/aya/core/term/CallTerm.java
@@ -82,7 +82,7 @@ public sealed interface CallTerm extends Term {
     @Override @NotNull DefVar<DataDef, TeleDecl.DataDecl> ref,
     @Override int ulift,
     @Override @NotNull ImmutableSeq<Arg<@NotNull Term>> args
-  ) implements DefCall {
+  ) implements DefCall, StableWHNF {
 
     public @NotNull ConHead conHead(@NotNull DefVar<CtorDef, TeleDecl.DataCtor> ctorRef) {
       return new ConHead(ref, ctorRef, ulift, args);
@@ -96,7 +96,7 @@ public sealed interface CallTerm extends Term {
     @Override @NotNull DefVar<StructDef, TeleDecl.StructDecl> ref,
     @Override int ulift,
     @Override @NotNull ImmutableSeq<Arg<@NotNull Term>> args
-  ) implements DefCall {
+  ) implements DefCall, StableWHNF {
   }
 
   record ConHead(

--- a/base/src/main/java/org/aya/core/term/FormTerm.java
+++ b/base/src/main/java/org/aya/core/term/FormTerm.java
@@ -18,7 +18,7 @@ public sealed interface FormTerm extends Term {
   /**
    * @author re-xyr, kiva, ice1000
    */
-  record Pi(@NotNull Term.Param param, @NotNull Term body) implements FormTerm {
+  record Pi(@NotNull Term.Param param, @NotNull Term body) implements FormTerm, StableWHNF {
 
     public @NotNull Term substBody(@NotNull Term term) {
       return body.subst(param.ref(), term);
@@ -50,13 +50,13 @@ public sealed interface FormTerm extends Term {
   /**
    * @author re-xyr
    */
-  record Sigma(@NotNull ImmutableSeq<@NotNull Param> params) implements FormTerm {
+  record Sigma(@NotNull ImmutableSeq<@NotNull Param> params) implements FormTerm, StableWHNF {
   }
 
   /**
    * @author ice1000
    */
-  record Univ(int lift) implements FormTerm {
+  record Univ(int lift) implements FormTerm, StableWHNF {
     public static final @NotNull FormTerm.Univ ZERO = new Univ(0);
   }
 
@@ -64,5 +64,5 @@ public sealed interface FormTerm extends Term {
   record PartTy(@NotNull Term type, @NotNull Restr<Term> restr) implements FormTerm {}
 
   /** generalized path type */
-  record Path(@NotNull Cube<Term> cube) implements FormTerm {}
+  record Path(@NotNull Cube<Term> cube) implements FormTerm, StableWHNF {}
 }

--- a/base/src/main/java/org/aya/core/term/IntroTerm.java
+++ b/base/src/main/java/org/aya/core/term/IntroTerm.java
@@ -22,7 +22,7 @@ public sealed interface IntroTerm extends Term {
   /**
    * @author ice1000
    */
-  record Lambda(@NotNull Param param, @NotNull Term body) implements IntroTerm {
+  record Lambda(@NotNull Param param, @NotNull Term body) implements IntroTerm, StableWHNF {
 
     public static @NotNull Term unwrap(@NotNull Term term, @NotNull Consumer<@NotNull Param> params) {
       while (term instanceof Lambda lambda) {
@@ -43,13 +43,13 @@ public sealed interface IntroTerm extends Term {
   record New(
     @NotNull CallTerm.Struct struct,
     @NotNull ImmutableMap<DefVar<FieldDef, TeleDecl.StructField>, Term> params
-  ) implements IntroTerm {
+  ) implements IntroTerm, StableWHNF {
   }
 
   /**
    * @author re-xyr
    */
-  record Tuple(@NotNull ImmutableSeq<Term> items) implements IntroTerm {
+  record Tuple(@NotNull ImmutableSeq<Term> items) implements IntroTerm, StableWHNF {
   }
 
   /** partial element */
@@ -59,5 +59,5 @@ public sealed interface IntroTerm extends Term {
   record PathLam(
     @NotNull ImmutableSeq<Term.Param> params,
     @NotNull Term body
-  ) implements IntroTerm {}
+  ) implements IntroTerm, StableWHNF {}
 }

--- a/base/src/main/java/org/aya/core/term/StableWHNF.java
+++ b/base/src/main/java/org/aya/core/term/StableWHNF.java
@@ -1,0 +1,20 @@
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.core.term;
+
+/**
+ * Cubical-stable WHNF: those who will not change to other term formers
+ * under face restrictions (aka cofibrations).
+ */
+public sealed interface StableWHNF permits
+  CallTerm.Data,
+  CallTerm.Struct,
+  FormTerm.Path,
+  FormTerm.Pi,
+  FormTerm.Sigma,
+  FormTerm.Univ,
+  IntroTerm.Lambda,
+  IntroTerm.New,
+  IntroTerm.PathLam,
+  IntroTerm.Tuple {
+}

--- a/base/src/main/java/org/aya/core/visitor/BetaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/BetaExpander.java
@@ -1,0 +1,65 @@
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.core.visitor;
+
+import kala.collection.mutable.MutableList;
+import org.aya.core.term.CallTerm;
+import org.aya.core.term.ElimTerm;
+import org.aya.core.term.IntroTerm;
+import org.aya.core.term.Term;
+import org.aya.generic.Arg;
+import org.aya.generic.Cube;
+import org.aya.guest0x0.cubical.CofThy;
+import org.aya.guest0x0.cubical.Partial;
+import org.aya.guest0x0.cubical.Restr;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+
+public interface BetaExpander extends EndoFunctor {
+  static @NotNull IntroTerm.PartEl partial(@NotNull IntroTerm.PartEl el) {
+    return new IntroTerm.PartEl(partial(el.partial()), el.rhsType());
+  }
+  private static @NotNull Partial<Term> partial(@NotNull Partial<Term> partial) {
+    return switch (partial) {
+      case Partial.Const<Term> par -> new Partial.Const<>(par.u());
+      case Partial.Split<Term> par -> {
+        var clauses = MutableList.<Restr.Side<Term>>create();
+        for (var clause : par.clauses()) {
+          var u = clause.u();
+          if (CofThy.normalizeCof(clause.cof(), clauses, cofib -> new Restr.Side<>(cofib, u))) {
+            yield new Partial.Const<>(u);
+          }
+        }
+        yield new Partial.Split<>(clauses.toImmutableSeq());
+      }
+    };
+  }
+  static @NotNull Term pathApp(@NotNull ElimTerm.PathApp app, @NotNull Function<Term, Term> next) {
+    if (app.of() instanceof IntroTerm.PathLam lam) {
+      var xi = lam.params().map(Term.Param::ref);
+      var ui = app.args().map(Arg::term);
+      var subst = new Subst(xi, ui);
+      return next.apply(lam.body().subst(subst));
+    }
+    return switch (partial(app.cube().partial())) {
+      case Partial.Split<Term> hap -> new ElimTerm.PathApp(app.of(), app.args(), new Cube<>(
+        app.cube().params(), app.cube().type(), hap));
+      case Partial.Const<Term> sad -> sad.u();
+    };
+  }
+  @Override default @NotNull Term post(@NotNull Term term) {
+    return switch (term) {
+      case ElimTerm.App app -> {
+        var result = CallTerm.make(app);
+        yield result == term ? result : apply(result);
+      }
+      case ElimTerm.Proj proj -> ElimTerm.proj(proj);
+      case ElimTerm.PathApp app -> pathApp(app, this);
+      case IntroTerm.PartEl partial -> partial(partial);
+      default -> term;
+    };
+  }
+
+  record Simplifier() implements BetaExpander {}
+}

--- a/base/src/main/java/org/aya/core/visitor/BetaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/BetaExpander.java
@@ -11,6 +11,12 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
 
+/**
+ * We think of all cubical reductions as beta reductions.
+ *
+ * @author wsx
+ * @see DeltaExpander
+ */
 public interface BetaExpander extends EndoFunctor {
   static @NotNull IntroTerm.PartEl partial(@NotNull IntroTerm.PartEl el) {
     return new IntroTerm.PartEl(partial(el.partial()), el.rhsType());

--- a/base/src/main/java/org/aya/core/visitor/BetaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/BetaExpander.java
@@ -2,16 +2,13 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.visitor;
 
-import kala.collection.mutable.MutableList;
 import org.aya.core.term.CallTerm;
 import org.aya.core.term.ElimTerm;
 import org.aya.core.term.IntroTerm;
 import org.aya.core.term.Term;
 import org.aya.generic.Arg;
 import org.aya.generic.Cube;
-import org.aya.guest0x0.cubical.CofThy;
 import org.aya.guest0x0.cubical.Partial;
-import org.aya.guest0x0.cubical.Restr;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
@@ -21,19 +18,7 @@ public interface BetaExpander extends EndoFunctor {
     return new IntroTerm.PartEl(partial(el.partial()), el.rhsType());
   }
   private static @NotNull Partial<Term> partial(@NotNull Partial<Term> partial) {
-    return switch (partial) {
-      case Partial.Const<Term> par -> new Partial.Const<>(par.u());
-      case Partial.Split<Term> par -> {
-        var clauses = MutableList.<Restr.Side<Term>>create();
-        for (var clause : par.clauses()) {
-          var u = clause.u();
-          if (CofThy.normalizeCof(clause.cof(), clauses, cofib -> new Restr.Side<>(cofib, u))) {
-            yield new Partial.Const<>(u);
-          }
-        }
-        yield new Partial.Split<>(clauses.toImmutableSeq());
-      }
-    };
+    return partial.flatMap(Function.identity());
   }
   static @NotNull Term pathApp(@NotNull ElimTerm.PathApp app, @NotNull Function<Term, Term> next) {
     if (app.of() instanceof IntroTerm.PathLam lam) {

--- a/base/src/main/java/org/aya/core/visitor/DeltaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/DeltaExpander.java
@@ -18,6 +18,10 @@ import org.aya.tyck.TyckState;
 import org.aya.util.error.WithPos;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * @author wsx
+ * @see BetaExpander
+ */
 public interface DeltaExpander extends EndoFunctor {
   @NotNull TyckState state();
 

--- a/base/src/main/java/org/aya/core/visitor/DeltaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/DeltaExpander.java
@@ -1,0 +1,112 @@
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.core.visitor;
+
+import kala.collection.SeqLike;
+import kala.collection.immutable.ImmutableSeq;
+import kala.collection.mutable.MutableMap;
+import kala.control.Option;
+import kala.tuple.Tuple;
+import org.aya.core.Matching;
+import org.aya.core.pat.PatMatcher;
+import org.aya.core.term.*;
+import org.aya.generic.Arg;
+import org.aya.generic.Modifier;
+import org.aya.guest0x0.cubical.CofThy;
+import org.aya.guest0x0.cubical.Restr;
+import org.aya.tyck.TyckState;
+import org.aya.util.error.WithPos;
+import org.jetbrains.annotations.NotNull;
+
+public interface DeltaExpander extends EndoFunctor {
+  @NotNull TyckState state();
+
+  static @NotNull Subst buildSubst(@NotNull SeqLike<Term.Param> self, @NotNull SeqLike<Arg<Term>> args) {
+    var entries = self.view().zip(args)
+      .map(t -> Tuple.of(t._1.ref(), t._2.term()));
+    return new Subst(MutableMap.from(entries));
+  }
+
+  @Override default @NotNull Term post(@NotNull Term term) {
+    return switch (term) {
+      case CallTerm.Con con -> {
+        var def = con.ref().core;
+        if (def == null) yield con;
+        yield tryUnfoldClauses(true, con.conArgs(), con.ulift(), def.clauses)
+          .map(un -> apply(un.data())).getOrDefault(con);
+      }
+      case CallTerm.Fn fn -> {
+        var def = fn.ref().core;
+        if (def == null || def.modifiers.contains(Modifier.Opaque)) yield fn;
+        yield def.body.fold(
+          lamBody -> apply(lamBody.rename().subst(buildSubst(def.telescope(), fn.args())).lift(fn.ulift())),
+          clauses -> tryUnfoldClauses(def.modifiers.contains(Modifier.Overlap), fn.args(), fn.ulift(), clauses)
+            .map(unfolded -> apply(unfolded.data())).getOrDefault(fn));
+      }
+      case CallTerm.Prim prim -> state().primFactory().unfold(prim.id(), prim, state());
+      case CallTerm.Hole hole -> {
+        var def = hole.ref();
+        yield state().metas().getOption(def)
+          .map(body -> apply(body.subst(buildSubst(def.fullTelescope(), hole.fullArgs()))))
+          .getOrDefault(hole);
+      }
+      case CallTerm.Access access -> {
+        var fieldDef = access.ref().core;
+        if (access.of() instanceof IntroTerm.New n) {
+          var fieldBody = access.fieldArgs().foldLeft(n.params().get(access.ref()), CallTerm::make);
+          yield apply(fieldBody.subst(buildSubst(fieldDef.ownerTele, access.structArgs())));
+        } else {
+          var subst = buildSubst(fieldDef.fullTelescope(), access.args());
+          for (var field : fieldDef.structRef.core.fields) {
+            if (field == fieldDef) continue;
+            var fieldArgs = field.telescope().map(Term.Param::toArg);
+            var acc = new CallTerm.Access(access.of(), field.ref, access.structArgs(), fieldArgs);
+            subst.add(field.ref, IntroTerm.Lambda.make(field.telescope(), acc));
+          }
+          yield tryUnfoldClauses(true, access.fieldArgs(), subst, 0, fieldDef.clauses)
+            .map(unfolded -> apply(unfolded.data())).getOrDefault(access);
+        }
+      }
+      case RefTerm.MetaPat metaPat -> metaPat.inline();
+      case PrimTerm.Mula mula -> simplFormula(mula);
+      case FormTerm.PartTy ty -> partialType(ty);
+      default -> term;
+    };
+  }
+
+  static @NotNull Term simplFormula(@NotNull PrimTerm.Mula mula) {
+    return Restr.formulae(mula.asFormula(), PrimTerm.Mula::new);
+  }
+
+  static @NotNull FormTerm.PartTy partialType(@NotNull FormTerm.PartTy ty) {
+    return new FormTerm.PartTy(ty.type(), restr(ty.restr()));
+  }
+
+  static @NotNull Restr<Term> restr(@NotNull Restr<Term> restr) {
+    return switch (restr) {
+      case Restr.Vary<Term> vary -> CofThy.normalizeRestr(vary);
+      case Restr.Const<Term> c -> c;
+    };
+  }
+
+  default @NotNull Option<WithPos<Term>> tryUnfoldClauses(
+    boolean orderIndependent, @NotNull SeqLike<Arg<Term>> args,
+    @NotNull Subst subst, int ulift, @NotNull ImmutableSeq<Matching> clauses
+  ) {
+    for (var matchy : clauses) {
+      var termSubst = PatMatcher.tryBuildSubstArgs(null, matchy.patterns(), args);
+      if (termSubst.isOk()) {
+        subst.add(termSubst.get());
+        var newBody = matchy.body().rename().subst(subst).lift(ulift);
+        return Option.some(new WithPos<>(matchy.sourcePos(), newBody));
+      } else if (!orderIndependent && termSubst.getErr()) return Option.none();
+    }
+    return Option.none();
+  }
+  default @NotNull Option<WithPos<Term>> tryUnfoldClauses(
+    boolean orderIndependent, @NotNull SeqLike<Arg<Term>> args,
+    int ulift, @NotNull ImmutableSeq<Matching> clauses
+  ) {
+    return tryUnfoldClauses(orderIndependent, args, new Subst(MutableMap.create()), ulift, clauses);
+  }
+}

--- a/base/src/main/java/org/aya/core/visitor/DeltaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/DeltaExpander.java
@@ -12,7 +12,6 @@ import org.aya.core.pat.PatMatcher;
 import org.aya.core.term.*;
 import org.aya.generic.Arg;
 import org.aya.generic.Modifier;
-import org.aya.guest0x0.cubical.CofThy;
 import org.aya.guest0x0.cubical.Restr;
 import org.aya.tyck.TyckState;
 import org.aya.util.error.WithPos;
@@ -79,14 +78,7 @@ public interface DeltaExpander extends EndoFunctor {
   }
 
   static @NotNull FormTerm.PartTy partialType(@NotNull FormTerm.PartTy ty) {
-    return new FormTerm.PartTy(ty.type(), restr(ty.restr()));
-  }
-
-  static @NotNull Restr<Term> restr(@NotNull Restr<Term> restr) {
-    return switch (restr) {
-      case Restr.Vary<Term> vary -> CofThy.normalizeRestr(vary);
-      case Restr.Const<Term> c -> c;
-    };
+    return new FormTerm.PartTy(ty.type(), ty.restr().normalize());
   }
 
   default @NotNull Option<WithPos<Term>> tryUnfoldClauses(

--- a/base/src/main/java/org/aya/core/visitor/DeltaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/DeltaExpander.java
@@ -9,10 +9,11 @@ import kala.control.Option;
 import kala.tuple.Tuple;
 import org.aya.core.Matching;
 import org.aya.core.pat.PatMatcher;
-import org.aya.core.term.*;
+import org.aya.core.term.CallTerm;
+import org.aya.core.term.IntroTerm;
+import org.aya.core.term.Term;
 import org.aya.generic.Arg;
 import org.aya.generic.Modifier;
-import org.aya.guest0x0.cubical.Restr;
 import org.aya.tyck.TyckState;
 import org.aya.util.error.WithPos;
 import org.jetbrains.annotations.NotNull;
@@ -66,19 +67,8 @@ public interface DeltaExpander extends EndoFunctor {
             .map(unfolded -> apply(unfolded.data())).getOrDefault(access);
         }
       }
-      case RefTerm.MetaPat metaPat -> metaPat.inline();
-      case PrimTerm.Mula mula -> simplFormula(mula);
-      case FormTerm.PartTy ty -> partialType(ty);
       default -> term;
     };
-  }
-
-  static @NotNull Term simplFormula(@NotNull PrimTerm.Mula mula) {
-    return Restr.formulae(mula.asFormula(), PrimTerm.Mula::new);
-  }
-
-  static @NotNull FormTerm.PartTy partialType(@NotNull FormTerm.PartTy ty) {
-    return new FormTerm.PartTy(ty.type(), ty.restr().normalize());
   }
 
   default @NotNull Option<WithPos<Term>> tryUnfoldClauses(

--- a/base/src/main/java/org/aya/core/visitor/EndoFunctor.java
+++ b/base/src/main/java/org/aya/core/visitor/EndoFunctor.java
@@ -75,18 +75,13 @@ public interface EndoFunctor extends Function<Term, Term> {
   /**
    * Performs capture-avoiding substitution.
    */
-  record Substituter(@NotNull Subst subst) implements EndoFunctor {
+  record Substituter(@NotNull Subst subst) implements BetaExpander {
     @Override public @NotNull Term post(@NotNull Term term) {
       return switch (term) {
         case RefTerm ref && ref.var() == LocalVar.IGNORED -> throw new InternalException("found usage of ignored var");
         case RefTerm ref -> replacement(ref, ref.var());
         case RefTerm.Field field -> replacement(field, field.ref());
-        case ElimTerm.Proj proj -> ElimTerm.proj(proj);
-        case PrimTerm.Mula mula -> DeltaExpander.simplFormula(mula);
-        case IntroTerm.PartEl par -> BetaExpander.partial(par);
-        case ElimTerm.PathApp app -> BetaExpander.pathApp(app, Function.identity());
-        case FormTerm.PartTy ty -> DeltaExpander.partialType(ty);
-        case Term misc -> misc;
+        case Term misc -> BetaExpander.super.post(misc);
       };
     }
 

--- a/base/src/main/java/org/aya/core/visitor/EndoFunctor.java
+++ b/base/src/main/java/org/aya/core/visitor/EndoFunctor.java
@@ -82,10 +82,10 @@ public interface EndoFunctor extends Function<Term, Term> {
         case RefTerm ref -> replacement(ref, ref.var());
         case RefTerm.Field field -> replacement(field, field.ref());
         case ElimTerm.Proj proj -> ElimTerm.proj(proj);
-        case PrimTerm.Mula mula -> Expander.simplFormula(mula);
-        case IntroTerm.PartEl par -> Expander.partial(par);
-        case ElimTerm.PathApp app -> Expander.pathApp(app, Function.identity());
-        case FormTerm.PartTy ty -> Expander.partialType(ty);
+        case PrimTerm.Mula mula -> DeltaExpander.simplFormula(mula);
+        case IntroTerm.PartEl par -> BetaExpander.partial(par);
+        case ElimTerm.PathApp app -> BetaExpander.pathApp(app, Function.identity());
+        case FormTerm.PartTy ty -> DeltaExpander.partialType(ty);
         case Term misc -> misc;
       };
     }

--- a/base/src/main/java/org/aya/core/visitor/Expander.java
+++ b/base/src/main/java/org/aya/core/visitor/Expander.java
@@ -2,190 +2,30 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.visitor;
 
-import kala.collection.SeqLike;
 import kala.collection.Set;
-import kala.collection.immutable.ImmutableSeq;
-import kala.collection.mutable.MutableList;
-import kala.collection.mutable.MutableMap;
 import kala.collection.mutable.MutableSet;
-import kala.control.Option;
-import kala.tuple.Tuple;
-import org.aya.core.Matching;
 import org.aya.core.def.PrimDef;
-import org.aya.core.pat.PatMatcher;
 import org.aya.core.term.*;
-import org.aya.generic.Arg;
-import org.aya.generic.Cube;
-import org.aya.generic.Modifier;
-import org.aya.guest0x0.cubical.CofThy;
-import org.aya.guest0x0.cubical.Partial;
-import org.aya.guest0x0.cubical.Restr;
 import org.aya.ref.AnyVar;
 import org.aya.tyck.TyckState;
-import org.aya.util.error.WithPos;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.function.Function;
-
-public interface Expander extends EndoFunctor {
-  @NotNull TyckState state();
-
-  static @NotNull Subst buildSubst(@NotNull SeqLike<Term.Param> self, @NotNull SeqLike<Arg<Term>> args) {
-    var entries = self.view().zip(args)
-      .map(t -> Tuple.of(t._1.ref(), t._2.term()));
-    return new Subst(MutableMap.from(entries));
+public interface Expander extends DeltaExpander, BetaExpander {
+  @Override @NotNull default Term post(@NotNull Term term) {
+    return BetaExpander.super.post(DeltaExpander.super.post(term));
   }
 
-  @Override default @NotNull Term post(@NotNull Term term) {
-    return switch (term) {
-      case CallTerm.Con con -> {
-        var def = con.ref().core;
-        if (def == null) yield con;
-        yield tryUnfoldClauses(true, con.conArgs(), con.ulift(), def.clauses)
-          .map(un -> apply(un.data())).getOrDefault(con);
-      }
-      case CallTerm.Fn fn -> {
-        var def = fn.ref().core;
-        if (def == null || def.modifiers.contains(Modifier.Opaque)) yield fn;
-        yield def.body.fold(
-          lamBody -> apply(lamBody.rename().subst(buildSubst(def.telescope(), fn.args())).lift(fn.ulift())),
-          clauses -> tryUnfoldClauses(def.modifiers.contains(Modifier.Overlap), fn.args(), fn.ulift(), clauses)
-            .map(unfolded -> apply(unfolded.data())).getOrDefault(fn));
-      }
-      case CallTerm.Prim prim -> state().primFactory().unfold(prim.id(), prim, state());
-      case CallTerm.Hole hole -> {
-        var def = hole.ref();
-        yield state().metas().getOption(def)
-          .map(body -> apply(body.subst(buildSubst(def.fullTelescope(), hole.fullArgs()))))
-          .getOrDefault(hole);
-      }
-      case CallTerm.Access access -> {
-        var fieldDef = access.ref().core;
-        if (access.of() instanceof IntroTerm.New n) {
-          var fieldBody = access.fieldArgs().foldLeft(n.params().get(access.ref()), CallTerm::make);
-          yield apply(fieldBody.subst(buildSubst(fieldDef.ownerTele, access.structArgs())));
-        } else {
-          var subst = buildSubst(fieldDef.fullTelescope(), access.args());
-          for (var field : fieldDef.structRef.core.fields) {
-            if (field == fieldDef) continue;
-            var fieldArgs = field.telescope().map(Term.Param::toArg);
-            var acc = new CallTerm.Access(access.of(), field.ref, access.structArgs(), fieldArgs);
-            subst.add(field.ref, IntroTerm.Lambda.make(field.telescope(), acc));
-          }
-          yield tryUnfoldClauses(true, access.fieldArgs(), subst, 0, fieldDef.clauses)
-            .map(unfolded -> apply(unfolded.data())).getOrDefault(access);
-        }
-      }
-      case RefTerm.MetaPat metaPat -> metaPat.inline();
-      case PrimTerm.Mula mula -> simplFormula(mula);
-      case FormTerm.PartTy ty -> partialType(ty);
-      default -> term;
-    };
-  }
-  static @NotNull Term simplFormula(@NotNull PrimTerm.Mula mula) {
-    return Restr.formulae(mula.asFormula(), PrimTerm.Mula::new);
-  }
-
-  default @NotNull Option<WithPos<Term>> tryUnfoldClauses(
-    boolean orderIndependent, @NotNull SeqLike<Arg<Term>> args,
-    @NotNull Subst subst, int ulift, @NotNull ImmutableSeq<Matching> clauses
-  ) {
-    for (var matchy : clauses) {
-      var termSubst = PatMatcher.tryBuildSubstArgs(null, matchy.patterns(), args);
-      if (termSubst.isOk()) {
-        subst.add(termSubst.get());
-        var newBody = matchy.body().rename().subst(subst).lift(ulift);
-        return Option.some(new WithPos<>(matchy.sourcePos(), newBody));
-      } else if (!orderIndependent && termSubst.getErr()) return Option.none();
-    }
-    return Option.none();
-  }
-  default @NotNull Option<WithPos<Term>> tryUnfoldClauses(
-    boolean orderIndependent, @NotNull SeqLike<Arg<Term>> args,
-    int ulift, @NotNull ImmutableSeq<Matching> clauses
-  ) {
-    return tryUnfoldClauses(orderIndependent, args, new Subst(MutableMap.create()), ulift, clauses);
-  }
-
-  default <T extends Term> @NotNull Term applyThoroughly(@NotNull Function<T, Term> f, @NotNull T term) {
-    var applied = f.apply(term);
-    return applied != term ? apply(applied) : applied;
-  }
-
-  record Normalizer(@NotNull TyckState state) implements Expander {
-    @Override public @NotNull Term post(@NotNull Term term) {
-      return switch (term) {
-        case ElimTerm.App app -> applyThoroughly(CallTerm::make, app);
-        case ElimTerm.Proj proj -> ElimTerm.proj(proj);
-        case IntroTerm.PartEl el -> partial(el);
-        case ElimTerm.PathApp app -> pathApp(app, this);
-        default -> Expander.super.post(term);
-      };
-    }
-  }
-
-  static @NotNull IntroTerm.PartEl partial(@NotNull IntroTerm.PartEl el) {
-    return new IntroTerm.PartEl(partial(el.partial()), el.rhsType());
-  }
-
-  static @NotNull FormTerm.PartTy partialType(@NotNull FormTerm.PartTy ty) {
-    return new FormTerm.PartTy(ty.type(), restr(ty.restr()));
-  }
-
-  static @NotNull Restr<Term> restr(@NotNull Restr<Term> restr) {
-    return switch (restr) {
-      case Restr.Vary<Term> vary -> CofThy.normalizeRestr(vary);
-      case Restr.Const<Term> c -> c;
-    };
-  }
-
-  private static @NotNull Partial<Term> partial(@NotNull Partial<Term> partial) {
-    return switch (partial) {
-      case Partial.Const<Term> par -> new Partial.Const<>(par.u());
-      case Partial.Split<Term> par -> {
-        var clauses = MutableList.<Restr.Side<Term>>create();
-        for (var clause : par.clauses()) {
-          var u = clause.u();
-          if (CofThy.normalizeCof(clause.cof(), clauses, cofib -> new Restr.Side<>(cofib, u))) {
-            yield new Partial.Const<>(u);
-          }
-        }
-        yield new Partial.Split<>(clauses.toImmutableSeq());
-      }
-    };
-  }
-
-  static @NotNull Term pathApp(@NotNull ElimTerm.PathApp app, @NotNull Function<Term, Term> next) {
-    if (app.of() instanceof IntroTerm.PathLam lam) {
-      var xi = lam.params().map(Term.Param::ref);
-      var ui = app.args().map(Arg::term);
-      var subst = new Subst(xi, ui);
-      return next.apply(lam.body().subst(subst));
-    }
-    return switch (Expander.partial(app.cube().partial())) {
-      case Partial.Split<Term> hap -> new ElimTerm.PathApp(app.of(), app.args(), new Cube<>(
-        app.cube().params(), app.cube().type(), hap));
-      case Partial.Const<Term> sad -> sad.u();
-    };
-  }
+  record Normalizer(@NotNull TyckState state) implements Expander {}
 
   record WHNFer(@NotNull TyckState state) implements Expander {
-    @Override public @NotNull Term post(@NotNull Term term) {
-      return switch (term) {
-        case ElimTerm.App app -> applyThoroughly(CallTerm::make, app);
-        case ElimTerm.Proj proj -> ElimTerm.proj(proj);
-        case PrimTerm.Mula mula -> simplFormula(mula);
-        default -> Expander.super.post(term);
-      };
-    }
-
     @Override public @NotNull Term apply(@NotNull Term term) {
       return switch (term) {
-        case IntroTerm.Lambda lambda -> lambda;
-        case IntroTerm.Tuple tuple -> tuple;
+        case IntroTerm intro -> intro;
         case FormTerm.Pi pi -> pi;
         case FormTerm.Sigma sigma -> sigma;
         case CallTerm.Data data -> data;
+        case CallTerm.Struct struct -> struct;
+        case CallTerm.Con con && (con.ref().core == null || con.ref().core.clauses.isEmpty()) -> con;
         default -> Expander.super.apply(term);
       };
     }

--- a/base/src/main/java/org/aya/core/visitor/Expander.java
+++ b/base/src/main/java/org/aya/core/visitor/Expander.java
@@ -5,7 +5,9 @@ package org.aya.core.visitor;
 import kala.collection.Set;
 import kala.collection.mutable.MutableSet;
 import org.aya.core.def.PrimDef;
-import org.aya.core.term.*;
+import org.aya.core.term.CallTerm;
+import org.aya.core.term.StableWHNF;
+import org.aya.core.term.Term;
 import org.aya.ref.AnyVar;
 import org.aya.tyck.TyckState;
 import org.jetbrains.annotations.NotNull;
@@ -20,11 +22,7 @@ public interface Expander extends DeltaExpander, BetaExpander {
   record WHNFer(@NotNull TyckState state) implements Expander {
     @Override public @NotNull Term apply(@NotNull Term term) {
       return switch (term) {
-        case IntroTerm intro -> intro;
-        case FormTerm.Pi pi -> pi;
-        case FormTerm.Sigma sigma -> sigma;
-        case CallTerm.Data data -> data;
-        case CallTerm.Struct struct -> struct;
+        case StableWHNF whnf -> term;
         case CallTerm.Con con && (con.ref().core == null || con.ref().core.clauses.isEmpty()) -> con;
         default -> Expander.super.apply(term);
       };

--- a/base/src/main/java/org/aya/core/visitor/Subst.java
+++ b/base/src/main/java/org/aya/core/visitor/Subst.java
@@ -107,7 +107,7 @@ public record Subst(
   }
 
   public @NotNull Restr<Term> restr(@NotNull TyckState state, @NotNull Restr<Term> restr) {
-    return Expander.restr(restr.fmap(t -> t.subst(this).normalize(state, NormalizeMode.WHNF)));
+    return DeltaExpander.restr(restr.fmap(t -> t.subst(this).normalize(state, NormalizeMode.WHNF)));
   }
 
   @Override public @NotNull Doc toDoc(@NotNull DistillerOptions options) {

--- a/base/src/main/java/org/aya/core/visitor/Subst.java
+++ b/base/src/main/java/org/aya/core/visitor/Subst.java
@@ -107,7 +107,7 @@ public record Subst(
   }
 
   public @NotNull Restr<Term> restr(@NotNull TyckState state, @NotNull Restr<Term> restr) {
-    return DeltaExpander.restr(restr.fmap(t -> t.subst(this).normalize(state, NormalizeMode.WHNF)));
+    return restr.fmap(t -> t.subst(this).normalize(state, NormalizeMode.WHNF)).normalize();
   }
 
   @Override public @NotNull Doc toDoc(@NotNull DistillerOptions options) {

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -17,7 +17,7 @@ import org.aya.concrete.stmt.TeleDecl;
 import org.aya.core.def.*;
 import org.aya.core.repr.AyaShape;
 import org.aya.core.term.*;
-import org.aya.core.visitor.Expander;
+import org.aya.core.visitor.DeltaExpander;
 import org.aya.core.visitor.Subst;
 import org.aya.generic.*;
 import org.aya.generic.util.InternalException;
@@ -154,7 +154,7 @@ public final class ExprTycker extends Tycker {
               return fail(proj, new FieldProblem.UnknownField(proj, fieldName));
             var fieldRef = field.ref();
 
-            var structSubst = Expander.buildSubst(structCore.telescope(), structCall.args());
+            var structSubst = DeltaExpander.buildSubst(structCore.telescope(), structCall.args());
             var tele = Term.Param.subst(fieldRef.core.selfTele, structSubst, 0);
             var teleRenamed = tele.map(Term.Param::rename);
             var access = new CallTerm.Access(projectee.wellTyped(), fieldRef,

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -5,7 +5,7 @@ package org.aya.tyck;
 import org.aya.core.def.Def;
 import org.aya.core.def.PrimDef;
 import org.aya.core.term.*;
-import org.aya.core.visitor.Expander;
+import org.aya.core.visitor.DeltaExpander;
 import org.aya.core.visitor.Subst;
 import org.aya.generic.Arg;
 import org.aya.generic.Constants;
@@ -36,8 +36,8 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
         var callRaw = term(access.of()).normalize(state, NormalizeMode.WHNF);
         if (!(callRaw instanceof CallTerm.Struct call)) yield ErrorTerm.typeOf(access);
         var core = access.ref().core;
-        var subst = Expander.buildSubst(core.telescope(), access.fieldArgs())
-          .add(Expander.buildSubst(call.ref().core.telescope(), access.structArgs()));
+        var subst = DeltaExpander.buildSubst(core.telescope(), access.fieldArgs())
+          .add(DeltaExpander.buildSubst(call.ref().core.telescope(), access.structArgs()));
         yield core.result().subst(subst);
       }
       case FormTerm.Sigma sigma -> {
@@ -97,7 +97,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
 
   private @NotNull Term defCall(@NotNull CallTerm.DefCall call) {
     return Def.defResult(call.ref())
-      .subst(Expander.buildSubst(Def.defTele(call.ref()), call.args()))
+      .subst(DeltaExpander.buildSubst(Def.defTele(call.ref()), call.args()))
       .lift(call.ulift());
   }
 }

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -22,8 +22,8 @@ import org.aya.core.def.Def;
 import org.aya.core.pat.Pat;
 import org.aya.core.pat.PatMatcher;
 import org.aya.core.term.*;
+import org.aya.core.visitor.DeltaExpander;
 import org.aya.core.visitor.EndoFunctor;
-import org.aya.core.visitor.Expander;
 import org.aya.core.visitor.Subst;
 import org.aya.generic.Constants;
 import org.aya.generic.util.InternalException;
@@ -401,7 +401,7 @@ public final class PatTycker {
   mischa(CallTerm.Data dataCall, CtorDef ctor, @Nullable LocalCtx ctx, @NotNull TyckState state) {
     if (ctor.pats.isNotEmpty()) return PatMatcher.tryBuildSubstTerms(ctx, ctor.pats, dataCall.args().view()
       .map(arg -> arg.term().normalize(state, NormalizeMode.WHNF)));
-    else return Result.ok(Expander.buildSubst(Def.defTele(dataCall.ref()), dataCall.args()));
+    else return Result.ok(DeltaExpander.buildSubst(Def.defTele(dataCall.ref()), dataCall.args()));
   }
 
   private record BodySubstitutor(

--- a/base/src/main/java/org/aya/tyck/unify/DefEq.java
+++ b/base/src/main/java/org/aya/tyck/unify/DefEq.java
@@ -13,7 +13,7 @@ import org.aya.core.def.CtorDef;
 import org.aya.core.def.Def;
 import org.aya.core.ops.Eta;
 import org.aya.core.term.*;
-import org.aya.core.visitor.Expander;
+import org.aya.core.visitor.DeltaExpander;
 import org.aya.core.visitor.Subst;
 import org.aya.generic.Arg;
 import org.aya.generic.Cube;
@@ -514,7 +514,7 @@ public final class DefEq {
       reporter.report(new HoleProblem.BadSpineError(lhs, pos));
       return null;
     }
-    var subst = Expander.buildSubst(meta.contextTele, lhs.contextArgs());
+    var subst = DeltaExpander.buildSubst(meta.contextTele, lhs.contextArgs());
     // In this case, the solution may not be unique (see #608),
     // so we may delay its resolution to the end of the tycking when we disallow vague unification.
     if (!allowVague && subst.overlap(argSubst).anyMatch(var -> preRhs.findUsages(var) > 0)) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -175,6 +175,7 @@ subprojects {
           dev("dark-flames", "Darkflames", "dark_flames@outlook.com")
           dev("tsao-chi", "tsao-chi", "tsao-chi@the-lingo.org")
           dev("lunalunaa", "Luna Xin", "luna.xin@outlook.com")
+          dev("wsx", "Shuxian Wang", "wsx@berkeley.edu")
         }
         scm {
           connection.set("scm:git:$githubUrl")


### PR DESCRIPTION
Introduce the `DeltaExpander` and `BetaExpander` interface to separately handle delta- and beta-reduction.
The `Expander` interface is now extending both `DeltaExpander` and `BetaExpander`.

Some unresolved issues:
1. I'm not sure how to classify operations on the cubical types as beta/delta reduction.
(See the static methods in each interface for the current arrangement)
2. There is a `Simplifier` visitor implementing `BetaExpander` that only do beta reduction.
Maybe we need to change `Substituter` to use this new visitor as per #451?

Edit (@ice1000): fix #451 as the code is pretty clear and good. The cubical reductions are classified as beta, and simplifier is superseded by the substitutor. I added `StableWHNF` for cubically stable term formers, see javadoc.