### PR TITLE
transport and hcomp

### DIFF
--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -170,9 +170,13 @@ public final class PrimDef extends TopLevelDef<Term> {
 
         var varX = new LocalVar("x");
 
-        var cofib = PrimTerm.Mula.and(phi, PrimTerm.Mula.inv(new RefTerm(varX)));
+        var cofib = PrimTerm.Mula.or(phi, PrimTerm.Mula.inv(new RefTerm(varX)));
+        var varY = new LocalVar("y");
+        var paramY = new Term.Param(varY, PrimTerm.Interval.INSTANCE, true);
+        var xAndY = PrimTerm.Mula.and(new RefTerm(varX), new RefTerm(varY));
+        var a = new IntroTerm.Lambda(paramY, new ElimTerm.App(type, new Arg<>(xAndY, true)));
 
-        var coe = new PrimTerm.Coe(type, isOne(cofib));
+        var coe = new PrimTerm.Coe(a, isOne(cofib));
         var coerced = new ElimTerm.App(coe, new Arg<>(u0, true));
 
         return new IntroTerm.PathLam(ImmutableSeq.of(varX), coerced);

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -103,6 +103,35 @@ public final class PrimDef extends TopLevelDef<Term> {
         return new PrimTerm.Coe(type, isOne(restr));
       }
 
+      private final @NotNull PrimDef.PrimSeed hcomp = new PrimSeed(ID.hcomp, this::hcomp, ref -> {
+        var varA = new LocalVar("A");
+        var paramA = new Term.Param(varA, FormTerm.Type.ZERO, false);
+        var varPhi = new LocalVar("phi");
+        var paramRestr = new Term.Param(varPhi, PrimTerm.Interval.INSTANCE, false);
+        var varU = new LocalVar("u");
+        var paramFuncU = new Term.Param(varU,
+          new FormTerm.Pi(
+            new Term.Param(LocalVar.IGNORED, PrimTerm.Interval.INSTANCE, true),
+            new FormTerm.PartTy(new RefTerm(varA), isOne(new RefTerm(varPhi)))),
+          true);
+        var varU0 = new LocalVar("u0");
+        var paramU0 = new Term.Param(varU0, new RefTerm(varA), true);
+        var result = new RefTerm(varA);
+        return new PrimDef(
+          ref,
+          ImmutableSeq.of(paramA, paramRestr, paramFuncU, paramU0),
+          result,
+          ID.hcomp
+        );
+      }, ImmutableSeq.of(ID.I));
+
+      private @NotNull Term hcomp(@NotNull CallTerm.Prim prim, @NotNull TyckState state) {
+        var A = prim.args().get(0).term();
+        var u = prim.args().get(2).term();
+        var u0 = prim.args().get(3).term();
+        return new PrimTerm.HComp(A, u, u0);
+      }
+
       // transpfill (A: I -> Type) (phi: I) (u0: A 0) : Path A u (coe A phi u)
       public final @NotNull PrimDef.PrimSeed coercefill = new PrimSeed(ID.COEFILL, this::coefill, ref -> {
         var varA = new LocalVar("A");
@@ -315,6 +344,7 @@ public final class PrimDef extends TopLevelDef<Term> {
     I("I"),
     PARTIAL("Partial"),
     COE("coe"),
+    hcomp("hcomp"),
     COEFILL("coefill");
 
     public final @NotNull @NonNls String id;

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -385,11 +385,14 @@ public final class PrimDef extends TopLevelDef<Term> {
     I("I"),
     PARTIAL("Partial"),
     COE("coe"),
-    HCOMP("hcomp"),
+    COEINV("coeInv"),
     COEFILL("coeFill"),
+    COEFILLINV("CoeFillInv"),
     FORWARD("forward"),
+    HCOMP("hcomp"),
     HFILL("hfill"),
-    COMP("comp");
+    COMP("comp"),
+    FILL("fill");
 
     public final @NotNull @NonNls String id;
 

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -103,7 +103,7 @@ public final class PrimDef extends TopLevelDef<Term> {
         return new PrimTerm.Coe(type, isOne(restr));
       }
 
-      private final @NotNull PrimDef.PrimSeed hcomp = new PrimSeed(ID.hcomp, this::hcomp, ref -> {
+      private final @NotNull PrimDef.PrimSeed hcomp = new PrimSeed(ID.HCOMP, this::hcomp, ref -> {
         var varA = new LocalVar("A");
         var paramA = new Term.Param(varA, FormTerm.Type.ZERO, false);
         var varPhi = new LocalVar("phi");
@@ -121,7 +121,7 @@ public final class PrimDef extends TopLevelDef<Term> {
           ref,
           ImmutableSeq.of(paramA, paramRestr, paramFuncU, paramU0),
           result,
-          ID.hcomp
+          ID.HCOMP
         );
       }, ImmutableSeq.of(ID.I));
 
@@ -133,7 +133,7 @@ public final class PrimDef extends TopLevelDef<Term> {
       }
 
       // transpfill (A: I -> Type) (phi: I) (u0: A 0) : Path A u (coe A phi u)
-      public final @NotNull PrimDef.PrimSeed coercefill = new PrimSeed(ID.COEFILL, this::coefill, ref -> {
+      public final @NotNull PrimDef.PrimSeed coeFill = new PrimSeed(ID.COEFILL, this::coeFill, ref -> {
         var varA = new LocalVar("A");
         var typeA = new FormTerm.Pi(new Term.Param(LocalVar.IGNORED, PrimTerm.Interval.INSTANCE, true), new FormTerm.Type(0));
         var paramA = new Term.Param(varA, typeA, true);
@@ -163,7 +163,7 @@ public final class PrimDef extends TopLevelDef<Term> {
           ID.COEFILL);
       }, ImmutableSeq.of(ID.COE));
 
-      private @NotNull Term coefill(@NotNull CallTerm.Prim prim, @NotNull TyckState state) {
+      private @NotNull Term coeFill(@NotNull CallTerm.Prim prim, @NotNull TyckState state) {
         var type = prim.args().get(0).term();
         var phi = prim.args().get(1).term();
         var u0 = prim.args().get(2).term();
@@ -270,7 +270,8 @@ public final class PrimDef extends TopLevelDef<Term> {
           init.intervalType,
           init.partialType,
           init.coerce,
-          init.coercefill
+          init.coeFill,
+          init.hcomp
         ).map(seed -> Tuple.of(seed.name, seed))
         .toImmutableMap();
     }
@@ -344,8 +345,11 @@ public final class PrimDef extends TopLevelDef<Term> {
     I("I"),
     PARTIAL("Partial"),
     COE("coe"),
-    hcomp("hcomp"),
-    COEFILL("coefill");
+    HCOMP("hcomp"),
+    COEFILL("coeFill"),
+    FORWARD("forward"),
+    HFILL("hfill"),
+    COMP("comp");
 
     public final @NotNull @NonNls String id;
 

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -166,11 +166,13 @@ public final class PrimDef extends TopLevelDef<Term> {
         var varI = new LocalVar("i");
         var varJ = new LocalVar("j");
         var iAndJ = PrimTerm.Mula.and(new RefTerm(varI), new RefTerm(varJ));
+
+        // TODO: move this elsewhere
         var partial = new Partial.Split<>(
           ImmutableSeq.of(
-            new Restr.Side<>(new Restr.Cofib<>(ImmutableSeq.of(new Restr.Cond<>(phi, false))),
+            new Restr.Side<>(new Restr.Conj<>(ImmutableSeq.of(new Restr.Cond<>(phi, false))),
               new ElimTerm.App(u, new Arg<>(iAndJ, true))),
-            new Restr.Side<>(new Restr.Cofib<>(ImmutableSeq.of(new Restr.Cond<>(new RefTerm(varI), true))), u0)));
+            new Restr.Side<>(new Restr.Conj<>(ImmutableSeq.of(new Restr.Cond<>(new RefTerm(varI), true))), u0)));
 
 
         return new PrimTerm.HComp(A, u, phi, u0);
@@ -196,8 +198,8 @@ public final class PrimDef extends TopLevelDef<Term> {
           new RefTerm(varA),
           new Partial.Split<>(
             ImmutableSeq.of(
-              new Restr.Side<>(new Restr.Cofib<>(ImmutableSeq.of(new Restr.Cond<>(refX, true))), new RefTerm(varU0)),
-              new Restr.Side<>(new Restr.Cofib<>(ImmutableSeq.of(new Restr.Cond<>(refX, false))), coerced)))
+              new Restr.Side<>(new Restr.Conj<>(ImmutableSeq.of(new Restr.Cond<>(refX, false))), new RefTerm(varU0)),
+              new Restr.Side<>(new Restr.Conj<>(ImmutableSeq.of(new Restr.Cond<>(refX, true))), coerced)))
         ));
 
         return new PrimDef(

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -146,7 +146,7 @@ public final class PrimDef extends TopLevelDef<Term> {
         var coe = new PrimTerm.Coe(type, isOne(cofib));
         var coerced = new ElimTerm.App(coe, new Arg<>(u0, true));
 
-        return new IntroTerm.PathLam(ImmutableSeq.of(new Term.Param(varX, PrimTerm.Interval.INSTANCE, true)), coerced);
+        return new IntroTerm.PathLam(ImmutableSeq.of(varX), coerced);
       }
 
       /** /\ in Cubical Agda, should elaborate to {@link Formula.Conn} */

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -130,6 +130,7 @@ public record Serializer(@NotNull Serializer.State state) {
       case RefTerm.MetaPat metaPat -> throw new InternalException("Shall not have metaPats serialized.");
       case ErrorTerm err -> throw new InternalException("Shall not have error term serialized.");
       case FormTerm.Sort sort -> serialize(sort);
+      case PrimTerm.HComp hComp -> throw new InternalException("TODO");
     };
   }
 

--- a/base/src/main/java/org/aya/core/term/PrimTerm.java
+++ b/base/src/main/java/org/aya/core/term/PrimTerm.java
@@ -50,6 +50,5 @@ public sealed interface PrimTerm extends Term {
 
   record Coe(@NotNull Term type, @NotNull Restr<Term> restr) implements PrimTerm {}
 
-  // iToPart is a function from interval to Partial
-  record HComp(@NotNull Term type, @NotNull Term u, @NotNull Term u0) implements PrimTerm {}
+  record HComp(@NotNull Term type, @NotNull Term phi, @NotNull Term u, @NotNull Term u0) implements PrimTerm {}
 }

--- a/base/src/main/java/org/aya/core/term/PrimTerm.java
+++ b/base/src/main/java/org/aya/core/term/PrimTerm.java
@@ -49,4 +49,7 @@ public sealed interface PrimTerm extends Term {
   }
 
   record Coe(@NotNull Term type, @NotNull Restr<Term> restr) implements PrimTerm {}
+
+  // iToPart is a function from interval to Partial
+  record HComp(@NotNull Term type, @NotNull Term u, @NotNull Term u0) implements PrimTerm {}
 }

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -183,6 +183,7 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits Cal
       case RefTerm.MetaPat metaPat -> metaPat;
       case RefTerm.Field field -> field;
       case ErrorTerm error -> error;
+      case PrimTerm.HComp hComp -> hComp; //TODO
     };
   }
 

--- a/base/src/main/java/org/aya/core/visitor/BetaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/BetaExpander.java
@@ -56,8 +56,16 @@ public interface BetaExpander extends EndoFunctor {
           var param = new Term.Param(var, ElimTerm.make(coe.type(), new Arg<>(PrimTerm.Mula.LEFT, true)), true);
           yield new IntroTerm.Lambda(param, new RefTerm(var));
         }
-        // TODO: coe computation
-        yield coe;
+
+        var A = apply(new ElimTerm.App(coe.type(), new Arg<>(new RefTerm(new LocalVar("x")), true)));
+
+        yield switch (A) {
+          case FormTerm.Path path -> null;
+          case FormTerm.Pi pi -> null;
+          case FormTerm.Sigma sigma -> null;
+          case FormTerm.Type type -> null;
+          default -> coe;
+        };
       }
       default -> term;
     };

--- a/base/src/main/java/org/aya/core/visitor/BetaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/BetaExpander.java
@@ -106,12 +106,29 @@ public interface BetaExpander extends EndoFunctor {
     return new IntroTerm.PathLam(ImmutableSeq.of(varX), coerced);
   }
 
-  // coeInv (A : I -> Type) (phi: I) (u: A 1) : A 0
-  private static @NotNull Term coeInv(@NotNull Term A, @NotNull Term phi, @NotNull Term u) {
-    throw new InternalException("TODO");
+  /**
+   * inverts interval in A : I -> Type
+   *
+   * @param A pi type I -> Type
+   * @return inverted A
+   */
+  private @NotNull Term invertA(@NotNull Term A) {
+    if (A instanceof FormTerm.Pi pi) {
+      var paramRef = new RefTerm(pi.param().ref());
+      var invertedParam = PrimTerm.Mula.inv(paramRef);
+      return pi.substBody(invertedParam);
+    } else {
+      throw new InternalException("expected A : I -> Type");
+    }
   }
 
-  private static @NotNull Term coeFillInv(@NotNull Term A, @NotNull Term phi, @NotNull Term u) {
-    throw new InternalException("TODO");
+  // coeInv (A : I -> Type) (phi: I) (u: A 1) : A 0
+  private @NotNull Term coeInv(@NotNull Term A, @NotNull Term phi, @NotNull Term u) {
+    return apply(new ElimTerm.App(new PrimTerm.Coe(invertA(A), isOne(phi)), new Arg<>(u, true)));
+  }
+
+  // coeFillInv
+  private @NotNull Term coeFillInv(@NotNull Term type, @NotNull Term phi, @NotNull Term u) {
+    return coeFill(invertA(type), phi, u);
   }
 }

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -12,6 +12,7 @@ import org.aya.core.pat.Pat;
 import org.aya.core.term.*;
 import org.aya.core.visitor.MonoidalVarFolder;
 import org.aya.generic.Arg;
+import org.aya.generic.util.InternalException;
 import org.aya.pretty.doc.Doc;
 import org.aya.ref.DefVar;
 import org.aya.util.distill.DistillerOptions;
@@ -188,6 +189,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
         app.args().view(), outer, options.map.get(DistillerOptions.Key.ShowImplicitArgs));
       case PrimTerm.Coe coe -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "coe"),
         term(Outer.AppSpine, coe.type()), Doc.parened(restr(options, coe.restr()))), Outer.AppSpine);
