### PR TITLE
repr: List

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ out/
 /.vscode/
 *.iml
 gradle.properties
+local.properties
 .DS_Store
 lombok.config
 /test.aya

--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -403,15 +403,7 @@ public sealed interface Expr extends AyaDocile, SourceNode, Restr.TermLike<Expr>
     @Override @NotNull SourcePos sourcePos,
     @NotNull Either<CompBlock, ElementList> arrayBlock
   ) implements Expr {
-    /**
-     * @param nilCtor  the Nil constructor, it is {@link org.aya.generic.Constants}.listNil in default
-     * @param consCtor the Cons constructor, it is {@link org.aya.generic.Constants}.listCons in default
-     */
-    public record ElementList(
-      @NotNull ImmutableSeq<Expr> exprList,
-      @NotNull Expr nilCtor,
-      @NotNull Expr consCtor
-    ) {}
+    public record ElementList(@NotNull ImmutableSeq<Expr> exprList) {}
 
     /**
      * <h1>Array Comp(?)</h1>
@@ -443,14 +435,10 @@ public sealed interface Expr extends AyaDocile, SourceNode, Restr.TermLike<Expr>
      */
     public static Expr.Array newList(
       @NotNull SourcePos sourcePos,
-      @NotNull ImmutableSeq<Expr> exprs,
-      @NotNull Expr nilCtor,
-      @NotNull Expr consCtor) {
+      @NotNull ImmutableSeq<Expr> exprs) {
       return new Expr.Array(
         sourcePos,
-        Either.right(new ElementList(
-          exprs, nilCtor, consCtor
-        ))
+        Either.right(new ElementList(exprs))
       );
     }
 

--- a/base/src/main/java/org/aya/concrete/Pattern.java
+++ b/base/src/main/java/org/aya/concrete/Pattern.java
@@ -12,7 +12,6 @@ import org.aya.generic.AyaDocile;
 import org.aya.pretty.doc.Doc;
 import org.aya.ref.AnyVar;
 import org.aya.ref.LocalVar;
-import org.aya.resolve.context.Context;
 import org.aya.util.ForLSP;
 import org.aya.util.binop.BinOpParser;
 import org.aya.util.distill.DistillerOptions;
@@ -101,10 +100,7 @@ public sealed interface Pattern extends AyaDocile, SourceNode, BinOpParser.Elem<
     @NotNull SourcePos sourcePos,
     boolean explicit,
     @NotNull ImmutableSeq<Pattern> elements,
-    @Nullable LocalVar as,
-    // dirty!!
-    @NotNull Pattern nilName,
-    @NotNull Pattern consName
+    @Nullable LocalVar as
   ) implements Pattern {
   }
 

--- a/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
+++ b/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
@@ -122,20 +122,8 @@ public record Desugarer(@NotNull ResolveInfo resolveInfo) implements StmtOps<Uni
             // desugar do-notation
             return pre(doNotation);
           },
-          // desugar `[1, 2, 3]` to `consCtor 1 (consCtor 2 (consCtor 3 nilCtor))`
-          right -> pre(right.exprList().foldRight(right.nilCtor(),
-            (e, last) -> {
-              // construct `(consCtor e) last`
-              // Note: the sourcePos of this call is the same as the element's (currently)
-              // Recommend: use sourcePos [currentElement..lastElement]
-              return new Expr.AppExpr(e.sourcePos(),
-                // construct `consCtor e`
-                new Expr.AppExpr(e.sourcePos(),
-                  right.consCtor(),
-                  new Expr.NamedArg(true, e)),
-                new Expr.NamedArg(true, last));
-            })
-          ));
+          // do not desugar
+          right -> arrayExpr);
         case Expr misc -> misc;
       };
     }

