### PR TITLE
Pretty: Expr.Do

### DIFF
--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -159,7 +159,7 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
 
         // Either not flat (single line) or full flat
         yield Doc.stickySep(      // doExpr is atom! It cannot be `do\n{ ... }`
-          Doc.symbol("do"),
+          Doc.styled(KEYWORD, "do"),
           Doc.flatAltBracedBlock(
             Doc.commaList(doBlockDoc),
             Doc.vcommaList(

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -167,7 +167,7 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
         yield Doc.flatAltBracedBlock(
           Doc.commaList(doBlockDoc),
           Doc.vcommaList(
-            doBlockDoc.map(x -> Doc.nest(2, x))     // TODO[hoshino]: constant indent?
+            doBlockDoc.map(x -> Doc.nest(2, x))
           )
         );
       }

--- a/base/src/test/java/org/aya/concrete/ParseTest.java
+++ b/base/src/test/java/org/aya/concrete/ParseTest.java
@@ -307,6 +307,24 @@ public class ParseTest {
         """);
   }
 
+  @Test public void doExpr() {
+    // Testing pretty but not parse! 😂
+    parseAndPretty("def foo => do { x <- xs, y <- ys, return (x * y) }", "def foo => do { x <- xs, y <- ys, return (x * y) }");
+    parseAndPretty("""
+      def foo => do
+        x <- xs, y <- ys,
+        return (x * y)
+      """, "def foo => do { x <- xs, y <- ys, return (x * y) }");
+    parseAndPretty("""
+      def foo => do {
+        x <- xs,
+        y <- ys,
+        return (x * y)
+      }
+      """, "def foo => do { x <- xs, y <- ys, return (x * y) }");
+    // TODO[hoshino]: How to let `do` flat? Improving parseAndPretty?
+  }
+
   private void parseAndPretty(@NotNull @NonNls @Language("Aya") String code, @NotNull @NonNls @Language("Aya") String pretty) {
     var stmt = parseStmt(code);
     assertEquals(pretty.trim(), Doc.vcat(stmt.view()

--- a/base/src/test/java/org/aya/concrete/ParseTest.java
+++ b/base/src/test/java/org/aya/concrete/ParseTest.java
@@ -322,7 +322,7 @@ public class ParseTest {
         return (x * y)
       }
       """, "def foo => do { x <- xs, y <- ys, return (x * y) }");
-    // TODO[hoshino]: How to let `do` flat? Improving parseAndPretty?
+    // TODO[hoshino]: How to make `do-notation` flat (multi-line) in testing? Improving parseAndPretty?
   }
 
   private void parseAndPretty(@NotNull @NonNls @Language("Aya") String code, @NotNull @NonNls @Language("Aya") String pretty) {

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -249,8 +249,8 @@ public sealed interface Doc extends Docile {
    */
   static @NotNull Doc flatAltBracedBlock(Doc defaultDoc, Doc flatDoc) {
     return flatAlt(
-      stickySep(Doc.plain("{"), defaultDoc, Doc.plain("}")),
-      vcat(Doc.plain("{"), flatDoc, Doc.plain("}"))
+      stickySep(Doc.symbol("{"), defaultDoc, Doc.symbol("}")),
+      vcat(Doc.symbol("{"), flatDoc, Doc.symbol("}"))
     );
   }
 

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -245,7 +245,7 @@ public sealed interface Doc extends Docile {
 
   /**
    * Either `{ defaultDoc }` or `{\nflatDoc\n}`
-   * TODO: There should be a better impl for this!
+   * TODO: There should be a better impl for this! For example, a new Doc element class
    */
   static @NotNull Doc flatAltBracedBlock(Doc defaultDoc, Doc flatDoc) {
     return flatAlt(

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -242,6 +242,18 @@ public sealed interface Doc extends Docile {
   static @NotNull Doc braced(Doc doc) {
     return wrap("{", "}", doc);
   }
+
+  /**
+   * Either `{ defaultDoc }` or `{\nflatDoc\n}`
+   * TODO: There should be a better impl for this!
+   */
+  static @NotNull Doc flatAltBracedBlock(Doc defaultDoc, Doc flatDoc) {
+    return flatAlt(
+      stickySep(Doc.plain("{"), defaultDoc, Doc.plain("}")),
+      vcat(Doc.plain("{"), flatDoc, Doc.plain("}"))
+    );
+  }
+
   static @NotNull Doc angled(Doc doc) {
     return wrap("<", ">", doc);
   }
@@ -516,6 +528,10 @@ public sealed interface Doc extends Docile {
 
   @Contract("_ -> new") static @NotNull Doc commaList(@NotNull SeqLike<Doc> docs) {
     return join(COMMA, docs);
+  }
+
+  @Contract("_ -> new") static @NotNull Doc vcommaList(@NotNull SeqLike<Doc> docs) {
+    return join(cat(plain(","), line()), docs);
   }
 
   @Contract("_, _ -> new") static @NotNull Doc join(@NotNull Doc delim, Doc @NotNull ... docs) {

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -245,7 +245,6 @@ public sealed interface Doc extends Docile {
 
   /**
    * Either `{ defaultDoc }` or `{\nflatDoc\n}`
-   * TODO: There should be a better impl for this! For example, a new Doc element class
    */
   static @NotNull Doc flatAltBracedBlock(Doc defaultDoc, Doc flatDoc) {
     return flatAlt(


### PR DESCRIPTION
My idea is that render an `Expr.Do` as Single Line or Multi-Line (see below)

Single Line (all bindings in one line):

```
do { x <- xs, y <- ys, return (x + y) }
```

Multi-Line (one binding each line):

```
do {
  x <- xs,
  y <- ys,
  return (x + y)
}
```

I dislike (simply `Doc.sep` when `lineRemaining` is insufficient):
```
do { x <- xs, y <- ys,
  return (x + y)
}
```

Can we advise the PrettyPrinter to flat something even though the page width is enough?