### PR TITLE
KALA: upgrade to 0.52.0

### DIFF
--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -166,21 +166,18 @@ public sealed interface Expr extends AyaDocile, SourceNode, Restr.TermLike<Expr>
 
   record IdiomNames(
     @NotNull Expr alternativeOr,
-    @NotNull Expr alternativeEmpty,
     @NotNull Expr applicativeAp,
     @NotNull Expr applicativePure
   ) {
     public IdiomNames fmap(@NotNull Function<Expr, Expr> f) {
       return new IdiomNames(
         f.apply(alternativeOr),
-        f.apply(alternativeEmpty),
         f.apply(applicativeAp),
         f.apply(applicativePure));
     }
 
     public boolean identical(@NotNull IdiomNames names) {
       return alternativeOr == names.alternativeOr &&
-        alternativeEmpty == names.alternativeEmpty &&
         applicativeAp == names.applicativeAp &&
         applicativePure == names.applicativePure;
     }

--- a/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
+++ b/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
@@ -86,7 +86,7 @@ public record Desugarer(@NotNull ResolveInfo resolveInfo) implements StmtOps<Uni
           return list.foldLeft(head, (e, arg) -> new Expr.AppExpr(e.sourcePos(),
             new Expr.AppExpr(e.sourcePos(), idiom.names().applicativeAp(),
               new Expr.NamedArg(true, e)), arg));
-        }).foldLeft(idiom.names().alternativeEmpty(), (e, arg) ->
+        }).reduceLeft((e, arg) ->
           new Expr.AppExpr(e.sourcePos(), new Expr.AppExpr(e.sourcePos(),
             idiom.names().alternativeOr(), new Expr.NamedArg(true, e)),
             new Expr.NamedArg(true, arg)));

--- a/cli/src/main/java/org/aya/cli/parse/AyaGKProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaGKProducer.java
@@ -579,7 +579,6 @@ public record AyaGKProducer(
       var block = node.peekChild(IDIOM_BLOCK);
       var names = new Expr.IdiomNames(
         Constants.alternativeOr(pos),
-        Constants.alternativeEmpty(pos),
         Constants.applicativeApp(pos),
         Constants.functorPure(pos)
       );

--- a/gradle/deps.properties
+++ b/gradle/deps.properties
@@ -9,7 +9,7 @@ version.project=0.22-SNAPSHOT
 version.annotations=23.0.0
 # https://github.com/antlr/antlr4/
 version.antlr=4.10.1
-version.kala=0.51.0
+version.kala=0.52.0
 version.guest0x0=0.17.2
 version.aya-upstream=0.0.6
 version.hamcrest=2.2

--- a/tools-repl/src/main/java/org/aya/repl/gk/JFlexAdapter.java
+++ b/tools-repl/src/main/java/org/aya/repl/gk/JFlexAdapter.java
@@ -2,7 +2,6 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.repl.gk;
 
-import com.intellij.KalaTODO;
 import com.intellij.lexer.FlexLexer;
 import com.intellij.psi.tree.IElementType;
 import kala.collection.Seq;
@@ -10,22 +9,18 @@ import kala.function.CheckedSupplier;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 public record JFlexAdapter(@NotNull FlexLexer lexer) {
-  // TODO: https://github.com/Glavo/kala-common/issues/61
-
   /** @return parsed tokens without the last EOF token */
-  @KalaTODO @NotNull Seq<Token> tokensNoEOF(String line) {
+  @NotNull Seq<Token> tokensNoEOF(String line) {
     lexer.reset(line, 0, line.length(), 0);
     CheckedSupplier<IElementType, IOException> action = lexer::advance;
-    return Seq.wrapJava(Stream.generate(() -> {
+    return Seq.generateUntilNull(() -> {
       var type = action.get();
       if (type == null) return null;
       return new Token(lexer.getTokenStart(), lexer.getTokenEnd(), type,
         line.substring(lexer.getTokenStart(), lexer.getTokenEnd()));
-    }).takeWhile(Objects::nonNull).toList());
+    });
   }
 
   public record Token(int tokenStart, int tokenEnd, @NotNull IElementType type, @NotNull String text) {


### PR DESCRIPTION
New methods:

* `Seq.generateUntil(Supplier<E>, Predicate<E>)`
* `Seq.generateUntilNull(Supplier<E>)`