### PR TITLE
Prop and Erased

### DIFF
--- a/base/reflect-config.txt
+++ b/base/reflect-config.txt
@@ -92,7 +92,7 @@ org.aya.core.serde.SerTerm$PathLam
 org.aya.core.serde.SerTerm$PathApp
 org.aya.core.serde.SerTerm$Coe
 org.aya.core.serde.SerTerm$SerCube
-org.aya.core.serde.SerTerm$Dummy
+org.aya.core.serde.SerTerm$Erased
 org.aya.core.serde.SerPat$Matchy
 org.aya.core.serde.SerPat$Absurd
 org.aya.core.serde.SerPat$Tuple

--- a/base/reflect-config.txt
+++ b/base/reflect-config.txt
@@ -92,6 +92,7 @@ org.aya.core.serde.SerTerm$PathLam
 org.aya.core.serde.SerTerm$PathApp
 org.aya.core.serde.SerTerm$Coe
 org.aya.core.serde.SerTerm$SerCube
+org.aya.core.serde.SerTerm$Dummy
 org.aya.core.serde.SerPat$Matchy
 org.aya.core.serde.SerPat$Absurd
 org.aya.core.serde.SerPat$Tuple

--- a/base/src/main/java/org/aya/core/serde/SerTerm.java
+++ b/base/src/main/java/org/aya/core/serde/SerTerm.java
@@ -333,9 +333,9 @@ public sealed interface SerTerm extends Serializable, Restr.TermLike<SerTerm> {
     }
   }
 
-  record Dummy(@NotNull SerTerm type) implements SerTerm {
-    public @NotNull DummyTerm de(@NotNull DeState state) {
-      return new DummyTerm(type.de(state));
+  record Erased(@NotNull SerTerm type) implements SerTerm {
+    public @NotNull ErasedTerm de(@NotNull DeState state) {
+      return new ErasedTerm(type.de(state));
     }
   }
 }

--- a/base/src/main/java/org/aya/core/serde/SerTerm.java
+++ b/base/src/main/java/org/aya/core/serde/SerTerm.java
@@ -332,4 +332,10 @@ public sealed interface SerTerm extends Serializable, Restr.TermLike<SerTerm> {
         partial.fmap(t -> t.de(state)));
     }
   }
+
+  record Dummy(@NotNull SerTerm type) implements SerTerm {
+    public @NotNull DummyTerm de(@NotNull DeState state) {
+      return new DummyTerm(type.de(state));
+    }
+  }
 }

--- a/base/src/main/java/org/aya/core/serde/SerTerm.java
+++ b/base/src/main/java/org/aya/core/serde/SerTerm.java
@@ -333,9 +333,9 @@ public sealed interface SerTerm extends Serializable, Restr.TermLike<SerTerm> {
     }
   }
 
-  record Erased(@NotNull SerTerm type) implements SerTerm {
+  record Erased(@NotNull SerTerm type, boolean isProp) implements SerTerm {
     public @NotNull ErasedTerm de(@NotNull DeState state) {
-      return new ErasedTerm(type.de(state));
+      return new ErasedTerm(type.de(state), isProp);
     }
   }
 }

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -130,6 +130,7 @@ public record Serializer(@NotNull Serializer.State state) {
       case RefTerm.MetaPat metaPat -> throw new InternalException("Shall not have metaPats serialized.");
       case ErrorTerm err -> throw new InternalException("Shall not have error term serialized.");
       case FormTerm.Sort sort -> serialize(sort);
+      case DummyTerm dummy -> new SerTerm.Dummy(serialize(dummy.type()));
     };
   }
 

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -130,7 +130,7 @@ public record Serializer(@NotNull Serializer.State state) {
       case RefTerm.MetaPat metaPat -> throw new InternalException("Shall not have metaPats serialized.");
       case ErrorTerm err -> throw new InternalException("Shall not have error term serialized.");
       case FormTerm.Sort sort -> serialize(sort);
-      case DummyTerm dummy -> new SerTerm.Dummy(serialize(dummy.type()));
+      case ErasedTerm erased -> new SerTerm.Erased(serialize(erased.type()));
     };
   }
 

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -130,7 +130,7 @@ public record Serializer(@NotNull Serializer.State state) {
       case RefTerm.MetaPat metaPat -> throw new InternalException("Shall not have metaPats serialized.");
       case ErrorTerm err -> throw new InternalException("Shall not have error term serialized.");
       case FormTerm.Sort sort -> serialize(sort);
-      case ErasedTerm erased -> new SerTerm.Erased(serialize(erased.type()));
+      case ErasedTerm erased -> new SerTerm.Erased(serialize(erased.type()), erased.isProp());
     };
   }
 

--- a/base/src/main/java/org/aya/core/term/DummyTerm.java
+++ b/base/src/main/java/org/aya/core/term/DummyTerm.java
@@ -1,0 +1,8 @@
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.core.term;
+
+import org.jetbrains.annotations.NotNull;
+
+public record DummyTerm(@NotNull Term type) implements Term {
+}

