### PR TITLE
Allow empty system

### DIFF
--- a/base/src/test/resources/success/common/src/Paths.aya
+++ b/base/src/test/resources/success/common/src/Paths.aya
@@ -54,7 +54,7 @@ def infixr <==> {a b c : A} (p : a = b) (q : b = c) : a = c =>
   \k => hcomp2d p q idp k
 
 def infixr <==>'
-  (p : [| i |] A {| |})
+  (p : [| i |] A)
   (q : [| i |] A {| ~ i := p 1 |})
   : [| i |] A {| ~ i := p 0 | i := q 1 |} =>
   coe (\ k => idp k = q k) 0 (λ j => p j)

--- a/base/src/test/resources/success/common/src/Paths.aya
+++ b/base/src/test/resources/success/common/src/Paths.aya
@@ -52,3 +52,9 @@ def hcomp2d
 
 def infixr <==> {a b c : A} (p : a = b) (q : b = c) : a = c =>
   \k => hcomp2d p q idp k
+
+def infixr <==>'
+  (p : [| i |] A {| |})
+  (q : [| i |] A {| ~ i := p 1 |})
+  : [| i |] A {| ~ i := p 0 | i := q 1 |} =>
+  coe (\ k => idp k = q k) 0 (λ j => p j)

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -102,7 +102,7 @@ expr : atom                                 # single
      ;
 
 subSystem : expr DEFINE_AS expr;
-partial : LPARTIAL BAR? subSystem (BAR subSystem)* RPARTIAL;
+partial : LPARTIAL (BAR? subSystem (BAR subSystem)*)? RPARTIAL;
 
 arrayBlock : exprList | expr BAR listComp;
 

--- a/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
+++ b/buildSrc/src/main/antlr/org/aya/parser/AyaParser.g4
@@ -98,7 +98,7 @@ expr : atom                                 # single
      | LARRAY arrayBlock? RARRAY            # array
      | THIS_KW (AT qualifiedId)?            # this
      | partial                              # partEl
-     | LPATH weakId+ RPATH expr partial     # path
+     | LPATH weakId+ RPATH expr partial?    # path
      ;
 
 subSystem : expr DEFINE_AS expr;

--- a/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaProducer.java
@@ -374,19 +374,23 @@ public record AyaProducer(
         else
           yield visitListComprehension(arrCtx.arrayBlock());
       }
-      case AyaParser.PartElContext elCtx -> visitPartial(elCtx.partial());
+      case AyaParser.PartElContext elCtx -> visitPartial(elCtx.partial(), elCtx);
       case AyaParser.PathContext path -> new Expr.Path(
         sourcePosOf(path),
         Seq.wrapJava(path.weakId()).map(w -> new LocalVar(w.getText(), sourcePosOf(w))),
         visitExpr(path.expr()),
-        visitPartial(path.partial())
+        visitPartial(path.partial(), path)
       );
       // TODO: match
       default -> throw new UnsupportedOperationException("TODO: " + ctx.getClass());
     };
   }
 
-  private @NotNull Expr.PartEl visitPartial(AyaParser.PartialContext ctx) {
+  private @NotNull Expr.PartEl visitPartial(
+    @Nullable AyaParser.PartialContext ctx,
+    @NotNull ParserRuleContext fallback
+  ) {
+    if (ctx == null) return new Expr.PartEl(sourcePosOf(fallback), ImmutableSeq.empty());
     return new Expr.PartEl(sourcePosOf(ctx), Seq.wrapJava(ctx.subSystem()).map(sys -> {
       var exprs = Seq.wrapJava(sys.expr()).map(this::visitExpr);
       return Tuple2.of(exprs.get(0), exprs.get(1));


### PR DESCRIPTION
@imkiva @lunalunaa is it a good idea to allow `[| i |] A` as a shorthand for `[| i |] A {| |}`?

P.S. I miss GK bc they generate nullability annotations.