+      case PrimTerm.HComp hComp -> throw new InternalException("TODO");
     };
   }
 

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -9,6 +9,7 @@ import org.aya.core.visitor.DeltaExpander;
 import org.aya.core.visitor.Subst;
 import org.aya.generic.Arg;
 import org.aya.generic.Constants;
+import org.aya.generic.util.InternalException;
 import org.aya.generic.util.NormalizeMode;
 import org.aya.guest0x0.cubical.Partial;
 import org.aya.tyck.env.LocalCtx;
@@ -93,6 +94,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
         yield app.cube().type().subst(new Subst(xi, ui));
       }
       case PrimTerm.Coe coe -> PrimDef.familyLeftToRight(coe.type());
+      case PrimTerm.HComp hComp -> throw new InternalException("TODO");
     };
   }
 


### PR DESCRIPTION
Implement the following primitives:

- [ ] `coe (A: I -> Type) (phi: I): A 0 -> A 1` (need to check the freezing condition)
- [x] `coeFill (A: I -> Type) (phi: I) (u0: A 0) : Path A u (coe A phi u)`
- [ ] `coeInv`
- [ ] `coeFillInv`
- [x] `forward (A: I -> Type) (r: I) (u: A r): A 1`
- [ ] `hcomp {A: Type} {phi: I} (u: I -> Partial phi A) (u0: A): A` (need to check cubical subtype $\Gamma\vdash u_0: A[\phi \mapsto u\ 0]$)
- [ ] `hfill {A: Type} {phi: I} (u: I -> Partial phi A) (u0: A): I -> A` (need to check cubical subtype condition for `u0`)
- [ ] `comp {phi: I} (A: Type) (u: I -> Partial phi A) (u0: A 0): A 1` (need to check cubical subtype condition for `u0`)

I will ignore the subtype checks before cubical subtype is implemented in another PR. After cubical subtype is finished we just need to change the signatures and add proper `inS` and `outS`.

TODO: explore ways to automatically insert `inS` and `outS`.

**Update (2022 Oct 23): `coeFill`, `coeInv`, `coeFillInv`, `forward`, `hfill`, `comp` will not be implemented as primitives. Instead they are helper functions**

This pull request closes #522, #525.