--- a/base/src/main/java/org/aya/core/term/ElimTerm.java
+++ b/base/src/main/java/org/aya/core/term/ElimTerm.java
@@ -18,7 +18,10 @@ import org.jetbrains.annotations.Nullable;
  * @author ice1000
  */
 public sealed interface ElimTerm extends Term {
-  // ErasedTerm itself and ElimTerm with `of` erased are erased.
+  /**
+   * {@link ErasedTerm} itself and {@link ElimTerm}
+   * with <code>of</code> erased are erased.
+   */
   static @Nullable ErasedTerm underlyingErased(@NotNull Term term) {
     if (term instanceof ElimTerm elim) return underlyingErased(elim.of());
     if (term instanceof CallTerm.Access elim) return underlyingErased(elim.of());
@@ -27,8 +30,10 @@ public sealed interface ElimTerm extends Term {
   static boolean isErased(@NotNull Term term) {
     return underlyingErased(term) != null;
   }
-  // ErasedTerm with a Prop type might safely appear in IntroTerms.
-  // ErasedTerm with a non-Prop type or ElimTerm with `of` erased are disallowed.
+  /**
+   * {@link ErasedTerm} with a Prop type might safely appear in {@link IntroTerm}s.
+   * {@link ErasedTerm} with a non-Prop type or {@link ElimTerm} with `of` erased are disallowed.
+   */
   static @Nullable ErasedTerm underlyingIllegalErasure(@NotNull Term term) {
     if (term instanceof ElimTerm elim) return underlyingErased(elim.of());
     if (term instanceof CallTerm.Access elim) return underlyingErased(elim.of());

--- a/base/src/main/java/org/aya/core/term/ElimTerm.java
+++ b/base/src/main/java/org/aya/core/term/ElimTerm.java
@@ -27,6 +27,13 @@ public sealed interface ElimTerm extends Term {
       if (hole.args().sizeLessThan(hole.ref().telescope))
         return new CallTerm.Hole(hole.ref(), hole.ulift(), hole.contextArgs(), hole.args().appended(app.arg()));
     }
+    if (app.of() instanceof ErasedTerm erased) {
+      if (erased.type() instanceof FormTerm.Pi pi) {
+        return new ErasedTerm(pi.substBody(app.arg().term()));
+      } else {
+        return new ErasedTerm(ErrorTerm.typeOf(app));
+      }
+    }
     if (app.of() instanceof IntroTerm.Lambda lam) return make(lam, app.arg());
     return app;
   }
@@ -61,6 +68,13 @@ public sealed interface ElimTerm extends Term {
     if (proj.of instanceof IntroTerm.Tuple tup) {
       assert tup.items().sizeGreaterThanOrEquals(proj.ix) && proj.ix > 0 : proj.of.toDoc(DistillerOptions.debug()).debugRender();
       return tup.items().get(proj.ix - 1);
+    }
+    if (proj.of instanceof ErasedTerm erased) {
+      if (erased.type() instanceof FormTerm.Sigma sigma) {
+        return new ErasedTerm(sigma.params().get(proj.ix - 1).type());
+      } else {
+        return new ErasedTerm(ErrorTerm.typeOf(proj));
+      }
     }
     return proj;
   }

--- a/base/src/main/java/org/aya/core/term/ElimTerm.java
+++ b/base/src/main/java/org/aya/core/term/ElimTerm.java
@@ -17,6 +17,11 @@ import org.jetbrains.annotations.NotNull;
  * @author ice1000
  */
 public sealed interface ElimTerm extends Term {
+  static boolean isErased(@NotNull Term term) {
+    if (term instanceof ElimTerm elim) return isErased(elim.of());
+    return term instanceof ErasedTerm;
+  }
+
   @Contract(pure = true) static @NotNull Term
   make(@NotNull Term f, @NotNull Arg<Term> arg) {
     return make(new App(f, arg));

--- a/base/src/main/java/org/aya/core/term/ElimTerm.java
+++ b/base/src/main/java/org/aya/core/term/ElimTerm.java
@@ -19,19 +19,19 @@ import org.jetbrains.annotations.Nullable;
  */
 public sealed interface ElimTerm extends Term {
   // ErasedTerm itself and ElimTerm with `of` erased are erased.
-  static @Nullable ErasedTerm checkErased(@NotNull Term term) {
-    if (term instanceof ElimTerm elim) return checkErased(elim.of());
-    if (term instanceof CallTerm.Access elim) return checkErased(elim.of());
+  static @Nullable ErasedTerm underlyingErased(@NotNull Term term) {
+    if (term instanceof ElimTerm elim) return underlyingErased(elim.of());
+    if (term instanceof CallTerm.Access elim) return underlyingErased(elim.of());
     return term instanceof ErasedTerm erased ? erased : null;
   }
   static boolean isErased(@NotNull Term term) {
-    return checkErased(term) != null;
+    return underlyingErased(term) != null;
   }
   // ErasedTerm with a Prop type might safely appear in IntroTerms.
   // ErasedTerm with a non-Prop type or ElimTerm with `of` erased are disallowed.
-  static @Nullable ErasedTerm checkErasedNotProp(@NotNull Term term) {
-    if (term instanceof ElimTerm elim) return checkErased(elim.of());
-    if (term instanceof CallTerm.Access elim) return checkErased(elim.of());
+  static @Nullable ErasedTerm underlyingIllegalErased(@NotNull Term term) {
+    if (term instanceof ElimTerm elim) return underlyingErased(elim.of());
+    if (term instanceof CallTerm.Access elim) return underlyingErased(elim.of());
     return term instanceof ErasedTerm erased && !erased.isProp() ? erased : null;
   }
 

--- a/base/src/main/java/org/aya/core/term/ElimTerm.java
+++ b/base/src/main/java/org/aya/core/term/ElimTerm.java
@@ -19,10 +19,12 @@ import org.jetbrains.annotations.NotNull;
 public sealed interface ElimTerm extends Term {
   static boolean isErased(@NotNull Term term) {
     if (term instanceof ElimTerm elim) return isErased(elim.of());
+    if (term instanceof CallTerm.Access elim) return isErased(elim.of());
     return term instanceof ErasedTerm;
   }
   static boolean isErasedNotProp(@NotNull Term term) {
-    if (term instanceof ElimTerm elim) return isErasedNotProp(elim.of());
+    if (term instanceof ElimTerm elim) return isErased(elim.of());
+    if (term instanceof CallTerm.Access elim) return isErased(elim.of());
     return term instanceof ErasedTerm elim && !elim.isProp();
   }
 

--- a/base/src/main/java/org/aya/core/term/ElimTerm.java
+++ b/base/src/main/java/org/aya/core/term/ElimTerm.java
@@ -21,6 +21,10 @@ public sealed interface ElimTerm extends Term {
     if (term instanceof ElimTerm elim) return isErased(elim.of());
     return term instanceof ErasedTerm;
   }
+  static boolean isErasedNotProp(@NotNull Term term) {
+    if (term instanceof ElimTerm elim) return isErasedNotProp(elim.of());
+    return term instanceof ErasedTerm elim && !elim.isProp();
+  }
 
   @Contract(pure = true) static @NotNull Term
   make(@NotNull Term f, @NotNull Arg<Term> arg) {
@@ -35,9 +39,9 @@ public sealed interface ElimTerm extends Term {
     if (app.of() instanceof ErasedTerm erased) {
       // erased.type() can be an ErrorTerm
       if (erased.type() instanceof FormTerm.Pi pi) {
-        return new ErasedTerm(pi.substBody(app.arg().term()));
+        return new ErasedTerm(pi.substBody(app.arg().term()), false);
       } else {
-        return new ErasedTerm(ErrorTerm.typeOf(app));
+        return new ErasedTerm(ErrorTerm.typeOf(app), true);
       }
     }
     if (app.of() instanceof IntroTerm.Lambda lam) return make(lam, app.arg());
@@ -78,9 +82,9 @@ public sealed interface ElimTerm extends Term {
     if (proj.of instanceof ErasedTerm erased) {
       // erased.type() can be an ErrorTerm
       if (erased.type() instanceof FormTerm.Sigma sigma) {
-        return new ErasedTerm(sigma.params().get(proj.ix - 1).type());
+        return new ErasedTerm(sigma.params().get(proj.ix - 1).type(), false);
       } else {
-        return new ErasedTerm(ErrorTerm.typeOf(proj));
+        return new ErasedTerm(ErrorTerm.typeOf(proj), true);
       }
     }
     return proj;

--- a/base/src/main/java/org/aya/core/term/ElimTerm.java
+++ b/base/src/main/java/org/aya/core/term/ElimTerm.java
@@ -33,6 +33,7 @@ public sealed interface ElimTerm extends Term {
         return new CallTerm.Hole(hole.ref(), hole.ulift(), hole.contextArgs(), hole.args().appended(app.arg()));
     }
     if (app.of() instanceof ErasedTerm erased) {
+      // erased.type() can be an ErrorTerm
       if (erased.type() instanceof FormTerm.Pi pi) {
         return new ErasedTerm(pi.substBody(app.arg().term()));
       } else {
@@ -75,6 +76,7 @@ public sealed interface ElimTerm extends Term {
       return tup.items().get(proj.ix - 1);
     }
     if (proj.of instanceof ErasedTerm erased) {
+      // erased.type() can be an ErrorTerm
       if (erased.type() instanceof FormTerm.Sigma sigma) {
         return new ErasedTerm(sigma.params().get(proj.ix - 1).type());
       } else {

--- a/base/src/main/java/org/aya/core/term/ElimTerm.java
+++ b/base/src/main/java/org/aya/core/term/ElimTerm.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.Nullable;
  * @author ice1000
  */
 public sealed interface ElimTerm extends Term {
+  // ErasedTerm itself and ElimTerm with `of` erased are erased.
   static @Nullable ErasedTerm checkErased(@NotNull Term term) {
     if (term instanceof ElimTerm elim) return checkErased(elim.of());
     if (term instanceof CallTerm.Access elim) return checkErased(elim.of());
@@ -26,6 +27,8 @@ public sealed interface ElimTerm extends Term {
   static boolean isErased(@NotNull Term term) {
     return checkErased(term) != null;
   }
+  // ErasedTerm with a Prop type might safely appear in IntroTerms.
+  // ErasedTerm with a non-Prop type or ElimTerm with `of` erased are disallowed.
   static @Nullable ErasedTerm checkErasedNotProp(@NotNull Term term) {
     if (term instanceof ElimTerm elim) return checkErased(elim.of());
     if (term instanceof CallTerm.Access elim) return checkErased(elim.of());

--- a/base/src/main/java/org/aya/core/term/ElimTerm.java
+++ b/base/src/main/java/org/aya/core/term/ElimTerm.java
@@ -29,7 +29,7 @@ public sealed interface ElimTerm extends Term {
   }
   // ErasedTerm with a Prop type might safely appear in IntroTerms.
   // ErasedTerm with a non-Prop type or ElimTerm with `of` erased are disallowed.
-  static @Nullable ErasedTerm underlyingIllegalErased(@NotNull Term term) {
+  static @Nullable ErasedTerm underlyingIllegalErasure(@NotNull Term term) {
     if (term instanceof ElimTerm elim) return underlyingErased(elim.of());
     if (term instanceof CallTerm.Access elim) return underlyingErased(elim.of());
     return term instanceof ErasedTerm erased && !erased.isProp() ? erased : null;

--- a/base/src/main/java/org/aya/core/term/ErasedTerm.java
+++ b/base/src/main/java/org/aya/core/term/ErasedTerm.java
@@ -2,8 +2,16 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.term;
 
+import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 // non-Prop erased term can not appear in non-erased terms
-public record ErasedTerm(@NotNull Term type, boolean isProp) implements Term {
+public record ErasedTerm(@NotNull Term type, boolean isProp, @Nullable SourcePos sourcePos) implements Term {
+  public ErasedTerm(@NotNull Term type) {
+    this(type, false, null);
+  }
+  public ErasedTerm(@NotNull Term type, boolean isProp) {
+    this(type, isProp, null);
+  }
 }

--- a/base/src/main/java/org/aya/core/term/ErasedTerm.java
+++ b/base/src/main/java/org/aya/core/term/ErasedTerm.java
@@ -4,5 +4,6 @@ package org.aya.core.term;
 
 import org.jetbrains.annotations.NotNull;
 
-public record ErasedTerm(@NotNull Term type) implements Term {
+// non-Prop erased term can not appear in non-erased terms
+public record ErasedTerm(@NotNull Term type, boolean isProp) implements Term {
 }

--- a/base/src/main/java/org/aya/core/term/ErasedTerm.java
+++ b/base/src/main/java/org/aya/core/term/ErasedTerm.java
@@ -4,5 +4,5 @@ package org.aya.core.term;
 
 import org.jetbrains.annotations.NotNull;
 
-public record DummyTerm(@NotNull Term type) implements Term {
+public record ErasedTerm(@NotNull Term type) implements Term {
 }

--- a/base/src/main/java/org/aya/core/term/ErasedTerm.java
+++ b/base/src/main/java/org/aya/core/term/ErasedTerm.java
@@ -6,11 +6,17 @@ import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-// non-Prop erased term can not appear in non-erased terms
+/**
+ * @param isProp If this term is of a Prop-type.
+ *               When working within Prop, there might be well-typed terms
+ *               whose type is not a Prop-type.
+ * @implNote non-Prop erased term can not appear in non-erased terms.
+ */
 public record ErasedTerm(@NotNull Term type, boolean isProp, @Nullable SourcePos sourcePos) implements Term {
   public ErasedTerm(@NotNull Term type) {
     this(type, false, null);
   }
+
   public ErasedTerm(@NotNull Term type, boolean isProp) {
     this(type, isProp, null);
   }

--- a/base/src/main/java/org/aya/core/term/FormTerm.java
+++ b/base/src/main/java/org/aya/core/term/FormTerm.java
@@ -75,10 +75,6 @@ public sealed interface FormTerm extends Term {
         case ISet -> ISet.INSTANCE;
       };
     }
-
-    default @NotNull Sort max(@NotNull Sort other) {
-      return Sort.create(this.kind().max(other.kind()), Math.max(this.lift(), other.lift()));
-    }
   }
 
   record Type(@Override int lift) implements Sort {

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -91,7 +91,7 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits Cal
       case ErasedTerm erased -> {
         var type = f.apply(erased.type());
         if (type == erased.type()) yield erased;
-        yield new ErasedTerm(type);
+        yield new ErasedTerm(type, erased.isProp());
       }
       case CallTerm.Struct struct -> {
         var args = struct.args().map(arg -> arg.descent(f));

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
  *
  * @author ice1000
  */
-public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits CallTerm, DummyTerm, ElimTerm,
+public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits CallTerm, ErasedTerm, ElimTerm,
   ErrorTerm, FormTerm, IntroTerm, LitTerm, PrimTerm, RefTerm, RefTerm.Field, RefTerm.MetaPat {
 
   default @NotNull Term descent(@NotNull Function<@NotNull Term, @NotNull Term> f) {
@@ -88,10 +88,10 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits Cal
         if (tuple == proj.of()) yield proj;
         yield new ElimTerm.Proj(tuple, proj.ix());
       }
-      case DummyTerm dummy -> {
-        var type = f.apply(dummy.type());
-        if (type == dummy.type()) yield dummy;
-        yield new DummyTerm(type);
+      case ErasedTerm erased -> {
+        var type = f.apply(erased.type());
+        if (type == erased.type()) yield erased;
+        yield new ErasedTerm(type);
       }
       case CallTerm.Struct struct -> {
         var args = struct.args().map(arg -> arg.descent(f));

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -91,7 +91,7 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits Cal
       case ErasedTerm erased -> {
         var type = f.apply(erased.type());
         if (type == erased.type()) yield erased;
-        yield new ErasedTerm(type, erased.isProp());
+        yield new ErasedTerm(type, erased.isProp(), erased.sourcePos());
       }
       case CallTerm.Struct struct -> {
         var args = struct.args().map(arg -> arg.descent(f));

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -36,8 +36,8 @@ import java.util.function.Function;
  *
  * @author ice1000
  */
-public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits CallTerm, ElimTerm, ErrorTerm,
-  FormTerm, IntroTerm, PrimTerm, RefTerm, RefTerm.Field, RefTerm.MetaPat, LitTerm {
+public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits CallTerm, DummyTerm, ElimTerm,
+  ErrorTerm, FormTerm, IntroTerm, LitTerm, PrimTerm, RefTerm, RefTerm.Field, RefTerm.MetaPat {
 
   default @NotNull Term descent(@NotNull Function<@NotNull Term, @NotNull Term> f) {
     return switch (this) {
@@ -87,6 +87,11 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits Cal
         var tuple = f.apply(proj.of());
         if (tuple == proj.of()) yield proj;
         yield new ElimTerm.Proj(tuple, proj.ix());
+      }
+      case DummyTerm dummy -> {
+        var type = f.apply(dummy.type());
+        if (type == dummy.type()) yield dummy;
+        yield new DummyTerm(type);
       }
       case CallTerm.Struct struct -> {
         var args = struct.args().map(arg -> arg.descent(f));

--- a/base/src/main/java/org/aya/core/visitor/BetaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/BetaExpander.java
@@ -41,7 +41,7 @@ public interface BetaExpander extends EndoFunctor {
         if (app.of() instanceof ErasedTerm) {
           var xi = app.cube().params();
           var ui = app.args().map(Arg::term);
-          yield new ErasedTerm(app.cube().type().subst(new Subst(xi, ui)));
+          yield new ErasedTerm(app.cube().type().subst(new Subst(xi, ui)), false);
         }
         if (app.of() instanceof IntroTerm.PathLam lam) {
           var ui = app.args().map(Arg::term);

--- a/base/src/main/java/org/aya/core/visitor/BetaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/BetaExpander.java
@@ -38,6 +38,11 @@ public interface BetaExpander extends EndoFunctor {
       }
       case ElimTerm.Proj proj -> ElimTerm.proj(proj);
       case ElimTerm.PathApp app -> {
+        if (app.of() instanceof ErasedTerm) {
+          var xi = app.cube().params();
+          var ui = app.args().map(Arg::term);
+          yield new ErasedTerm(app.cube().type().subst(new Subst(xi, ui)));
+        }
         if (app.of() instanceof IntroTerm.PathLam lam) {
           var ui = app.args().map(Arg::term);
           var subst = new Subst(lam.params(), ui);

--- a/base/src/main/java/org/aya/core/visitor/BetaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/BetaExpander.java
@@ -41,7 +41,7 @@ public interface BetaExpander extends EndoFunctor {
         if (app.of() instanceof ErasedTerm) {
           var xi = app.cube().params();
           var ui = app.args().map(Arg::term);
-          yield new ErasedTerm(app.cube().type().subst(new Subst(xi, ui)), false);
+          yield new ErasedTerm(app.cube().type().subst(new Subst(xi, ui)));
         }
         if (app.of() instanceof IntroTerm.PathLam lam) {
           var ui = app.args().map(Arg::term);

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -188,7 +188,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
         app.args().view(), outer, options.map.get(DistillerOptions.Key.ShowImplicitArgs));
       case PrimTerm.Coe coe -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "coe"),
         term(Outer.AppSpine, coe.type()), Doc.parened(restr(options, coe.restr()))), Outer.AppSpine);
-      case DummyTerm dummy -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "dummy"), term(Outer.AppSpine, dummy.type())), Outer.AppSpine);
+      case ErasedTerm erased -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "erased"), term(Outer.AppSpine, erased.type())), Outer.AppSpine);
     };
   }
 

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -188,6 +188,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
         app.args().view(), outer, options.map.get(DistillerOptions.Key.ShowImplicitArgs));
       case PrimTerm.Coe coe -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "coe"),
         term(Outer.AppSpine, coe.type()), Doc.parened(restr(options, coe.restr()))), Outer.AppSpine);
+      case DummyTerm dummy -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "dummy"), term(Outer.AppSpine, dummy.type())), Outer.AppSpine);
     };
   }
 

--- a/base/src/main/java/org/aya/generic/SortKind.java
+++ b/base/src/main/java/org/aya/generic/SortKind.java
@@ -10,11 +10,4 @@ public enum SortKind {
   public boolean hasLevel() {
     return this == Type || this == Set;
   }
-
-  public @NotNull SortKind max(@NotNull SortKind other) {
-    if (this == Set || other == Set) return Set;
-    if (this == Type || other == Type) return Type;
-    // Prop or ISet
-    return this == other ? this : Type;
-  }
 }

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -462,9 +462,8 @@ public final class ExprTycker extends Tycker {
             var resultParam = new Term.Param(var, type, param.explicit());
             var body = dt.substBody(resultParam.toTerm());
             yield localCtx.with(resultParam, () -> {
-              var rec = inherit(lam.body(), body);
-              var lamBody = checkIllegalErasure(lam.body().sourcePos(), rec.wellTyped(), body);
-              return new TermResult(new IntroTerm.Lambda(resultParam, lamBody), dt);
+              var rec = check(lam.body(), body);
+              return new TermResult(new IntroTerm.Lambda(resultParam, rec.wellTyped()), dt);
             });
           }
           // Path lambda!
@@ -835,6 +834,10 @@ public final class ExprTycker extends Tycker {
 
   private @NotNull Arg<Term> mockArg(Term.Param param, SourcePos pos) {
     return new Arg<>(mockTerm(param, pos), param.explicit());
+  }
+
+  public @NotNull Result check(@NotNull Expr expr, @NotNull Term type) {
+    return checkIllegalErasure(expr.sourcePos(), inherit(expr, type));
   }
 
   public @NotNull Result checkIllegalErasure(@NotNull SourcePos sourcePos, @NotNull Result result) {

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -463,7 +463,7 @@ public final class ExprTycker extends Tycker {
             var body = dt.substBody(resultParam.toTerm());
             yield localCtx.with(resultParam, () -> {
               var rec = inherit(lam.body(), body);
-              var lamBody = checkNotErased(lam.body().sourcePos(), rec.wellTyped(), body);
+              var lamBody = checkIllegalErasure(lam.body().sourcePos(), rec.wellTyped(), body);
               return new TermResult(new IntroTerm.Lambda(resultParam, lamBody), dt);
             });
           }
@@ -837,22 +837,22 @@ public final class ExprTycker extends Tycker {
     return new Arg<>(mockTerm(param, pos), param.explicit());
   }
 
-  public @NotNull Result checkNotErased(@NotNull SourcePos sourcePos, @NotNull Result result) {
-    return new TermResult(checkNotErased(sourcePos, result.wellTyped(), result.type()), result.type());
+  public @NotNull Result checkIllegalErasure(@NotNull SourcePos sourcePos, @NotNull Result result) {
+    return new TermResult(checkIllegalErasure(sourcePos, result.wellTyped(), result.type()), result.type());
   }
 
-  public @NotNull Term checkNotErased(@NotNull SourcePos sourcePos, @NotNull Term wellTyped, @NotNull Term type) {
+  public @NotNull Term checkIllegalErasure(@NotNull SourcePos sourcePos, @NotNull Term wellTyped, @NotNull Term type) {
     if (wellTyped instanceof FormTerm.Sort) return wellTyped;
     var sort = type.computeType(state, localCtx);
     if (sort instanceof FormTerm.Prop) return wellTyped;
-    return checkNotErased(sourcePos, wellTyped);
+    return checkIllegalErasure(sourcePos, wellTyped);
   }
 
-  public @NotNull Term checkNotErased(@NotNull SourcePos sourcePos, @NotNull Term term) {
+  public @NotNull Term checkIllegalErasure(@NotNull SourcePos sourcePos, @NotNull Term term) {
     var checker = new Function<Term, Term>() {
       private @NotNull Term post(@NotNull Term term) {
         if (term instanceof FormTerm.Sort) return term;
-        var erased = ElimTerm.underlyingIllegalErased(term);
+        var erased = ElimTerm.underlyingIllegalErasure(term);
         if (erased != null) {
           reporter.report(new ErasedError(sourcePos, erased, null));
           return new ErrorTerm(term);

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -463,7 +463,8 @@ public final class ExprTycker extends Tycker {
             var body = dt.substBody(resultParam.toTerm());
             yield localCtx.with(resultParam, () -> {
               var rec = inherit(lam.body(), body);
-              return new TermResult(new IntroTerm.Lambda(resultParam, rec.wellTyped()), dt);
+              var lamBody = checkNotErased(lam.body().sourcePos(), rec.wellTyped(), body);
+              return new TermResult(new IntroTerm.Lambda(resultParam, lamBody), dt);
             });
           }
           // Path lambda!

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -852,7 +852,7 @@ public final class ExprTycker extends Tycker {
     var checker = new Function<Term, Term>() {
       private @NotNull Term post(@NotNull Term term) {
         if (term instanceof FormTerm.Sort) return term;
-        var erased = ElimTerm.checkErasedNotProp(term);
+        var erased = ElimTerm.underlyingIllegalErased(term);
         if (erased != null) {
           reporter.report(new ErasedError(sourcePos, erased, null));
           return new ErrorTerm(term);

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -839,7 +839,7 @@ public final class ExprTycker extends Tycker {
 
   public @NotNull Term checkNotErased(@NotNull SourcePos sourcePos, @NotNull Term term) {
     var functor = new EndoFunctor() {
-      @Override public Term post(@NotNull Term term) {
+      @Override public @NotNull Term post(@NotNull Term term) {
         if (term instanceof FormTerm.Sort) return term;
         if (ElimTerm.isErased(term)) {
           reporter.report(new ErasedError(sourcePos, term, null));

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -831,9 +831,10 @@ public final class ExprTycker extends Tycker {
 
     default Result checkErased(@NotNull TyckState state, @NotNull LocalCtx ctx) {
       var type = type();
-      if(type instanceof FormTerm.Sort) return this;
+      if (type instanceof FormTerm.Sort) return this;
       var sort = type.computeType(state, ctx);
-      if(sort instanceof FormTerm.Prop) return new TermResult(new ErasedTerm(type), type);
+      if (sort instanceof FormTerm.Prop || ElimTerm.isErased(wellTyped()))
+        return new TermResult(new ErasedTerm(type), type);
       return this;
     }
   }

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -132,7 +132,7 @@ public final class ExprTycker extends Tycker {
             return fail(proj, new TupleError.ProjIxError(proj, ix, telescope.size()));
           var type = telescope.get(index).type();
           var subst = ElimTerm.Proj.projSubst(projectee.wellTyped(), index, telescope);
-          return new TermResult(new ElimTerm.Proj(projectee.wellTyped(), ix), type.subst(subst));
+          return new TermResult(ElimTerm.proj(projectee.wellTyped(), ix), type.subst(subst));
         }, sp -> {
           var fieldName = sp.justName();
           if (!(projectee.type() instanceof CallTerm.Struct structCall))

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -842,7 +842,7 @@ public final class ExprTycker extends Tycker {
   }
 
   public @NotNull Term checkNotErased(@NotNull SourcePos sourcePos, @NotNull Term wellTyped, @NotNull Term type) {
-    if (type instanceof FormTerm.Sort) return wellTyped;
+    if (wellTyped instanceof FormTerm.Sort) return wellTyped;
     var sort = type.computeType(state, localCtx);
     if (sort instanceof FormTerm.Prop) return wellTyped;
     return checkNotErased(sourcePos, wellTyped);

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -631,14 +631,14 @@ public final class ExprTycker extends Tycker {
       var implicitParam = new Term.Param(new LocalVar(Constants.ANONYMOUS_PREFIX), pi.param().type(), false);
       var body = localCtx.with(implicitParam, () -> inherit(expr, pi.substBody(implicitParam.toTerm()))).wellTyped();
       result = new TermResult(new IntroTerm.Lambda(implicitParam, body), pi);
-    } else result = doInherit(expr, type).checkDummy(state, localCtx);
+    } else result = doInherit(expr, type).checkErased(state, localCtx);
     traceExit(result, expr);
     return result;
   }
 
   public @NotNull Result synthesize(@NotNull Expr expr) {
     tracing(builder -> builder.shift(new Trace.ExprT(expr, null)));
-    var res = doSynthesize(expr).checkDummy(state, localCtx);
+    var res = doSynthesize(expr).checkErased(state, localCtx);
     traceExit(res, expr);
     return res;
   }
@@ -829,11 +829,11 @@ public final class ExprTycker extends Tycker {
     @NotNull Term type();
     @NotNull Result freezeHoles(@NotNull TyckState state);
 
-    default Result checkDummy(@NotNull TyckState state, @NotNull LocalCtx ctx) {
+    default Result checkErased(@NotNull TyckState state, @NotNull LocalCtx ctx) {
       var type = type();
       if(type instanceof FormTerm.Sort) return this;
       var sort = type.computeType(state, ctx);
-      if(sort instanceof FormTerm.Prop) return new TermResult(new DummyTerm(type), type);
+      if(sort instanceof FormTerm.Prop) return new TermResult(new ErasedTerm(type), type);
       return this;
     }
   }

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -64,8 +64,9 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       case FormTerm.Pi pi -> {
         var paramTyRaw = term(pi.param().type()).normalize(state, NormalizeMode.WHNF);
         var resultParam = new Term.Param(pi.param().ref(), paramTyRaw, pi.param().explicit());
-        yield localCtx.with(resultParam, () -> {
-          var retTyRaw = term(pi.body()).normalize(state, NormalizeMode.WHNF);
+        var t = new LittleTyper(state, localCtx.deriveMap());
+        yield t.localCtx.with(resultParam, () -> {
+          var retTyRaw = t.term(pi.body()).normalize(state, NormalizeMode.WHNF);
           if (paramTyRaw instanceof FormTerm.Sort paramTy && retTyRaw instanceof FormTerm.Sort retTy)
             return new FormTerm.Type(Math.max(paramTy.lift(), retTy.lift()));
           else return ErrorTerm.typeOf(pi);

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -63,12 +63,12 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       case RefTerm.MetaPat metaPat -> metaPat.ref().type();
       case FormTerm.Pi pi -> {
         var paramTyRaw = term(pi.param().type()).normalize(state, NormalizeMode.WHNF);
-        var resultParam = new Term.Param(pi.param().ref(), paramTyRaw, pi.param().explicit());
+        var resultParam = new Term.Param(pi.param().ref(), pi.param().type().normalize(state, NormalizeMode.WHNF), pi.param().explicit());
         var t = new LittleTyper(state, localCtx.deriveMap());
         yield t.localCtx.with(resultParam, () -> {
           var retTyRaw = t.term(pi.body()).normalize(state, NormalizeMode.WHNF);
           if (paramTyRaw instanceof FormTerm.Sort paramTy && retTyRaw instanceof FormTerm.Sort retTy)
-            return new FormTerm.Type(Math.max(paramTy.lift(), retTy.lift()));
+            return ExprTycker.sortPi(paramTy, retTy);
           else return ErrorTerm.typeOf(pi);
         });
       }

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -93,6 +93,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
         yield app.cube().type().subst(new Subst(xi, ui));
       }
       case PrimTerm.Coe coe -> PrimDef.familyLeftToRight(coe.type());
+      case DummyTerm dummy -> dummy.type();
     };
   }
 

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -97,7 +97,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
         yield app.cube().type().subst(new Subst(xi, ui));
       }
       case PrimTerm.Coe coe -> PrimDef.familyLeftToRight(coe.type());
-      case DummyTerm dummy -> dummy.type();
+      case ErasedTerm erased -> erased.type();
     };
   }
 

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -231,7 +231,8 @@ public record StmtTycker(@NotNull Reporter reporter, Trace.@Nullable Builder tra
           ? patTycker.visitPatterns(sig, ctor.patterns.view())._1.toImmutableSeq()
           // No patterns, leave it blank
           : ImmutableSeq.<Pat>empty();
-        var tele = tele(tycker, ctor.telescope, dataConcrete.ulift);
+        var ctorSort = dataConcrete.ulift instanceof FormTerm.Prop ? FormTerm.Type.ZERO : dataConcrete.ulift;
+        var tele = tele(tycker, ctor.telescope, ctorSort);
         ctor.signature = new Def.Signature(tele, dataCall);
         ctor.yetTycker = patTycker;
         ctor.yetTyckedPat = pat;

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -243,8 +243,9 @@ public record StmtTycker(@NotNull Reporter reporter, Trace.@Nullable Builder tra
         var structSig = structRef.concrete.signature;
         assert structSig != null;
         var structLvl = structRef.concrete.ulift;
+        var fieldSort = structLvl instanceof FormTerm.Prop ? FormTerm.Type.ZERO : structLvl;
         var tele = tele(tycker, field.telescope, structLvl);
-        var result = tycker.zonk(tycker.inherit(field.result, structLvl)).wellTyped();
+        var result = tycker.zonk(tycker.inherit(field.result, fieldSort)).wellTyped();
         field.signature = new Def.Signature(tele, result);
       }
     }

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -73,7 +73,7 @@ public record StmtTycker(@NotNull Reporter reporter, Trace.@Nullable Builder tra
           new FnDef(decl.ref, signature.param(), resultTy, decl.modifiers, body));
         yield decl.body.fold(
           body -> {
-            var nobody = tycker.checkIllegalErasure(body.sourcePos(), tycker.inherit(body, signature.result())).wellTyped();
+            var nobody = tycker.check(body, signature.result()).wellTyped();
             tycker.solveMetas();
             // It may contain unsolved metas. See `checkTele`.
             var resultTy = tycker.zonk(signature.result());
@@ -158,7 +158,7 @@ public record StmtTycker(@NotNull Reporter reporter, Trace.@Nullable Builder tra
     var okTele = checkTele(tycker, fn.telescope, null);
     var preresult = tycker.synthesize(fn.result).wellTyped();
     var bodyExpr = fn.body.getLeftValue();
-    var prebody = tycker.checkIllegalErasure(bodyExpr.sourcePos(), tycker.inherit(bodyExpr, preresult)).wellTyped();
+    var prebody = tycker.check(bodyExpr, preresult).wellTyped();
     tycker.solveMetas();
     var result = tycker.zonk(preresult);
     var tele = zonkTele(tycker, okTele);

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -158,7 +158,7 @@ public record StmtTycker(@NotNull Reporter reporter, Trace.@Nullable Builder tra
     var okTele = checkTele(tycker, fn.telescope, null);
     var preresult = tycker.synthesize(fn.result).wellTyped();
     var bodyExpr = fn.body.getLeftValue();
-    var prebody = tycker.inherit(bodyExpr, preresult).wellTyped();
+    var prebody = tycker.checkNotErased(bodyExpr.sourcePos(), tycker.inherit(bodyExpr, preresult)).wellTyped();
     tycker.solveMetas();
     var result = tycker.zonk(preresult);
     var tele = zonkTele(tycker, okTele);

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -73,7 +73,7 @@ public record StmtTycker(@NotNull Reporter reporter, Trace.@Nullable Builder tra
           new FnDef(decl.ref, signature.param(), resultTy, decl.modifiers, body));
         yield decl.body.fold(
           body -> {
-            var nobody = tycker.inherit(body, signature.result()).wellTyped();
+            var nobody = tycker.checkNotErased(body.sourcePos(), tycker.inherit(body, signature.result())).wellTyped();
             tycker.solveMetas();
             // It may contain unsolved metas. See `checkTele`.
             var resultTy = tycker.zonk(signature.result());

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -73,7 +73,7 @@ public record StmtTycker(@NotNull Reporter reporter, Trace.@Nullable Builder tra
           new FnDef(decl.ref, signature.param(), resultTy, decl.modifiers, body));
         yield decl.body.fold(
           body -> {
-            var nobody = tycker.checkNotErased(body.sourcePos(), tycker.inherit(body, signature.result())).wellTyped();
+            var nobody = tycker.checkIllegalErasure(body.sourcePos(), tycker.inherit(body, signature.result())).wellTyped();
             tycker.solveMetas();
             // It may contain unsolved metas. See `checkTele`.
             var resultTy = tycker.zonk(signature.result());
@@ -158,7 +158,7 @@ public record StmtTycker(@NotNull Reporter reporter, Trace.@Nullable Builder tra
     var okTele = checkTele(tycker, fn.telescope, null);
     var preresult = tycker.synthesize(fn.result).wellTyped();
     var bodyExpr = fn.body.getLeftValue();
-    var prebody = tycker.checkNotErased(bodyExpr.sourcePos(), tycker.inherit(bodyExpr, preresult)).wellTyped();
+    var prebody = tycker.checkIllegalErasure(bodyExpr.sourcePos(), tycker.inherit(bodyExpr, preresult)).wellTyped();
     tycker.solveMetas();
     var result = tycker.zonk(preresult);
     var tele = zonkTele(tycker, okTele);

--- a/base/src/main/java/org/aya/tyck/error/ErasedError.java
+++ b/base/src/main/java/org/aya/tyck/error/ErasedError.java
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck.error;
 
+import org.aya.core.term.ErasedTerm;
 import org.aya.core.term.Term;
 import org.aya.pretty.doc.Doc;
 import org.aya.util.distill.DistillerOptions;
@@ -10,17 +11,19 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public record ErasedError(
-  @Override @NotNull SourcePos sourcePos,
-  @NotNull Term wellTyped, @Nullable Term type) implements TyckError {
+  @NotNull SourcePos sourcePos,
+  @NotNull ErasedTerm wellTyped, @Nullable Term type) implements TyckError {
+  @Override public @NotNull SourcePos sourcePos() {
+    return wellTyped.sourcePos() == null ? sourcePos : wellTyped.sourcePos();
+  }
+
   @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
     if (type == null) {
-      return Doc.sepNonEmpty(Doc.english("The term is expected to be not erased"),
-        wellTyped.toDoc(options));
+      return Doc.sepNonEmpty(Doc.english("The"),
+        wellTyped.type().toDoc(options), Doc.english("term is expected to be not erased"));
     } else {
-      return Doc.sepNonEmpty(Doc.english("The term is expected to be not erased"),
-        wellTyped.toDoc(options),
-        Doc.symbol(":"),
-        type.toDoc(options));
+      return Doc.sepNonEmpty(Doc.english("The"), wellTyped.type().toDoc(options), Doc.english("term with type"),
+        type.toDoc(options), Doc.english("is expected to be not erased"));
     }
   }
 }

--- a/base/src/main/java/org/aya/tyck/error/ErasedError.java
+++ b/base/src/main/java/org/aya/tyck/error/ErasedError.java
@@ -1,0 +1,26 @@
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.tyck.error;
+
+import org.aya.core.term.Term;
+import org.aya.pretty.doc.Doc;
+import org.aya.util.distill.DistillerOptions;
+import org.aya.util.error.SourcePos;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public record ErasedError(
+  @Override @NotNull SourcePos sourcePos,
+  @NotNull Term wellTyped, @Nullable Term type) implements TyckError {
+  @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+    if (type == null) {
+      return Doc.sepNonEmpty(Doc.english("The term is expected to be not erased"),
+        wellTyped.toDoc(options));
+    } else {
+      return Doc.sepNonEmpty(Doc.english("The term is expected to be not erased"),
+        wellTyped.toDoc(options),
+        Doc.symbol(":"),
+        type.toDoc(options));
+    }
+  }
+}

--- a/base/src/main/java/org/aya/tyck/error/ErasedError.java
+++ b/base/src/main/java/org/aya/tyck/error/ErasedError.java
@@ -3,27 +3,22 @@
 package org.aya.tyck.error;
 
 import org.aya.core.term.ErasedTerm;
-import org.aya.core.term.Term;
 import org.aya.pretty.doc.Doc;
 import org.aya.util.distill.DistillerOptions;
 import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public record ErasedError(
   @NotNull SourcePos sourcePos,
-  @NotNull ErasedTerm wellTyped, @Nullable Term type) implements TyckError {
+  @NotNull ErasedTerm wellTyped
+) implements TyckError {
   @Override public @NotNull SourcePos sourcePos() {
     return wellTyped.sourcePos() == null ? sourcePos : wellTyped.sourcePos();
   }
 
   @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
-    if (type == null) {
-      return Doc.sepNonEmpty(Doc.english("The"),
-        wellTyped.type().toDoc(options), Doc.english("term is expected to be not erased"));
-    } else {
-      return Doc.sepNonEmpty(Doc.english("The"), wellTyped.type().toDoc(options), Doc.english("term with type"),
-        type.toDoc(options), Doc.english("is expected to be not erased"));
-    }
+    return Doc.sepNonEmpty(Doc.plain("The"),
+      wellTyped.type().toDoc(options),
+      Doc.english("term is expected to be not erased"));
   }
 }

--- a/base/src/test/resources/failure/tyck/erased.aya
+++ b/base/src/test/resources/failure/tyck/erased.aya
@@ -1,0 +1,4 @@
+open struct Squash (A: Type): Prop
+  | value: A
+
+def badSquashElim {A: Type} {Q: Type} (f: A -> Q) (squash: Squash A): Q => f squash.value

--- a/base/src/test/resources/failure/tyck/erased.aya.txt
+++ b/base/src/test/resources/failure/tyck/erased.aya.txt
@@ -1,11 +1,11 @@
-In file $FILE:4:75 ->
+In file $FILE:4:77 ->
 
   2 |   | value: A
-  3 | 
+  3 |
   4 | def badSquashElim {A: Type} {Q: Type} (f: A -> Q) (squash: Squash A): Q => f squash.value
-                                                                                 ^------------^
+                                                                                   ^----------^
 
-Error: The term is expected to be not erased erased A
+Error: The A term is expected to be not erased
 
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/tyck/erased.aya.txt
+++ b/base/src/test/resources/failure/tyck/erased.aya.txt
@@ -1,0 +1,11 @@
+In file $FILE:4:75 ->
+
+  2 |   | value: A
+  3 | 
+  4 | def badSquashElim {A: Type} {Q: Type} (f: A -> Q) (squash: Squash A): Q => f squash.value
+                                                                                 ^------------^
+
+Error: The term is expected to be not erased erased A
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tyck/erased.aya.txt
+++ b/base/src/test/resources/failure/tyck/erased.aya.txt
@@ -1,7 +1,7 @@
 In file $FILE:4:77 ->
 
   2 |   | value: A
-  3 |
+  3 | 
   4 | def badSquashElim {A: Type} {Q: Type} (f: A -> Q) (squash: Squash A): Q => f squash.value
                                                                                    ^----------^
 

--- a/base/src/test/resources/success/src/Prop.aya
+++ b/base/src/test/resources/success/src/Prop.aya
@@ -1,0 +1,4 @@
+open struct Squash (A: Type): Prop
+  | squash: A
+
+def squashElim {A: Type} {P: Prop} (f: A -> P) (squash: Squash A): P => f squash.squash

--- a/base/src/test/resources/success/src/Prop.aya
+++ b/base/src/test/resources/success/src/Prop.aya
@@ -6,5 +6,8 @@ open data Squash2 (A: Type): Prop
 
 def squashElim {A: Type} {P: Prop} (f: A -> P) (squash: Squash A): P => f squash.value
 
+counterexample def badSquashElim {A: Type} {Q: Type} (f: A -> Q) (squash: Squash A): Q => f squash.value
+
 def squash2Elim {A: Type} {P: Prop} (f: A -> P) (squash: Squash2 A): P
   | f, (squash a) => f a
+

--- a/base/src/test/resources/success/src/Prop.aya
+++ b/base/src/test/resources/success/src/Prop.aya
@@ -1,4 +1,4 @@
 open struct Squash (A: Type): Prop
-  | squash: A
+  | value: A
 
-def squashElim {A: Type} {P: Prop} (f: A -> P) (squash: Squash A): P => f squash.squash
+def squashElim {A: Type} {P: Prop} (f: A -> P) (squash: Squash A): P => f squash.value

--- a/base/src/test/resources/success/src/Prop.aya
+++ b/base/src/test/resources/success/src/Prop.aya
@@ -1,4 +1,10 @@
 open struct Squash (A: Type): Prop
   | value: A
 
+open data Squash2 (A: Type): Prop
+  | squash A
+
 def squashElim {A: Type} {P: Prop} (f: A -> P) (squash: Squash A): P => f squash.value
+
+def squash2Elim {A: Type} {P: Prop} (f: A -> P) (squash: Squash2 A): P
+  | f, (squash a) => f a

--- a/base/src/test/resources/success/src/Prop.aya
+++ b/base/src/test/resources/success/src/Prop.aya
@@ -6,8 +6,6 @@ open data Squash2 (A: Type): Prop
 
 def squashElim {A: Type} {P: Prop} (f: A -> P) (squash: Squash A): P => f squash.value
 
-counterexample def badSquashElim {A: Type} {Q: Type} (f: A -> Q) (squash: Squash A): Q => f squash.value
-
 def squash2Elim {A: Type} {P: Prop} (f: A -> P) (squash: Squash2 A): P
   | f, (squash a) => f a
 

--- a/base/src/test/resources/success/src/Sorts.aya
+++ b/base/src/test/resources/success/src/Sorts.aya
@@ -6,6 +6,8 @@ def c: Set 1 => ISet
 def e: Set 2 => Unit -> Set 1
 def d: e => \u => ISet
 
+def f: Prop => Sig (A : Prop) ** A
+
 open data Rua : Set | rua
 open import Paths
 def II : ISet => Sig I ** I


### PR DESCRIPTION
This pr
+ Added ErasedTerm
+ generate ErasedTerm on inherit/synthesize whenever sort is Prop
+ implement illegal erased term check.
+ add a reduction rule: `elim(erased)` become `erased`
+ corrected prop-related tyck rules for sigma types and struct
+ updated LittleTyper to support new universe system for `type.computeType()` use cases