### PR TITLE
Issue #598, Part 1.

### DIFF
--- a/base/src/main/java/org/aya/core/repr/AyaShape.java
+++ b/base/src/main/java/org/aya/core/repr/AyaShape.java
@@ -37,12 +37,12 @@ public sealed interface AyaShape {
 
   record AyaListShape() implements AyaShape {
     public static final @NotNull CodeShape DATA_LIST = new DataShape(
-      ImmutableSeq.of(CodeShape.ParamShape.ex(new CodeShape.TermShape.Sort(null, 0))),
+      ImmutableSeq.of(CodeShape.ParamShape.any(new CodeShape.TermShape.Sort(null, 0))),
       ImmutableSeq.of(
         new CtorShape(ImmutableSeq.empty()),    // nil
         new CtorShape(ImmutableSeq.of(          // cons A (List A)
-          CodeShape.ParamShape.ex(new CodeShape.TermShape.TeleRef(0, 0)),   // A
-          CodeShape.ParamShape.ex(new CodeShape.TermShape.Call(                          // List A
+          CodeShape.ParamShape.any(new CodeShape.TermShape.TeleRef(0, 0)),   // A
+          CodeShape.ParamShape.any(new CodeShape.TermShape.Call(                          // List A
             0,
             ImmutableSeq.of(new CodeShape.TermShape.TeleRef(0, 0))))))
       ));

--- a/base/src/main/java/org/aya/core/repr/CodeShape.java
+++ b/base/src/main/java/org/aya/core/repr/CodeShape.java
@@ -44,7 +44,7 @@ public sealed interface CodeShape {
 
     /**
      * @param superLevel the data def reference
-     * @param args corresponds to {@link CallTerm.Data#args()}
+     * @param args       corresponds to {@link CallTerm.Data#args()}
      */
     record Call(int superLevel, @NotNull ImmutableSeq<TermShape> args) implements TermShape {
       @Contract("_ -> new") public static @NotNull Call justCall(int superLevel) {
@@ -57,11 +57,11 @@ public sealed interface CodeShape {
     /**
      * The shape to Sort term, I am not very work well at type theory, so improve this feel free!
      *
+     * @param kind  the SortKind, null if accept any kind of sort. see {@link ShapeMatcher#matchTerm(TermShape, Term)}
+     * @param lift I don't know.
      * @author hoshino
-     * @param kind the SortKind, null if accept any kind of sort. see {@link ShapeMatcher#matchTerm(TermShape, Term)}
-     * @param ulift the lower bound of the type level.
      */
-    record Sort(@Nullable SortKind kind, int ulift) implements TermShape {}
+    record Sort(@Nullable SortKind kind, int lift) implements TermShape {}
   }
 
   /**
@@ -75,18 +75,29 @@ public sealed interface CodeShape {
    * @author kiva
    */
   sealed interface ParamShape {
+    // TODO[hoshino]: a better name is requested!
+    enum Explicit {
+      Any,
+      Explicit,
+      Implicit
+    }
+
     record Any() implements ParamShape {}
 
-    record Licit(@NotNull CodeShape.TermShape type, boolean explicit) implements ParamShape {}
+    record Licit(@NotNull CodeShape.TermShape type, Explicit explicit) implements ParamShape {}
 
     record Optional(@NotNull CodeShape.ParamShape param) implements ParamShape {}
 
     static @NotNull CodeShape.ParamShape ex(@NotNull CodeShape.TermShape type) {
-      return new Licit(type, true);
+      return new Licit(type, Explicit.Explicit);
     }
 
     static @NotNull CodeShape.ParamShape im(@NotNull CodeShape.TermShape type) {
-      return new Licit(type, false);
+      return new Licit(type, Explicit.Implicit);
+    }
+
+    static @NotNull CodeShape.ParamShape any(@NotNull CodeShape.TermShape type) {
+      return new Licit(type, Explicit.Any);
     }
 
     static @NotNull CodeShape.ParamShape anyEx() {
@@ -95,6 +106,9 @@ public sealed interface CodeShape {
 
     static @NotNull CodeShape.ParamShape anyIm() {
       return im(new TermShape.Any());
+    }
+    static @NotNull CodeShape.ParamShape anyLicit() {
+      return any(new TermShape.Any());
     }
   }
 }

--- a/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
+++ b/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
@@ -100,10 +100,19 @@ public record ShapeMatcher(
     if (shape instanceof CodeShape.ParamShape.Any) return true;
     if (shape instanceof CodeShape.ParamShape.Optional opt) return matchParam(opt.param(), param);
     if (shape instanceof CodeShape.ParamShape.Licit licit) {
-      if (licit.explicit() != param.explicit()) return false;
-      return matchTerm(licit.type(), param.type());
+      return matchLicit(licit.explicit(), param.explicit())
+        && matchTerm(licit.type(), param.type());
     }
     return false;
+  }
+
+  /**
+   * @param licit the licit from shape
+   * @param explicit the explicit from term
+   */
+  private boolean matchLicit(@NotNull CodeShape.ParamShape.Explicit licit, boolean explicit) {
+    if (licit == CodeShape.ParamShape.Explicit.Any) return true;
+    return (licit == CodeShape.ParamShape.Explicit.Explicit) == explicit;
   }
 
   private boolean matchInside(@NotNull DefVar<? extends Def, ? extends Decl.Telescopic> defVar, @NotNull BooleanSupplier matcher) {

--- a/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
+++ b/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
@@ -36,6 +36,8 @@ public class ShapeMatcherTest {
     match(true, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | nil | cons A (List A)");
     match(true, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | cons A (List A) | nil");
     match(true, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | nil | infixr :< A (List A)");
+    match(true, AyaShape.AyaListShape.DATA_LIST, "data List {A : Type} | nil | cons {A} (List {A})");
+    match(true, AyaShape.AyaListShape.DATA_LIST, "data List {A : Type} | nil | cons (A) {List {A}}");
 
     match(false, AyaShape.AyaListShape.DATA_LIST, "data List | nil | cons");
     match(false, AyaShape.AyaListShape.DATA_LIST, "data List (A : Type) | nil | cons");


### PR DESCRIPTION
## This PR should:

+ [x] Supports any licit ParamShape (whatever explicit or implicit)
+ [ ] Desugar `[ {O} ]` ~~correctly~~ (or reject it).
+ [ ] Handle `cons` with implicit arguments correctly.

## Questions

+ Should we support `[ {expr/pattern} ]` ?
  - We do not support
    * When do we reject this expression/pattern? Parsing (in `.bnf`)? Producing (in `AyaGKProducer`)?
  - ~~We do support~~
    * ~~How to handle `[ (S n) as m ]` where `| cons {A} (List A)`~~
    * ~~Similarly, how to handle `[ {S n} as m ]` where `| cons (A) (List A)`~~
   