--- a/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
+++ b/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
@@ -146,25 +146,6 @@ public record Desugarer(@NotNull ResolveInfo resolveInfo) implements StmtOps<Uni
   @Override
   public @NotNull Pattern visitPattern(@NotNull Pattern pattern, Unit pp) {
     return switch (pattern) {
-      case Pattern.List list -> {
-        assert list.nilName() instanceof Pattern.Ctor : "resolver bug";
-        assert list.consName() instanceof Pattern.Ctor : "resolver bug";
-        var nilCtor = (Pattern.Ctor) list.nilName();
-        var consCtor = (Pattern.Ctor) list.consName();
-
-        var newPattern = list.elements().view()
-          .map(x -> visitPattern(x, pp))
-          .foldRight(nilCtor, (e, right) -> {
-            // e : current element
-            // right : right element
-            // Goal : consCtor e right
-            return new Pattern.Ctor(consCtor.sourcePos(), consCtor.explicit(), consCtor.resolved(),
-              ImmutableSeq.of(e, right), null);
-          });
-
-        // replace newPattern.as() with list.as()
-        yield visitPattern(new Pattern.Ctor(newPattern.sourcePos(), newPattern.explicit(), newPattern.resolved(), newPattern.params(), list.as()), pp);
-      }
       case Pattern.BinOpSeq(var pos, var seq, var as, var explicit) -> {
         assert seq.isNotEmpty() : pos.toString();
         var pat = new BinPatternParser(explicit, resolveInfo, seq.view()).build(pos);

--- a/base/src/main/java/org/aya/concrete/visitor/ExprView.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprView.java
@@ -158,13 +158,11 @@ public interface ExprView {
         },
         right -> {
           var exprs = right.exprList().map(this::commit);
-          var nilCtor = commit(right.nilCtor());
-          var consCtor = commit(right.consCtor());
 
-          if (exprs.sameElements(right.exprList()) && nilCtor == right.nilCtor() && consCtor == right.consCtor()) {
+          if (exprs.sameElements(right.exprList())) {
             return arrayExpr;
           } else {
-            return Expr.Array.newList(arrayExpr.sourcePos(), exprs, nilCtor, consCtor);
+            return Expr.Array.newList(arrayExpr.sourcePos(), exprs);
           }
         }
       );

--- a/base/src/main/java/org/aya/concrete/visitor/StmtOps.java
+++ b/base/src/main/java/org/aya/concrete/visitor/StmtOps.java
@@ -83,8 +83,8 @@ public interface StmtOps<P> extends ExprTraversal<P> {
         new Pattern.Ctor(pos, licit, resolved, params.map(p -> visitPattern(p, pp)), as);
       case Pattern.Tuple(var pos, var licit, var patterns, var as) ->
         new Pattern.Tuple(pos, licit, patterns.map(p -> visitPattern(p, pp)), as);
-      case Pattern.List(var pos, var licit, var patterns, var as, var nilCtor, var consCtor) ->
-        new Pattern.List(pos, licit, patterns.map(p -> visitPattern(p, pp)), as, visitPattern(nilCtor, pp), visitPattern(consCtor, pp));
+      case Pattern.List(var pos, var licit, var patterns, var as) ->
+        new Pattern.List(pos, licit, patterns.map(p -> visitPattern(p, pp)), as);
       default -> pattern;
     };
   }

--- a/base/src/main/java/org/aya/concrete/visitor/StmtOps.java
+++ b/base/src/main/java/org/aya/concrete/visitor/StmtOps.java
@@ -11,7 +11,6 @@ import java.util.function.BiConsumer;
 
 /**
  * @author ice1000
- * TODO: rewrite this class using pattern matching
  */
 public interface StmtOps<P> extends ExprTraversal<P> {
   default <T extends Decl> void traced(@NotNull T yeah, P p, @NotNull BiConsumer<T, P> f) {

--- a/base/src/main/java/org/aya/core/pat/PatMatcher.java
+++ b/base/src/main/java/org/aya/core/pat/PatMatcher.java
@@ -64,6 +64,7 @@ public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx) {
           case RefTerm.MetaPat metaPat -> solve(pat, metaPat);
           // TODO[literal]: We may convert constructor call to literals to avoid possible stack overflow?
           case LitTerm.ShapedInt litTerm -> match(ctor, litTerm.constructorForm());
+          case LitTerm.ShapedList litTerm -> match(ctor, litTerm.constructorForm());
           default -> throw new Mismatch(true);
         }
       }

--- a/base/src/main/java/org/aya/core/repr/AyaShape.java
+++ b/base/src/main/java/org/aya/core/repr/AyaShape.java
@@ -22,7 +22,7 @@ public sealed interface AyaShape {
 
   @NotNull AyaShape NAT_SHAPE = new AyaIntLitShape();
   @NotNull AyaShape LIST_SHAPE = new AyaListShape();
-  @NotNull ImmutableSeq<AyaShape> LITERAL_SHAPES = ImmutableSeq.of(NAT_SHAPE);
+  @NotNull ImmutableSeq<AyaShape> LITERAL_SHAPES = ImmutableSeq.of(NAT_SHAPE, LIST_SHAPE);
 
   record AyaIntLitShape() implements AyaShape {
     public static final @NotNull CodeShape DATA_NAT = new DataShape(ImmutableSeq.empty(), ImmutableSeq.of(

--- a/base/src/main/java/org/aya/core/repr/AyaShape.java
+++ b/base/src/main/java/org/aya/core/repr/AyaShape.java
@@ -41,7 +41,9 @@ public sealed interface AyaShape {
         new CtorShape(ImmutableSeq.empty()),    // nil
         new CtorShape(ImmutableSeq.of(          // cons A (List A)
           CodeShape.ParamShape.ex(new CodeShape.TermShape.TeleRef(0, 0)),   // A
-          CodeShape.ParamShape.ex(new CodeShape.TermShape.Call(0))))            // List A, TODO: not always List A, improve Call!
+          CodeShape.ParamShape.ex(new CodeShape.TermShape.DataApp(                       // List A
+            new CodeShape.TermShape.Call(0),
+            ImmutableSeq.of(new CodeShape.TermShape.TeleRef(0, 0))))))
       ));
 
     @Override public @NotNull CodeShape codeShape() {

--- a/base/src/main/java/org/aya/core/repr/AyaShape.java
+++ b/base/src/main/java/org/aya/core/repr/AyaShape.java
@@ -34,6 +34,21 @@ public sealed interface AyaShape {
     }
   }
 
+  record AyaListShape() implements AyaShape {
+    public static final @NotNull CodeShape DATA_LIST = new DataShape(
+      ImmutableSeq.of(CodeShape.ParamShape.ex(new CodeShape.TermShape.Sort(null, 0))),
+      ImmutableSeq.of(
+        new CtorShape(ImmutableSeq.empty()),    // nil
+        new CtorShape(ImmutableSeq.of(          // cons A (List A)
+          CodeShape.ParamShape.ex(new CodeShape.TermShape.TeleRef(0, 0)),   // A
+          CodeShape.ParamShape.ex(new CodeShape.TermShape.Call(0))))            // List A, TODO: not always List A, improve Call!
+      ));
+
+    @Override public @NotNull CodeShape codeShape() {
+      return DATA_LIST;
+    }
+  }
+
   class Factory {
     public @NotNull MutableMap<GenericDef, AyaShape> discovered = MutableLinkedHashMap.of();
 

--- a/base/src/main/java/org/aya/core/repr/AyaShape.java
+++ b/base/src/main/java/org/aya/core/repr/AyaShape.java
@@ -21,12 +21,13 @@ public sealed interface AyaShape {
   @NotNull CodeShape codeShape();
 
   @NotNull AyaShape NAT_SHAPE = new AyaIntLitShape();
+  @NotNull AyaShape LIST_SHAPE = new AyaListShape();
   @NotNull ImmutableSeq<AyaShape> LITERAL_SHAPES = ImmutableSeq.of(NAT_SHAPE);
 
   record AyaIntLitShape() implements AyaShape {
     public static final @NotNull CodeShape DATA_NAT = new DataShape(ImmutableSeq.empty(), ImmutableSeq.of(
       new CtorShape(ImmutableSeq.empty()),
-      new CtorShape(ImmutableSeq.of(CodeShape.ParamShape.ex(new CodeShape.TermShape.Call(0))))
+      new CtorShape(ImmutableSeq.of(CodeShape.ParamShape.ex(CodeShape.TermShape.Call.justCall(0))))
     ));
 
     @Override public @NotNull CodeShape codeShape() {
@@ -41,8 +42,8 @@ public sealed interface AyaShape {
         new CtorShape(ImmutableSeq.empty()),    // nil
         new CtorShape(ImmutableSeq.of(          // cons A (List A)
           CodeShape.ParamShape.ex(new CodeShape.TermShape.TeleRef(0, 0)),   // A
-          CodeShape.ParamShape.ex(new CodeShape.TermShape.DataApp(                       // List A
-            new CodeShape.TermShape.Call(0),
+          CodeShape.ParamShape.ex(new CodeShape.TermShape.Call(                          // List A
+            0,
             ImmutableSeq.of(new CodeShape.TermShape.TeleRef(0, 0))))))
       ));
 

--- a/base/src/main/java/org/aya/core/repr/CodeShape.java
+++ b/base/src/main/java/org/aya/core/repr/CodeShape.java
@@ -4,7 +4,7 @@ package org.aya.core.repr;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.core.term.CallTerm;
-import org.aya.core.term.FormTerm;
+import org.aya.generic.SortKind;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -58,11 +58,11 @@ public sealed interface CodeShape {
      *
      * @author hoshino
      * @param kind the SortKind,
-     *             if the kind doesn't {@link FormTerm.SortKind#hasLevel()}, {@param ulift} is ignored during term matching.
+     *             if the kind doesn't {@link SortKind#hasLevel()}, {@param ulift} is ignored during term matching.
      *             null if accept any sort (also omits {@param ulift})
      * @param ulift the lower bound of the type level.
      */
-    record Sort(@Nullable FormTerm.SortKind kind, int ulift) implements TermShape {}
+    record Sort(@Nullable SortKind kind, int ulift) implements TermShape {}
   }
 
   /**

--- a/base/src/main/java/org/aya/core/repr/CodeShape.java
+++ b/base/src/main/java/org/aya/core/repr/CodeShape.java
@@ -3,6 +3,7 @@
 package org.aya.core.repr;
 
 import kala.collection.immutable.ImmutableSeq;
+import org.aya.core.term.CallTerm;
 import org.aya.core.term.FormTerm;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -53,6 +54,12 @@ public sealed interface CodeShape {
      * @param ulift the lower bound of the type level.
      */
     record Sort(@Nullable FormTerm.SortKind kind, int ulift) implements TermShape {}
+
+    /**
+     * @param data the data def reference
+     * @param args corresponds to {@link CallTerm.Data#args()}
+     */
+    record DataApp(@NotNull Call data, @NotNull ImmutableSeq<TermShape> args) implements TermShape {}
   }
 
   /**

--- a/base/src/main/java/org/aya/core/repr/CodeShape.java
+++ b/base/src/main/java/org/aya/core/repr/CodeShape.java
@@ -3,7 +3,9 @@
 package org.aya.core.repr;
 
 import kala.collection.immutable.ImmutableSeq;
+import org.aya.core.term.FormTerm;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author kiva
@@ -40,6 +42,17 @@ public sealed interface CodeShape {
     record Call(int superLevel) implements TermShape {}
 
     record TeleRef(int superLevel, int nth) implements TermShape {}
+
+    /**
+     * The shape to Sort term, I am not very work well at type theory, so improve this feel free!
+     *
+     * @author hoshino
+     * @param kind the SortKind,
+     *             if the kind doesn't {@link FormTerm.SortKind#hasLevel()}, {@param ulift} is ignored during term matching.
+     *             null if accept any sort (also omits {@param ulift})
+     * @param ulift the lower bound of the type level.
+     */
+    record Sort(@Nullable FormTerm.SortKind kind, int ulift) implements TermShape {}
   }
 
   /**

--- a/base/src/main/java/org/aya/core/repr/CodeShape.java
+++ b/base/src/main/java/org/aya/core/repr/CodeShape.java
@@ -5,6 +5,7 @@ package org.aya.core.repr;
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.core.term.CallTerm;
 import org.aya.core.term.FormTerm;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,7 +41,15 @@ public sealed interface CodeShape {
   sealed interface TermShape {
     record Any() implements TermShape {}
 
-    record Call(int superLevel) implements TermShape {}
+    /**
+     * @param superLevel the data def reference
+     * @param args corresponds to {@link CallTerm.Data#args()}
+     */
+    record Call(int superLevel, @NotNull ImmutableSeq<TermShape> args) implements TermShape {
+      @Contract("_ -> new") public static @NotNull Call justCall(int superLevel) {
+        return new Call(superLevel, ImmutableSeq.empty());
+      }
+    }
 
     record TeleRef(int superLevel, int nth) implements TermShape {}
 
@@ -54,12 +63,6 @@ public sealed interface CodeShape {
      * @param ulift the lower bound of the type level.
      */
     record Sort(@Nullable FormTerm.SortKind kind, int ulift) implements TermShape {}
-
-    /**
-     * @param data the data def reference
-     * @param args corresponds to {@link CallTerm.Data#args()}
-     */
-    record DataApp(@NotNull Call data, @NotNull ImmutableSeq<TermShape> args) implements TermShape {}
   }
 
   /**

--- a/base/src/main/java/org/aya/core/repr/CodeShape.java
+++ b/base/src/main/java/org/aya/core/repr/CodeShape.java
@@ -4,6 +4,7 @@ package org.aya.core.repr;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.core.term.CallTerm;
+import org.aya.core.term.Term;
 import org.aya.generic.SortKind;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -57,9 +58,7 @@ public sealed interface CodeShape {
      * The shape to Sort term, I am not very work well at type theory, so improve this feel free!
      *
      * @author hoshino
-     * @param kind the SortKind,
-     *             if the kind doesn't {@link SortKind#hasLevel()}, {@param ulift} is ignored during term matching.
-     *             null if accept any sort (also omits {@param ulift})
+     * @param kind the SortKind, null if accept any kind of sort. see {@link ShapeMatcher#matchTerm(TermShape, Term)}
      * @param ulift the lower bound of the type level.
      */
     record Sort(@Nullable SortKind kind, int ulift) implements TermShape {}

--- a/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
+++ b/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
@@ -12,6 +12,7 @@ import org.aya.core.def.DataDef;
 import org.aya.core.def.Def;
 import org.aya.core.def.GenericDef;
 import org.aya.core.term.CallTerm;
+import org.aya.core.term.FormTerm;
 import org.aya.core.term.RefTerm;
 import org.aya.core.term.Term;
 import org.aya.ref.AnyVar;
@@ -60,6 +61,16 @@ public record ShapeMatcher(
       if (tele == null) return false;
       var teleVar = teleSubst.getOrNull(tele.ref());
       return teleVar == refTerm.var() || tele.ref() == refTerm.var();
+    }
+    if (shape instanceof CodeShape.TermShape.Sort sort && term instanceof FormTerm.Sort sortTerm) {
+      // TODO[hoshino]: Is Set \0-Type ?
+
+      // If kind is null, any sort!
+      return sort.kind() == null ||
+        // If kind is not null, simply comparing
+        (sort.kind() == sortTerm.kind() &&
+          // If the kind doesn't have level, omit the ulift
+          ((! sort.kind().hasLevel()) || sort.ulift() <= sortTerm.lift()));
     }
     return false;
   }

--- a/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
+++ b/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
@@ -72,7 +72,7 @@ public record ShapeMatcher(
       // kind is null -> any sort
       if (sort.kind() == null) return true;
 
-      // TODO
+      // TODO[hoshino]: match kind, but I don't know how to do.
       throw new UnsupportedOperationException("TODO");
     }
     return false;

--- a/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
+++ b/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
@@ -69,14 +69,11 @@ public record ShapeMatcher(
       return teleVar == refTerm.var() || tele.ref() == refTerm.var();
     }
     if (shape instanceof CodeShape.TermShape.Sort sort && term instanceof FormTerm.Sort sortTerm) {
-      // TODO[hoshino]: Is Set \0-Type ?
+      // kind is null -> any sort
+      if (sort.kind() == null) return true;
 
-      // If kind is null, any sort!
-      return sort.kind() == null ||
-        // If kind is not null, simply comparing
-        (sort.kind() == sortTerm.kind() &&
-          // If the kind doesn't have level, omit the ulift
-          ((! sort.kind().hasLevel()) || sort.ulift() <= sortTerm.lift()));
+      // TODO
+      throw new UnsupportedOperationException("TODO");
     }
     return false;
   }

--- a/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
+++ b/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
@@ -72,6 +72,19 @@ public record ShapeMatcher(
           // If the kind doesn't have level, omit the ulift
           ((! sort.kind().hasLevel()) || sort.ulift() <= sortTerm.lift()));
     }
+    if (shape instanceof CodeShape.TermShape.DataApp dataApp && term instanceof CallTerm.Data dataTerm) {
+      var dataDef = def.getOrNull(dataApp.data().superLevel());
+      if (dataDef == null) return false;
+      if (dataDef != dataTerm.ref()) return false;
+      if (dataApp.args().size() != dataTerm.args().size()) return false;      // TODO[hoshino]: do we also match implicit arguments?
+
+      // match each arg
+      // TODO[hoshino]: generalize this.
+      return dataApp.args().zipView(dataTerm.args())
+        .map(t -> matchTerm(t._1, t._2.term()))   // match each term, but lazy
+        .allMatch(x -> x);    // check all term matching
+    }
+
     return false;
   }
 

--- a/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
+++ b/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
@@ -53,12 +53,13 @@ public record ShapeMatcher(
     if (shape instanceof CodeShape.TermShape.Call call && term instanceof CallTerm callTerm) {
       var superLevel = def.getOrNull(call.superLevel());
       if (superLevel != callTerm.ref()) return false;                      // implies null check
-      if (call.args().size() != callTerm.args().size()) return false;      // TODO[hoshino]: do we also match implicit arguments?
+      if (call.args().size() != callTerm.args().size())
+        return false;      // TODO[hoshino]: do we also match implicit arguments?
 
       // match each arg
-      return call.args().zipView(callTerm.args())
-        .map(t -> matchTerm(t._1, t._2.term()))   // match each term, but lazy
-        .allMatch(x -> x);    // check all term matching
+      return call.args().allMatchWith(callTerm.args(),
+        // match each term, but lazy
+        (l, r) -> matchTerm(l, r.term()));
     }
     if (shape instanceof CodeShape.TermShape.TeleRef ref && term instanceof RefTerm refTerm) {
       var superLevel = def.getOrNull(ref.superLevel());

--- a/base/src/main/java/org/aya/core/serde/SerDef.java
+++ b/base/src/main/java/org/aya/core/serde/SerDef.java
@@ -147,16 +147,19 @@ public sealed interface SerDef extends Serializable {
 
   /** serialized {@link AyaShape} */
   enum SerAyaShape implements Serializable {
-    NAT;
+    NAT,
+    LIST;
 
     public @NotNull AyaShape de() {
       return switch (this) {
         case NAT -> AyaShape.NAT_SHAPE;
+        case LIST -> AyaShape.LIST_SHAPE;
       };
     }
 
     public static @NotNull SerAyaShape serialize(@NotNull AyaShape shape) {
       if (shape == AyaShape.NAT_SHAPE) return NAT;
+      if (shape == AyaShape.LIST_SHAPE) return LIST;
       throw new InternalException("unexpected shape: " + shape.getClass());
     }
   }

--- a/base/src/main/java/org/aya/core/serde/SerTerm.java
+++ b/base/src/main/java/org/aya/core/serde/SerTerm.java
@@ -256,6 +256,21 @@ public sealed interface SerTerm extends Serializable, Restr.TermLike<SerTerm> {
     }
   }
 
+  record ShapedList(
+    @NotNull ImmutableSeq<SerTerm> repr,
+    @NotNull SerDef.SerAyaShape shape,
+    @NotNull SerTerm type
+  ) implements SerTerm {
+    @Override
+    public @NotNull Term de(@NotNull DeState state) {
+      var termDesered = repr.map(x -> x.de(state));
+      var shape = shape().de();
+      var type = type().de(state);
+
+      return new LitTerm.ShapedList(termDesered, shape, type);
+    }
+  }
+
   record Str(@NotNull String string) implements SerTerm {
     @Override public @NotNull Term de(@NotNull DeState state) {
       return new PrimTerm.Str(string);

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -82,6 +82,11 @@ public record Serializer(@NotNull Serializer.State state) {
     return switch (term) {
       case LitTerm.ShapedInt lit ->
         new SerTerm.ShapedInt(lit.repr(), SerDef.SerAyaShape.serialize(lit.shape()), serialize(lit.type()));
+      case LitTerm.ShapedList lit ->
+        new SerTerm.ShapedList(
+          lit.repr().map(this::serialize).toImmutableSeq(),
+          SerDef.SerAyaShape.serialize(lit.shape()),
+          serialize(lit.type()));
       case PrimTerm.Mula end -> new SerTerm.Mula(end.asFormula().fmap(this::serialize));
       case PrimTerm.Str str -> new SerTerm.Str(str.string());
       case RefTerm ref -> new SerTerm.Ref(state.local(ref.var()));

--- a/base/src/main/java/org/aya/core/term/LitTerm.java
+++ b/base/src/main/java/org/aya/core/term/LitTerm.java
@@ -34,7 +34,7 @@ public sealed interface LitTerm extends Term {
     @Override @NotNull ImmutableSeq<Term> repr,
     @Override @NotNull AyaShape shape,
     @Override @NotNull Term type
-    ) implements LitTerm, Shaped.List<Term> {
+  ) implements LitTerm, Shaped.List<Term> {
 
     @Override
     public @NotNull Term makeNil(@NotNull CtorDef nil, @NotNull Arg<Term> dataArg) {
@@ -42,9 +42,9 @@ public sealed interface LitTerm extends Term {
     }
 
     @Override
-    public @NotNull Term makeCons(@NotNull CtorDef cons, @NotNull Arg<Term> dataArg, @NotNull Term value, @NotNull Term last) {
+    public @NotNull Term makeCons(@NotNull CtorDef cons, @NotNull Arg<Term> dataArg, @NotNull Term x, @NotNull Term last) {
       return new CallTerm.Con(cons.dataRef, cons.ref(), ImmutableSeq.of(dataArg), 0, ImmutableSeq.of(
-        new Arg<>(value, true),
+        new Arg<>(x, true),
         new Arg<>(last, true)
       ));
     }

--- a/base/src/main/java/org/aya/core/term/LitTerm.java
+++ b/base/src/main/java/org/aya/core/term/LitTerm.java
@@ -50,17 +50,6 @@ public sealed interface LitTerm extends Term {
       ));
     }
 
-
-
-    // TODO[hoshino]: move to Shaped.List<T>
-    public boolean compareUntyped(@NotNull TermComparator comparator, @NotNull Shaped.List<Term> other) {
-      var rhsRepr = other.repr();
-      if (! repr().sizeEquals(rhsRepr)) return false;
-      return repr().view().zip(rhsRepr)
-        .foldLeft(true, (l, tuple) ->
-          l && comparator.compare(tuple._1, tuple._2, null));
-    }
-
     @Override
     public @NotNull Term destruct(@NotNull ImmutableSeq<Term> repr) {
       return new ShapedList(repr, shape(), type());

--- a/base/src/main/java/org/aya/core/term/LitTerm.java
+++ b/base/src/main/java/org/aya/core/term/LitTerm.java
@@ -7,7 +7,6 @@ import org.aya.core.def.CtorDef;
 import org.aya.core.repr.AyaShape;
 import org.aya.generic.Arg;
 import org.aya.generic.Shaped;
-import org.aya.tyck.unify.TermComparator;
 import org.jetbrains.annotations.NotNull;
 
 public sealed interface LitTerm extends Term {

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -135,6 +135,15 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits Cal
         if (type == shaped.type()) yield shaped;
         yield new LitTerm.ShapedInt(shaped.repr(), shaped.shape(), type);
       }
+      case LitTerm.ShapedList shaped -> {
+        var type = f.apply(shaped.type());
+        var elements = shaped.repr().map(f).toImmutableSeq();
+
+        if (type == shaped.type()
+          && elements.sameElements(shaped.repr())) yield shaped;
+
+        yield new LitTerm.ShapedList(elements, shaped.shape(), type);
+      }
       case FormTerm.PartTy ty -> {
         var type = f.apply(ty.type());
         var restr = ty.restr().map(f);

--- a/base/src/main/java/org/aya/distill/BaseDistiller.java
+++ b/base/src/main/java/org/aya/distill/BaseDistiller.java
@@ -235,6 +235,10 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
     return Doc.linkRef(Doc.styled(color, Doc.plain(String.valueOf(literal))), ref.hashCode());
   }
 
+  public static @NotNull Doc linkListLit(Doc display, @NotNull AnyVar ref, @NotNull Style color) {
+    return Doc.linkDef(Doc.styled(color, display), ref.hashCode());
+  }
+
   public static @NotNull Doc linkDef(@NotNull AnyVar ref) {
     return Doc.linkDef(Doc.plain(ref.name()), ref.hashCode());
   }

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -159,6 +159,17 @@ public class CoreDistiller extends BaseDistiller<Term> {
           ? linkLit(0, zero.ref, CON_CALL)
           : linkLit(shaped.repr(), suc.ref, CON_CALL),
         () -> Doc.plain(String.valueOf(shaped.repr())));
+      case LitTerm.ShapedList shaped -> {
+        var display = Doc.sep(
+          Doc.symbol("["),
+          Doc.commaList(shaped.repr().map(x -> term(Outer.Free, x))),
+          Doc.symbol("]"));
+
+        yield shaped.with((nil, cons, dataArg) -> {
+          // link to data, i think.
+          return linkListLit(display, nil.dataRef, DATA_CALL);   // Maybe we should use other style.
+        }, () -> display);
+      }
       case PrimTerm.Str str -> Doc.plain("\"" + StringUtil.escapeStringCharacters(str.string()) + "\"");
       case FormTerm.PartTy ty -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "Partial"),
         term(Outer.AppSpine, ty.type()), Doc.parened(restr(options, ty.restr()))), Outer.AppSpine);

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -164,7 +164,7 @@ public class CoreDistiller extends BaseDistiller<Term> {
 
         yield shaped.with((nil, cons, dataArg) -> Doc.sep(
           linkListLit(Doc.symbol("["), nil.ref(), CON_CALL),
-          Doc.join(linkListLit(Doc.COMMA, cons.ref(), CON_CALL)),
+          Doc.join(linkListLit(Doc.COMMA, cons.ref(), CON_CALL), subterms),
           linkListLit(Doc.symbol("]"), nil.ref(), CON_CALL)
         ), () -> Doc.sep(
           Doc.symbol("["),

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -169,7 +169,8 @@ public class CoreDistiller extends BaseDistiller<Term> {
         ), () -> Doc.sep(
           Doc.symbol("["),
           Doc.commaList(subterms),
-          Doc.symbol("]")));
+          Doc.symbol("]"))
+        );
       }
       case PrimTerm.Str str -> Doc.plain("\"" + StringUtil.escapeStringCharacters(str.string()) + "\"");
       case FormTerm.PartTy ty -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "Partial"),

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -160,15 +160,16 @@ public class CoreDistiller extends BaseDistiller<Term> {
           : linkLit(shaped.repr(), suc.ref, CON_CALL),
         () -> Doc.plain(String.valueOf(shaped.repr())));
       case LitTerm.ShapedList shaped -> {
-        var display = Doc.sep(
-          Doc.symbol("["),
-          Doc.commaList(shaped.repr().map(x -> term(Outer.Free, x))),
-          Doc.symbol("]"));
+        var subterms = shaped.repr().map(x -> term(Outer.Free, x));
 
-        yield shaped.with((nil, cons, dataArg) -> {
-          // link to data, i think.
-          return linkListLit(display, nil.dataRef, DATA_CALL);   // Maybe we should use other style.
-        }, () -> display);
+        yield shaped.with((nil, cons, dataArg) -> Doc.sep(
+          linkListLit(Doc.symbol("["), nil.ref(), CON_CALL),
+          Doc.join(linkListLit(Doc.COMMA, cons.ref(), CON_CALL)),
+          linkListLit(Doc.symbol("]"), nil.ref(), CON_CALL)
+        ), () -> Doc.sep(
+          Doc.symbol("["),
+          Doc.commaList(subterms),
+          Doc.symbol("]")));
       }
       case PrimTerm.Str str -> Doc.plain("\"" + StringUtil.escapeStringCharacters(str.string()) + "\"");
       case FormTerm.PartTy ty -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "Partial"),

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -102,26 +102,11 @@ public interface Shaped<T> {
 
     private @Nullable CallTerm.Data solved(@Nullable TyckState state) {
       var type = type();
+      if (state != null) type = type.normalize(state, NormalizeMode.WHNF);
       // already reported as UnsolvedMeta
       if (type instanceof ErrorTerm) return null;
       if (type instanceof CallTerm.Data data) return data;
-      if (type instanceof CallTerm.Hole hole) {
-        if (state == null) return null;
-        var sol = findSolution(state, hole);
-        if (sol instanceof CallTerm.Data data) return data;
-        // report ill-typed solution? is this possible?
-        throw new InternalException("unknown type for literal");
-      }
       throw new InternalException("unknown type for literal");
-    }
-
-    private @Nullable Term findSolution(@NotNull TyckState state, @NotNull Term maybeHole) {
-      if (maybeHole instanceof CallTerm.Hole hole) {
-        var sol = state.metas().getOrNull(hole.ref());
-        if (sol == null) return null;
-        else return findSolution(state, sol);
-      }
-      return maybeHole;
     }
   }
 
@@ -196,26 +181,11 @@ public interface Shaped<T> {
 
     private @Nullable CallTerm.Data solved(@Nullable TyckState state) {
       var type = type();
+      if (state != null) type = type.normalize(state, NormalizeMode.WHNF);
       // already reported as UnsolvedMeta
       if (type instanceof ErrorTerm) return null;
       if (type instanceof CallTerm.Data data) return data;
-      if (type instanceof CallTerm.Hole hole) {
-        if (state == null) return null;
-        var sol = findSolution(state, hole);
-        if (sol instanceof CallTerm.Data data) return data;
-        // report ill-typed solution? is this possible?
-        throw new InternalException("unknown type for literal");
-      }
       throw new InternalException("unknown type for literal");
-    }
-
-    private @Nullable Term findSolution(@NotNull TyckState state, @NotNull Term maybeHole) {
-      if (maybeHole instanceof CallTerm.Hole hole) {
-        var sol = state.metas().getOrNull(hole.ref());
-        if (sol == null) return null;
-        else return findSolution(state, sol);
-      }
-      return maybeHole;
     }
 
     /// endregion

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -21,9 +21,10 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 /**
- * <h2> What should I do if I create a new Shape? </h2>
+ * <h2> What should I do after I creating a new Shape? </h2>
  * <ul>
- *   <li>impl your Shape, see {@link org.aya.core.term.LitTerm.ShapedInt}, and do everything you should after you creating a Term.</l1>
+ *   <li>impl your Shape, see {@link org.aya.core.term.LitTerm.ShapedInt},
+ *   and do everything you should after you creating a {@link Term}/{@link Pat}.</l1>
  *   <li>impl TermComparator, see {@link TermComparator#doCompareUntyped(Term, Term, TermComparator.Sub, TermComparator.Sub)}</li>
  *   <li>impl PatMatcher, see {@link org.aya.core.pat.PatMatcher#match(Pat, Term)}</li>
  *   <li>impl PatUnifier, see {@link org.aya.core.pat.PatUnify#unify(Pat, Pat)}</li>

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -118,26 +118,31 @@ public interface Shaped<T> {
     @NotNull T makeCons(@NotNull CtorDef cons, @NotNull Arg<Term> type, T value, T last);
     @NotNull T destruct(@NotNull ImmutableSeq<T> repr);
 
-    // TODO[hoshino]: I hope that I have a `SomeComparator.compare : T -> O -> Boolean`
-    //                TermComparator : Term -> Term -> Boolean
-    //                PatUnifier     : Pat  -> Pat  -> Boolean
-    //                PatMatcher     : Pat  -> Term -> Boolean
     default <O> boolean compareShape(@NotNull TermComparator comparator, @NotNull Shaped<O> other) {
       if (shape() != other.shape()) return false;
       if (!(other instanceof Shaped.List<?> otherData)) return false;
-      return comparator.compare(type(), otherData.type(), null);   // TODO[hoshino]: I don't know whether it is true.
+      return comparator.compare(type(), otherData.type(), null);   // TODO[hoshino]: I don't know whether it is correct.
     }
 
+    /**
+     * Comparing two List
+     *
+     * @param other      another list
+     * @param comparator a comparator that should compare the subterms between two List.
+     * @return true if they matches (a term matches a pat or two terms are equivalent,
+     * which depends on the type parameters {@link T} and {@link O}), false if otherwise.
+     */
     default <O> boolean compareUntyped(@NotNull Shaped.List<O> other, @NotNull BiFunction<T, O, Boolean> comparator) {
+      var lhsRepr = repr();
       var rhsRepr = other.repr();
-      if (! repr().sizeEquals(rhsRepr)) return false;
-      return repr().view().zip(rhsRepr)
+      if (!lhsRepr.sizeEquals(rhsRepr)) return false;    // the size should equal.
+      return lhsRepr.zip(rhsRepr)
         .foldLeft(true, (l, tuple) ->
           l && comparator.apply(tuple._1, tuple._2));
     }
 
     /// region Copied from Shaped.Nat
-    /// FIXME: see above
+    /// FIXME: see above, maybe move these to Shaped.Data
 
     @Override
     default @NotNull T constructorForm(@Nullable TyckState state) {

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -114,7 +114,7 @@ public interface Shaped<T> {
   non-sealed interface List<T> extends Inductive<T> {
     @NotNull ImmutableSeq<T> repr();
     @NotNull T makeNil(@NotNull CtorDef nil, @NotNull Arg<Term> type);
-    @NotNull T makeCons(@NotNull CtorDef cons, @NotNull Arg<Term> type, T value, T last);
+    @NotNull T makeCons(@NotNull CtorDef cons, @NotNull Arg<Term> type, T x, T xs);
     @NotNull T destruct(@NotNull ImmutableSeq<T> repr);
 
     /**
@@ -141,7 +141,8 @@ public interface Shaped<T> {
       return with(state, (nil, cons, dataArg) -> {
         var elements = repr();
         if (elements.isEmpty()) return makeNil(nil, dataArg);
-        return makeCons(cons, dataArg, elements.first(), destruct(elements.drop(1)));
+        return makeCons(cons, dataArg, elements.first(),
+          destruct(elements.drop(1)));
       }, () -> {
         // TODO[literal]: how to handle this?
         throw new InternalException("trying to make constructor form without type solved");

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -128,6 +128,14 @@ public interface Shaped<T> {
       return comparator.compare(type(), otherData.type(), null);   // TODO[hoshino]: I don't know whether it is true.
     }
 
+    default <O> boolean compareUntyped(@NotNull Shaped.List<O> other, @NotNull BiFunction<T, O, Boolean> comparator) {
+      var rhsRepr = other.repr();
+      if (! repr().sizeEquals(rhsRepr)) return false;
+      return repr().view().zip(rhsRepr)
+        .foldLeft(true, (l, tuple) ->
+          l && comparator.apply(tuple._1, tuple._2));
+    }
+
     /// region Copied from Shaped.Nat
     /// FIXME: see above
 

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
 /**
@@ -121,17 +122,15 @@ public interface Shaped<T> {
      *
      * @param other      another list
      * @param comparator a comparator that should compare the subterms between two List.
-     * @return true if they matches (a term matches a pat or two terms are equivalent,
+     * @return true if they match (a term matches a pat or two terms are equivalent,
      * which depends on the type parameters {@link T} and {@link O}), false if otherwise.
      */
-    default <O> boolean compareUntyped(@NotNull Shaped.List<O> other, @NotNull BiFunction<T, O, Boolean> comparator) {
+    default <O> boolean compareUntyped(@NotNull Shaped.List<O> other, @NotNull BiPredicate<T, O> comparator) {
       var lhsRepr = repr();
       var rhsRepr = other.repr();
       // the size should equal.
       if (!lhsRepr.sizeEquals(rhsRepr)) return false;
-      return lhsRepr.zip(rhsRepr)
-        .foldLeft(true, (l, tuple) ->
-          l && comparator.apply(tuple._1, tuple._2));
+      return lhsRepr.allMatchWith(rhsRepr, comparator);
     }
 
     /// region Copied from Shaped.Nat

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -5,6 +5,7 @@ package org.aya.generic;
 import kala.collection.immutable.ImmutableSeq;
 import kala.function.TriFunction;
 import org.aya.core.def.CtorDef;
+import org.aya.core.pat.Pat;
 import org.aya.core.repr.AyaShape;
 import org.aya.core.term.CallTerm;
 import org.aya.core.term.ErrorTerm;
@@ -19,6 +20,16 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
+/**
+ * <h2> What should I do if I create a new Shape? </h2>
+ * <ul>
+ *   <l1>impl your Shape, see {@link org.aya.core.term.LitTerm.ShapedInt}, and do everything you should after you creating a Term.</l1>
+ *   <li>impl TermComparator, see {@link TermComparator#doCompareUntyped(Term, Term, TermComparator.Sub, TermComparator.Sub)}</li>
+ *   <li>impl PatMatcher, see {@link org.aya.core.pat.PatMatcher#match(Pat, Term)}</li>
+ *   <li>impl PatUnifier, see {@link org.aya.core.pat.PatUnify#unify(Pat, Pat)}</li>
+ * </ul>
+ * @param <T>
+ */
 public interface Shaped<T> {
   @NotNull AyaShape shape();
   @NotNull Term type();

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
  *   <li>impl PatMatcher, see {@link org.aya.core.pat.PatMatcher#match(Pat, Term)}</li>
  *   <li>impl PatUnifier, see {@link org.aya.core.pat.PatUnify#unify(Pat, Pat)}</li>
  * </ul>
+ *
  * @param <T>
  */
 public interface Shaped<T> {
@@ -133,7 +134,7 @@ public interface Shaped<T> {
     default <O> boolean compareShape(@NotNull TermComparator comparator, @NotNull Shaped<O> other) {
       if (shape() != other.shape()) return false;
       if (!(other instanceof Shaped.List<?> otherData)) return false;
-      return comparator.compare(type(), otherData.type(), null);   // TODO[hoshino]: I don't know whether it is correct.
+      return comparator.compare(type(), otherData.type(), null);
     }
 
     /**
@@ -147,7 +148,8 @@ public interface Shaped<T> {
     default <O> boolean compareUntyped(@NotNull Shaped.List<O> other, @NotNull BiFunction<T, O, Boolean> comparator) {
       var lhsRepr = repr();
       var rhsRepr = other.repr();
-      if (!lhsRepr.sizeEquals(rhsRepr)) return false;    // the size should equal.
+      // the size should equal.
+      if (!lhsRepr.sizeEquals(rhsRepr)) return false;
       return lhsRepr.zip(rhsRepr)
         .foldLeft(true, (l, tuple) ->
           l && comparator.apply(tuple._1, tuple._2));

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -48,9 +48,9 @@ public interface Shaped<T> {
       var type = type();
       if (state != null) type = type.normalize(state, NormalizeMode.WHNF);
       // already reported as UnsolvedMeta
-      if (type instanceof ErrorTerm) return null;
+      if (type instanceof ErrorTerm || type instanceof CallTerm.Hole) return null;
       if (type instanceof CallTerm.Data data) return data;
-      throw new InternalException("unknown type for literal");
+      throw new InternalException("unknown type for literal of type " + type);
     }
 
     default <O> boolean compareShape(TermComparator comparator, @NotNull Shaped<O> other) {

--- a/base/src/main/java/org/aya/generic/Shaped.java
+++ b/base/src/main/java/org/aya/generic/Shaped.java
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
 /**
  * <h2> What should I do if I create a new Shape? </h2>
  * <ul>
- *   <l1>impl your Shape, see {@link org.aya.core.term.LitTerm.ShapedInt}, and do everything you should after you creating a Term.</l1>
+ *   <li>impl your Shape, see {@link org.aya.core.term.LitTerm.ShapedInt}, and do everything you should after you creating a Term.</l1>
  *   <li>impl TermComparator, see {@link TermComparator#doCompareUntyped(Term, Term, TermComparator.Sub, TermComparator.Sub)}</li>
  *   <li>impl PatMatcher, see {@link org.aya.core.pat.PatMatcher#match(Pat, Term)}</li>
  *   <li>impl PatUnifier, see {@link org.aya.core.pat.PatUnify#unify(Pat, Pat)}</li>

--- a/base/src/main/java/org/aya/resolve/visitor/ExprResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/ExprResolver.java
@@ -131,13 +131,11 @@ public record ExprResolver(
         },
         right -> {
           var exprs = right.exprList().map(e -> resolve(e, ctx));
-          var nilCtor = resolve(right.nilCtor(), ctx);
-          var consCtor = resolve(right.consCtor(), ctx);
 
-          if (exprs.sameElements(right.exprList()) && nilCtor == right.nilCtor() && consCtor == right.consCtor()) {
+          if (exprs.sameElements(right.exprList())) {
             return arrayExpr;
           } else {
-            return Expr.Array.newList(arrayExpr.sourcePos(), exprs, nilCtor, consCtor);
+            return Expr.Array.newList(arrayExpr.sourcePos(), exprs);
           }
         }
       );

--- a/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
@@ -20,7 +20,6 @@ import org.aya.resolve.ResolveInfo;
 import org.aya.resolve.context.Context;
 import org.aya.resolve.error.NameProblem;
 import org.aya.tyck.order.TyckOrder;
-import org.aya.tyck.pat.PatternProblem;
 import org.aya.util.binop.OpDecl;
 import org.aya.util.error.SourcePos;
 import org.aya.util.reporter.Problem;
@@ -262,22 +261,9 @@ public interface StmtResolver {
         // resolve subpatterns
         var subpats = list.elements().map(x -> subpatterns(newCtx, x));
 
-        // resolve ctors (these resolving won't change context, maybe...)
-        var nilPat = resolve(list.nilName(), newCtx.get());
-        var consPat = resolve(list.consName(), newCtx.get());
-
-        // check both patterns
-
-        if (!(nilPat._2 instanceof Pattern.Ctor))
-          resolvingInterrupt(context.reporter(), new PatternProblem.UnknownCtor(list.nilName()));
-        if (!(consPat._2 instanceof Pattern.Ctor))
-          resolvingInterrupt(context.reporter(), new PatternProblem.UnknownCtor(list.consName()));
-
-        // now both patterns are Ctors
-
         yield Tuple.of(
           bindAs(list.as(), newCtx.get(), list.sourcePos()),
-          new Pattern.List(list.sourcePos(), list.explicit(), subpats, list.as(), nilPat._2, consPat._2));
+          new Pattern.List(list.sourcePos(), list.explicit(), subpats, list.as()));
       }
       default -> Tuple.of(context, pattern);
     };

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -5,7 +5,6 @@ package org.aya.tyck;
 import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableMap;
 import kala.collection.immutable.ImmutableSeq;
-import kala.collection.mutable.MutableArrayList;
 import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableMap;
 import kala.tuple.Tuple;
@@ -288,17 +287,8 @@ public final class ExprTycker extends Tycker {
           new Arg<>(hole._1, dataParam.explicit())));
 
         // do type check
-        var wellTypeds = MutableArrayList.<Term>create(elements.size());
-
-        for (var element : elements) {
-          var result = inherit(element, hole._1);
-
-          // imkiva        : It's ok to push ErrorTerms to that list and typecheck the remaining elements.
-          // future hoshino: Right, the `fail` will `report` the error.
-          wellTypeds.append(result.wellTyped());
-        }
-
-        yield new TermResult(new LitTerm.ShapedList(wellTypeds.toImmutableSeq(), AyaShape.LIST_SHAPE, type), type);
+        var results = elements.map(element -> inherit(element, hole._1).wellTyped());
+        yield new TermResult(new LitTerm.ShapedList(results, AyaShape.LIST_SHAPE, type), type);
       }
       default -> fail(expr, new NoRuleError(expr, null));
     };
@@ -412,7 +402,7 @@ public final class ExprTycker extends Tycker {
 
   private @NotNull Result doInherit(@NotNull Expr expr, @NotNull Term term) {
     return switch (expr) {
-      case Expr.TupExpr (var pos, var it) -> {
+      case Expr.TupExpr(var pos, var it) -> {
         var items = MutableList.<Term>create();
         var resultTele = MutableList.<Term.@NotNull Param>create();
         var typeWHNF = whnf(term);
@@ -485,7 +475,7 @@ public final class ExprTycker extends Tycker {
           default -> fail(lam, term, BadTypeError.pi(state, lam, term));
         };
       }
-      case Expr.LitIntExpr (var pos, var end) -> {
+      case Expr.LitIntExpr(var pos, var end) -> {
         var ty = whnf(term);
         if (ty instanceof PrimTerm.Interval) {
           if (end == 0 || end == 1) yield new TermResult(end == 0 ? PrimTerm.Mula.LEFT : PrimTerm.Mula.RIGHT, ty);

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -293,8 +293,8 @@ public final class ExprTycker extends Tycker {
         for (var element : elements) {
           var result = inherit(element, hole._1);
 
-          // imkiva   : It's ok to push ErrorTerms to that list and typecheck the remaining elements.
-          // future me: Right, the `fail` will `report` the error.
+          // imkiva        : It's ok to push ErrorTerms to that list and typecheck the remaining elements.
+          // future hoshino: Right, the `fail` will `report` the error.
           wellTypeds.append(result.wellTyped());
         }
 

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -272,7 +272,7 @@ public final class ExprTycker extends Tycker {
       });
       case Expr.Array arr when arr.arrayBlock().isRight() -> {
         var arrayBlock = arr.arrayBlock().getRightValue();
-        var elements = arrayBlock.exprList().view();
+        var elements = arrayBlock.exprList();
 
         // find def
         var defs = shapeFactory.findImpl(AyaShape.LIST_SHAPE);
@@ -293,7 +293,8 @@ public final class ExprTycker extends Tycker {
         for (var element : elements) {
           var result = inherit(element, hole._1);
 
-          if (result.wellTyped() instanceof ErrorTerm || result.type() instanceof ErrorTerm) yield result;
+          // imkiva   : It's ok to push ErrorTerms to that list and typecheck the remaining elements.
+          // future me: Right, the `fail` will `report` the error.
           wellTypeds.append(result.wellTyped());
         }
 

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -77,6 +77,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       case PrimTerm.Mula end -> PrimTerm.Interval.INSTANCE;
       case PrimTerm.Str str -> state.primFactory().getCall(PrimDef.ID.STRING);
       case LitTerm.ShapedInt shaped -> shaped.type();
+      case LitTerm.ShapedList shaped -> shaped.type();
       case FormTerm.PartTy ty -> FormTerm.Type.ZERO;
       case IntroTerm.PartEl el -> new FormTerm.PartTy(el.rhsType(), el.partial().restr());
       case FormTerm.Path path -> FormTerm.Type.ZERO;

--- a/base/src/main/java/org/aya/tyck/error/LiteralError.java
+++ b/base/src/main/java/org/aya/tyck/error/LiteralError.java
@@ -4,14 +4,11 @@ package org.aya.tyck.error;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.concrete.Expr;
-import org.aya.concrete.Pattern;
 import org.aya.core.def.GenericDef;
-import org.aya.core.term.Term;
 import org.aya.generic.ExprProblem;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.doc.Style;
 import org.aya.util.distill.DistillerOptions;
-import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 
 public interface LiteralError extends TyckError {
@@ -23,41 +20,13 @@ public interface LiteralError extends TyckError {
       return Doc.vcat(
         Doc.english("More than one types can be used to encode the literal:"),
         Doc.par(1, expr.toDoc(options)),
-        Doc.english("Candidates are:"),
+        Doc.plain("Candidates:"),
         Doc.par(1, Doc.join(Doc.plain(", "), defs.map(d -> Doc.styled(Style.code(), d.ref().name()))))
       );
     }
 
     @Override public @NotNull Doc hint(@NotNull DistillerOptions options) {
       return Doc.english("Specify the type explicitly can resolve the ambiguity.");
-    }
-  }
-
-  record BadLitPattern(
-    @NotNull SourcePos sourcePos,
-    int integer,
-    @NotNull Term type
-  ) implements LiteralError {
-    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
-      return Doc.vcat(Doc.english("The literal"),
-        Doc.par(1, Doc.plain(String.valueOf(integer))),
-        Doc.english("cannot be encoded as a term of type:"),
-        Doc.par(1, type.toDoc(options)));
-    }
-  }
-
-  record BadListPattern(
-    @NotNull SourcePos sourcePos,
-    Pattern.List pattern,
-    @NotNull Term type
-  ) implements LiteralError {
-
-    @Override
-    public @NotNull Doc describe(@NotNull DistillerOptions options) {
-      return Doc.vcat(Doc.english("The literal"),
-        Doc.par(1, pattern.toDoc(options)),
-        Doc.english("cannot be encoded as a term of type:"),
-        Doc.par(1, type.toDoc(options)));
     }
   }
 }

--- a/base/src/main/java/org/aya/tyck/error/LiteralError.java
+++ b/base/src/main/java/org/aya/tyck/error/LiteralError.java
@@ -4,6 +4,7 @@ package org.aya.tyck.error;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.concrete.Expr;
+import org.aya.concrete.Pattern;
 import org.aya.core.def.GenericDef;
 import org.aya.core.term.Term;
 import org.aya.generic.ExprProblem;
@@ -40,6 +41,21 @@ public interface LiteralError extends TyckError {
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
       return Doc.vcat(Doc.english("The literal"),
         Doc.par(1, Doc.plain(String.valueOf(integer))),
+        Doc.english("cannot be encoded as a term of type:"),
+        Doc.par(1, type.toDoc(options)));
+    }
+  }
+
+  record BadListPattern(
+    @NotNull SourcePos sourcePos,
+    Pattern.List pattern,
+    @NotNull Term type
+  ) implements LiteralError {
+
+    @Override
+    public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.vcat(Doc.english("The literal"),
+        Doc.par(1, pattern.toDoc(options)),
         Doc.english("cannot be encoded as a term of type:"),
         Doc.par(1, type.toDoc(options)));
     }

--- a/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
@@ -226,7 +226,7 @@ public record AyaSccTycker(
       .filter(u -> selfReferencing(resolveInfo.depGraph(), u))
       .map(TyckOrder::unit);
     if (recDefs.isEmpty()) return;
-    // TODO: terck other definitions
+    // TODO: positivity check for data/record definitions
     var fn = recDefs.filterIsInstance(TeleDecl.FnDecl.class)
       .map(f -> f.ref.core);
     terckRecursiveFn(fn);

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -291,7 +291,7 @@ public record PatClassifier(
           var hasBind = nonEmpty.filter(subPats -> head(subPats) instanceof Pat.Bind);
           if (hasLit.isNotEmpty() && hasBind.isNotEmpty() && hasLit.size() + hasBind.size() == nonEmpty.size()) {
             // We are in the base case -- group literals by their values, and add all bind patterns to each group.
-            var lits = hasLit.stream()
+            var lits = hasLit
               .collect(Collectors.groupingBy(subPats -> ((Pat.ShapedInt) head(subPats)).repr()))
               .values().stream()
               .map(ImmutableSeq::from)

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -215,7 +215,7 @@ public final class PatTycker {
         if (ty instanceof CallTerm.Data dataCall) {
           var data = dataCall.ref().core;
           var shape = exprTycker.shapeFactory.find(data);
-          if (shape.isDefined()) yield new Pat.ShapedInt(num.number(), shape.get(), dataCall, num.explicit());
+          if (shape.isDefined() && shape.get() == AyaShape.NAT_SHAPE) yield new Pat.ShapedInt(num.number(), shape.get(), dataCall, num.explicit());
         }
         yield withError(new LiteralError.BadLitPattern(num.sourcePos(), num.number(), term), num, term);
       }
@@ -258,7 +258,7 @@ public final class PatTycker {
           }
         }
 
-        // TODO[hoshino]
+        // TODO[hoshino]: create a new LiteralError
         yield withError(new LiteralError.BadLitPattern(list.sourcePos(), -1, term), list, term);
       }
       case Pattern.BinOpSeq binOpSeq -> throw new InternalException("BinOpSeq patterns should be desugared");

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -215,7 +215,8 @@ public final class PatTycker {
         if (ty instanceof CallTerm.Data dataCall) {
           var data = dataCall.ref().core;
           var shape = exprTycker.shapeFactory.find(data);
-          if (shape.isDefined() && shape.get() == AyaShape.NAT_SHAPE) yield new Pat.ShapedInt(num.number(), shape.get(), dataCall, num.explicit());
+          if (shape.isDefined() && shape.get() == AyaShape.NAT_SHAPE)
+            yield new Pat.ShapedInt(num.number(), shape.get(), dataCall, num.explicit());
         }
         yield withError(new LiteralError.BadLitPattern(num.sourcePos(), num.number(), term), num, term);
       }
@@ -229,11 +230,7 @@ public final class PatTycker {
           var data = dataCall.ref().core;
           var shape = exprTycker.shapeFactory.find(data);
 
-          if (shape.isDefined()) {
-            if (shape.get() != AyaShape.LIST_SHAPE) {
-              yield withError(new LiteralError.BadLitPattern(list.sourcePos(), -114, term), list, term);
-            }
-
+          if (shape.isDefined() && shape.get() == AyaShape.LIST_SHAPE) {
             // prepare
             // FIXME: duplicated code, see Shaped.List#with
             var nilCtor = data.body.find(x -> x.selfTele.sizeEquals(0));
@@ -258,8 +255,7 @@ public final class PatTycker {
           }
         }
 
-        // TODO[hoshino]: create a new LiteralError
-        yield withError(new LiteralError.BadLitPattern(list.sourcePos(), -1, term), list, term);
+        yield withError(new LiteralError.BadListPattern(list.sourcePos(), list, term), list, term);
       }
       case Pattern.BinOpSeq binOpSeq -> throw new InternalException("BinOpSeq patterns should be desugared");
     };

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -36,7 +36,6 @@ import org.aya.ref.LocalVar;
 import org.aya.tyck.ExprTycker;
 import org.aya.tyck.TyckState;
 import org.aya.tyck.env.LocalCtx;
-import org.aya.tyck.error.LiteralError;
 import org.aya.tyck.error.PrimError;
 import org.aya.tyck.error.TyckOrderError;
 import org.aya.tyck.trace.Trace;
@@ -218,7 +217,7 @@ public final class PatTycker {
           if (shape.isDefined() && shape.get() == AyaShape.NAT_SHAPE)
             yield new Pat.ShapedInt(num.number(), shape.get(), dataCall, num.explicit());
         }
-        yield withError(new LiteralError.BadLitPattern(num.sourcePos(), num.number(), term), num, term);
+        yield withError(new PatternProblem.BadLitPattern(num, term), num, term);
       }
       case Pattern.List list -> {
         // desugar `Pattern.List` to `Pattern.Ctor` here, but use `CodeShape` !
@@ -255,7 +254,7 @@ public final class PatTycker {
           }
         }
 
-        yield withError(new LiteralError.BadListPattern(list.sourcePos(), list, term), list, term);
+        yield withError(new PatternProblem.BadLitPattern(list, term), list, term);
       }
       case Pattern.BinOpSeq binOpSeq -> throw new InternalException("BinOpSeq patterns should be desugared");
     };

--- a/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck.pat;
 
@@ -106,7 +106,8 @@ public sealed interface PatternProblem extends Problem {
     }
   }
 
-  record TooManyImplicitPattern(@Override @NotNull Pattern pattern, @NotNull Term.Param param) implements PatternProblem {
+  record TooManyImplicitPattern(@Override @NotNull Pattern pattern,
+                                @NotNull Term.Param param) implements PatternProblem {
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
       return Doc.vcat(
         Doc.english("There are too many implicit patterns:"),
@@ -119,5 +120,17 @@ public sealed interface PatternProblem extends Problem {
 
   @Override default @NotNull Severity level() {
     return Severity.ERROR;
+  }
+
+  record BadLitPattern(
+    @NotNull Pattern pattern,
+    @NotNull Term type
+  ) implements PatternProblem {
+    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.vcat(Doc.english("The literal"),
+        Doc.par(1, pattern.toDoc(options)),
+        Doc.english("cannot be encoded as a term of type:"),
+        Doc.par(1, type.toDoc(options)));
+    }
   }
 }

--- a/base/src/main/java/org/aya/tyck/unify/TermComparator.java
+++ b/base/src/main/java/org/aya/tyck/unify/TermComparator.java
@@ -490,7 +490,7 @@ public sealed abstract class TermComparator permits Unifier {
       }
       case LitTerm.ShapedInt lhs -> switch (preRhs) {
         case LitTerm.ShapedInt rhs -> {
-          if (!lhs.compareShape(state, rhs)) yield null;
+          if (!lhs.compareShape(this, rhs)) yield null;
           if (!lhs.compareUntyped(rhs)) yield null;
           yield lhs.type(); // What about rhs.type()? A: sameValue implies same type
         }

--- a/base/src/main/java/org/aya/tyck/unify/TermComparator.java
+++ b/base/src/main/java/org/aya/tyck/unify/TermComparator.java
@@ -500,7 +500,7 @@ public sealed abstract class TermComparator permits Unifier {
       case LitTerm.ShapedList lhs -> switch (preRhs) {
         case LitTerm.ShapedList rhs -> {
           if (! lhs.compareShape(this, rhs)) yield null;
-          if (! lhs.compareUntyped(this, rhs)) yield null;
+          if (! lhs.compareUntyped(rhs, (l, r) -> compare(l, r, null))) yield null;
 
           yield lhs.type();
         }

--- a/base/src/main/java/org/aya/tyck/unify/TermComparator.java
+++ b/base/src/main/java/org/aya/tyck/unify/TermComparator.java
@@ -500,7 +500,8 @@ public sealed abstract class TermComparator permits Unifier {
       case LitTerm.ShapedList lhs -> switch (preRhs) {
         case LitTerm.ShapedList rhs -> {
           if (! lhs.compareShape(this, rhs)) yield null;
-          if (! lhs.compareUntyped(rhs, (l, r) -> compare(l, r, null))) yield null;
+          if (! lhs.compareUntyped(rhs,
+            (l, r) -> compare(l, r, lr, rl, null))) yield null;
 
           yield lhs.type();
         }

--- a/base/src/main/java/org/aya/tyck/unify/TermComparator.java
+++ b/base/src/main/java/org/aya/tyck/unify/TermComparator.java
@@ -477,6 +477,7 @@ public sealed abstract class TermComparator permits Unifier {
           yield null;
         }
         case LitTerm.ShapedInt rhs -> compareUntyped(lhs, rhs.constructorForm(state), lr, rl);
+        case LitTerm.ShapedList rhs -> compareUntyped(lhs, rhs.constructorForm(state), lr, rl);
         default -> null;
       };
       case CallTerm.Prim lhs -> null;
@@ -493,6 +494,17 @@ public sealed abstract class TermComparator permits Unifier {
           if (!lhs.compareUntyped(rhs)) yield null;
           yield lhs.type(); // What about rhs.type()? A: sameValue implies same type
         }
+        case CallTerm.Con rhs -> compareUntyped(lhs.constructorForm(state), rhs, lr, rl);
+        default -> null;
+      };
+      case LitTerm.ShapedList lhs -> switch (preRhs) {
+        case LitTerm.ShapedList rhs -> {
+          if (! lhs.compareShape(this, rhs)) yield null;
+          if (! lhs.compareUntyped(this, rhs)) yield null;
+
+          yield lhs.type();
+        }
+
         case CallTerm.Con rhs -> compareUntyped(lhs.constructorForm(state), rhs, lr, rl);
         default -> null;
       };

--- a/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
+++ b/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
@@ -48,7 +48,7 @@ public class ShapeMatcherTest {
       data List (A : Type)
         | nil
         | cons A (List False)
-      """);   // FIXME!!
+      """);
   }
 
   public void match(boolean should, @NotNull CodeShape shape, @Language("Aya") @NonNls @NotNull String code) {

--- a/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
+++ b/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
@@ -30,6 +30,27 @@ public class ShapeMatcherTest {
     match(false, AyaShape.AyaIntLitShape.DATA_NAT, "open data Nat | s | z");
   }
 
+  @Test
+  public void matchList() {
+    match(true, AyaShape.AyaListShape.DATA_LIST, "data List (A : Prop) | nil | cons A (List A)");
+    match(true, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | nil | cons A (List A)");
+    match(true, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | cons A (List A) | nil");
+    match(true, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | nil | infixr :< A (List A)");
+
+    match(false, AyaShape.AyaListShape.DATA_LIST, "data List | nil | cons");
+    match(false, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | nil | cons");
+    match(false, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | nil | cons A A");
+    match(false, AyaShape.AyaListShape.DATA_LIST, "data List (A B : Type) | nil | cons A A");
+    match(false, AyaShape.AyaListShape.DATA_LIST, "data List (A B : Type) | nil | cons A B");
+    match(ImmutableSeq.of(false, false), AyaShape.AyaListShape.DATA_LIST, """
+      data False
+      
+      data List (A : Type)
+        | nil
+        | cons A (List False)
+      """);   // FIXME!!
+  }
+
   public void match(boolean should, @NotNull CodeShape shape, @Language("Aya") @NonNls @NotNull String code) {
     var def = TyckDeclTest.successTyckDecls(code)._2;
     def.forEach(d -> assertEquals(should, ShapeMatcher.match(shape, d)));

--- a/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
+++ b/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
@@ -40,6 +40,7 @@ public class ShapeMatcherTest {
     match(false, AyaShape.AyaListShape.DATA_LIST, "data List | nil | cons");
     match(false, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | nil | cons");
     match(false, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | nil | cons A A");
+    match(false, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | nil A | cons A (List A)");
     match(false, AyaShape.AyaListShape.DATA_LIST, "data List (A B : Type) | nil | cons A A");
     match(false, AyaShape.AyaListShape.DATA_LIST, "data List (A B : Type) | nil | cons A B");
     match(ImmutableSeq.of(false, false), AyaShape.AyaListShape.DATA_LIST, """

--- a/base/src/test/resources/failure/patterns/literal-list-bad-inner.aya
+++ b/base/src/test/resources/failure/patterns/literal-list-bad-inner.aya
@@ -1,0 +1,8 @@
+open data List (A : Type) | nil | cons A (List A)
+open data Nat | O | S Nat
+open data Unit | unit
+
+def bad (xs : List Nat) : Nat
+  | [ ] => O
+  | [ [ ] ] => S O
+  | _ => S (S O)

--- a/base/src/test/resources/failure/patterns/literal-list-bad-inner.aya.txt
+++ b/base/src/test/resources/failure/patterns/literal-list-bad-inner.aya.txt
@@ -1,0 +1,14 @@
+In file $FILE:7:6 ->
+
+  5 | def bad (xs : List Nat) : Nat
+  6 |   | [ ] => O
+  7 |   | [ [ ] ] => S O
+            ^-^
+
+Error: The literal
+         [  ]
+       cannot be encoded as a term of type:
+         Nat
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/patterns/literal-list-bad.aya
+++ b/base/src/test/resources/failure/patterns/literal-list-bad.aya
@@ -1,0 +1,6 @@
+open data Nat | O | S Nat
+
+def bad (n : Nat) : Nat
+  | [ ] => O
+  | [ e ] => S O
+  | x => S (S O)

--- a/base/src/test/resources/failure/patterns/literal-list-bad.aya.txt
+++ b/base/src/test/resources/failure/patterns/literal-list-bad.aya.txt
@@ -1,0 +1,26 @@
+In file $FILE:4:4 ->
+
+  2 | 
+  3 | def bad (n : Nat) : Nat
+  4 |   | [ ] => O
+          ^-^
+
+Error: The literal
+         [  ]
+       cannot be encoded as a term of type:
+         Nat
+
+In file $FILE:5:4 ->
+
+  3 | def bad (n : Nat) : Nat
+  4 |   | [ ] => O
+  5 |   | [ e ] => S O
+          ^---^
+
+Error: The literal
+         [ e ]
+       cannot be encoded as a term of type:
+         Nat
+
+2 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tyck/list-type-mismatch.aya
+++ b/base/src/test/resources/failure/tyck/list-type-mismatch.aya
@@ -1,0 +1,5 @@
+open data List (A : Type) | nil | cons A (List A)
+open data Nat | O | S Nat
+open data Mat | zero | suc Mat
+
+def bad => [ O, S O, zero ]

--- a/base/src/test/resources/failure/tyck/list-type-mismatch.aya
+++ b/base/src/test/resources/failure/tyck/list-type-mismatch.aya
@@ -2,4 +2,4 @@ open data List (A : Type) | nil | cons A (List A)
 open data Nat | O | S Nat
 open data Mat | zero | suc Mat
 
-def bad => [ O, S O, zero ]
+def bad => [ O, S O, zero, suc zero ]

--- a/base/src/test/resources/failure/tyck/list-type-mismatch.aya.txt
+++ b/base/src/test/resources/failure/tyck/list-type-mismatch.aya.txt
@@ -2,7 +2,7 @@ In file $FILE:5:21 ->
 
   3 | open data Mat | zero | suc Mat
   4 | 
-  5 | def bad => [ O, S O, zero ]
+  5 | def bad => [ O, S O, zero, suc zero ]
                            ^--^
 
 Error: Cannot check the expression
@@ -12,5 +12,19 @@ Error: Cannot check the expression
        against the type
          Nat
 
-1 error(s), 0 warning(s).
+In file $FILE:5:27 ->
+
+  3 | open data Mat | zero | suc Mat
+  4 | 
+  5 | def bad => [ O, S O, zero, suc zero ]
+                                 ^------^
+
+Error: Cannot check the expression
+         suc zero
+       of type
+         Mat
+       against the type
+         Nat
+
+2 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/tyck/list-type-mismatch.aya.txt
+++ b/base/src/test/resources/failure/tyck/list-type-mismatch.aya.txt
@@ -1,0 +1,16 @@
+In file $FILE:5:21 ->
+
+  3 | open data Mat | zero | suc Mat
+  4 | 
+  5 | def bad => [ O, S O, zero ]
+                           ^--^
+
+Error: Cannot check the expression
+         zero
+       of type
+         Mat
+       against the type
+         Nat
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tyck/list-unknown.aya
+++ b/base/src/test/resources/failure/tyck/list-unknown.aya
@@ -1,0 +1,5 @@
+open data List (A : Type) | nil | cons A (List A)
+open data Unit | unit
+
+def good : List Unit => [ ]
+def bad => [ ]

--- a/base/src/test/resources/failure/tyck/list-unknown.aya.txt
+++ b/base/src/test/resources/failure/tyck/list-unknown.aya.txt
@@ -1,0 +1,23 @@
+In file $FILE:5:11 ->
+
+  3 | 
+  4 | def good : List Unit => [ ]
+  5 | def bad => [ ]
+                 ^-^
+
+Error: Unsolved meta _
+       in `List _`
+
+In file $FILE:5:11 ->
+
+  3 | 
+  4 | def good : List Unit => [ ]
+  5 | def bad => [ ]
+                 ^-^
+
+Error: Unsolved meta _
+       in `List _`
+       in `[  ]`
+
+2 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/tyck/literal-ambiguous-2.aya.txt
+++ b/base/src/test/resources/failure/tyck/literal-ambiguous-2.aya.txt
@@ -7,7 +7,7 @@ In file $FILE:6:17 ->
 
 Error: More than one types can be used to encode the literal:
          0
-       Candidates are:
+       Candidates:
          `Nat1`, `Nat2`
 note: Specify the type explicitly can resolve the ambiguity.
 

--- a/base/src/test/resources/success/src/List.aya
+++ b/base/src/test/resources/success/src/List.aya
@@ -12,6 +12,7 @@ def termDesuList : List Nat => 1 :< (y 2) :< x :< nil
 -- do { a <- [ 1, 2, 3 ], b <- [ 4, 5, 6 ], return (a + b) }
 def termDesuListComp : List Nat => [ 1, 2, 3 ] >>= (\ a => [ 4, 5, 6 ] >>= (\ b => pure (a + b)))
 
+def testSimpleList : [ 4, 5, 6 ] = [ 4, 5, 6 ] => idp
 def testDesuList : termList = termDesuList => idp
 def testDesuListComp : termListComp = termDesuListComp => idp
 

--- a/base/src/test/resources/success/src/List2.aya
+++ b/base/src/test/resources/success/src/List2.aya
@@ -1,0 +1,21 @@
+open import Arith::Nat
+open import Paths
+
+-- This test make sure that `Pattern.List` did desugar to `Pattern.Ctor` with CodeShape instead of `nil` and `:<`
+
+open data SomeList (A : Type) | cons A (SomeList A) | empty
+
+def simpleMatch (x : SomeList Nat) : SomeList Nat
+| [ ] => empty
+| [ 1 ] => cons 1 empty
+| [ 1, e2 ] => cons 1 (cons e2 empty)
+| [ 1, e2, _ ] as l' => l'
+| [ _, _, _, _ ] as l' => l'
+| _ => x
+
+def testSimpleMatch0 : simpleMatch [ ] = empty => idp
+def testSimpleMatch1 : simpleMatch [ 1 ] = [ 1 ] => idp
+def testSimpleMatch2 : simpleMatch [ 1, 1 ] = [ 1, 1 ] => idp
+def testSimpleMatch3 : simpleMatch [ 1, 1, 4 ] = [ 1, 1, 4 ] => idp
+def testSimpleMatch4 : simpleMatch [ 1, 9, 1, 9 ] = [ 1, 9, 1, 9 ] => idp
+def testSimpleMatch5 : simpleMatch [ 1, 9, 1, 9, 8, 1, 0 ] = [ 1, 9, 1, 9, 8, 1, 0 ] => idp

--- a/base/src/test/resources/success/src/List2.aya
+++ b/base/src/test/resources/success/src/List2.aya
@@ -1,7 +1,7 @@
 open import Arith::Nat
 open import Paths
 
--- This test make sure that `Pattern.List` did desugar to `Pattern.Ctor` with CodeShape instead of `nil` and `:<`
+-- This test makes sure that `Pattern.List` DO desugar to `Pattern.Ctor` with CodeShape instead of `nil` and `:<`
 
 open data SomeList (A : Type) | cons A (SomeList A) | empty
 

--- a/cli/src/main/java/org/aya/cli/parse/AyaGKProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaGKProducer.java
@@ -737,16 +737,9 @@ public record AyaGKProducer(
 
       var weakId = node.peekChild(WEAK_ID);
       var asId = weakId == null ? null : LocalVar.from(weakId(weakId));
-      var nilBind = new Pattern.Bind(sourcePos, true,
-        new LocalVar(Constants.LIST_NIL, sourcePos),
-        MutableValue.create());
-      var consBind = new Pattern.Bind(sourcePos, true,
-        new LocalVar(Constants.LIST_CONS, sourcePos),
-        MutableValue.create());
 
       return ex -> new Pattern.List(sourcePos, ex,
-        patterns.map(f -> f.apply(true, null)).toImmutableSeq(), asId,
-        nilBind, consBind);
+        patterns.map(f -> f.apply(true, null)).toImmutableSeq(), asId);
     }
     if (node.is(ATOM_NUMBER_PATTERN))
       return ex -> new Pattern.Number(sourcePos, ex, Integer.parseInt(node.tokenText()));

--- a/cli/src/main/java/org/aya/cli/parse/AyaGKProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaGKProducer.java
@@ -606,8 +606,7 @@ public record AyaGKProducer(
     if (node.is(ARRAY_ATOM)) {
       var arrayBlock = node.peekChild(ARRAY_BLOCK);
 
-      if (arrayBlock == null)
-        return Expr.Array.newList(pos, ImmutableSeq.empty(), Constants.listNil(pos), Constants.listCons(pos));
+      if (arrayBlock == null) return Expr.Array.newList(pos, ImmutableSeq.empty());
       if (arrayBlock.is(ARRAY_COMP_BLOCK)) return arrayCompBlock(arrayBlock, pos);
       if (arrayBlock.is(ARRAY_ELEMENTS_BLOCK)) return arrayElementList(arrayBlock, pos);
     }
@@ -782,10 +781,8 @@ public record AyaGKProducer(
     var exprs = node.child(EXPR_LIST).childrenOfType(EXPR)
       .map(this::expr)
       .toImmutableSeq();
-    var nilCtor = Constants.listNil(entireSourcePos);
-    var consCtor = Constants.listCons(entireSourcePos);
 
-    return Expr.Array.newList(entireSourcePos, exprs, nilCtor, consCtor);
+    return Expr.Array.newList(entireSourcePos, exprs);
   }
 
   public @NotNull ImmutableSeq<Pattern> patterns(@NotNull GenericNode<?> node) {


### PR DESCRIPTION
- [x] `Expr.Array` -> `LitTerm.ShapedList`
- [ ] ~~`Pattern.List` -> `Pat.ShapedList`~~
- [x] `LitTerm.ShapedList` ser/deser
- [ ] ~~`Pat.ShapedList` ser/deser~~
- [x] Desugar `Pattern.List` with `CodeShape`

~~I think the code is buggy (and not elegant) for [now](https://github.com/aya-prover/aya-dev/tree/4802bad65280ca341125a92b572035688954a9cc), but they passed the tests.~~ I also need some help with the TODOs.

Edit (by @ice1000): there are two missing things in this PR, but it looks pretty good now.

+ [ ] In case `cons` constructor has implicit arguments, we should generate the correct implicitness accordingly.
+ [ ] I think the infrastructure of `Shaped` can be improved. Currently it's a bit wacky as we use `state` from time to time and it is nullable. I think we can do this: there is a thing "unknown type literal" that bans `constructorForm` and the type is a hole, and "known type literal" which does not need a `state` in `constructorForm` and the type is `DataCall`. When we need to use `constructorForm` of "unknown type literal" in a type-checking function, we try to convert it into known type literal by using the `state` and in this case, it's always NotNull. If it fails we can report error. This makes more operations type-safe and less error-prone.