### PR TITLE
Cherry pick from @HoshinoTented's branch

### DIFF
--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -240,7 +240,7 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term> permits Cal
     return new EndoFunctor() {
       @Override public @NotNull Term pre(@NotNull Term term) {
         return term instanceof CallTerm.Hole hole && state != null
-          ? state.metas().getOrDefault(hole.ref(), term)
+          ? state.metas().getOption(hole.ref()).map(this::pre).getOrDefault(term)
           : term;
       }
     }.apply(this);

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -33,7 +33,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       case ErrorTerm term -> ErrorTerm.typeOf(term);
       case RefTerm.Field field -> Def.defType(field.ref());
       case CallTerm.Access access -> {
-        var callRaw = term(access.of()).normalize(state, NormalizeMode.WHNF);
+        var callRaw = whnf(term(access.of()));
         if (!(callRaw instanceof CallTerm.Struct call)) yield ErrorTerm.typeOf(access);
         var core = access.ref().core;
         var subst = DeltaExpander.buildSubst(core.telescope(), access.fieldArgs())
@@ -42,7 +42,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       }
       case FormTerm.Sigma sigma -> {
         var univ = sigma.params().view()
-          .map(param -> term(param.type()).normalize(state, NormalizeMode.WHNF))
+          .map(param -> whnf(term(param.type())))
           .filterIsInstance(FormTerm.Sort.class)
           .toImmutableSeq();
         if (univ.sizeEquals(sigma.params().size())) {
@@ -57,7 +57,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       }
       case IntroTerm.Lambda lambda -> new FormTerm.Pi(lambda.param(), term(lambda.body()));
       case ElimTerm.Proj proj -> {
-        var sigmaRaw = term(proj.of()).normalize(state, NormalizeMode.WHNF);
+        var sigmaRaw = whnf(term(proj.of()));
         if (!(sigmaRaw instanceof FormTerm.Sigma sigma)) yield ErrorTerm.typeOf(proj);
         var index = proj.ix() - 1;
         var telescope = sigma.params();
@@ -69,11 +69,11 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
         new Term.Param(Constants.anonymous(), term(item), true)));
       case RefTerm.MetaPat metaPat -> metaPat.ref().type();
       case FormTerm.Pi pi -> {
-        var paramTyRaw = term(pi.param().type()).normalize(state, NormalizeMode.WHNF);
-        var resultParam = new Term.Param(pi.param().ref(), pi.param().type().normalize(state, NormalizeMode.WHNF), pi.param().explicit());
+        var paramTyRaw = whnf(term(pi.param().type()));
+        var resultParam = new Term.Param(pi.param().ref(), whnf(pi.param().type()), pi.param().explicit());
         var t = new LittleTyper(state, localCtx.deriveMap());
         yield t.localCtx.with(resultParam, () -> {
-          var retTyRaw = t.term(pi.body()).normalize(state, NormalizeMode.WHNF);
+          var retTyRaw = whnf(t.term(pi.body()));
           if (paramTyRaw instanceof FormTerm.Sort paramTy && retTyRaw instanceof FormTerm.Sort retTy) {
             try {
               return ExprTycker.sortPi(paramTy, retTy);
@@ -86,7 +86,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
         });
       }
       case ElimTerm.App app -> {
-        var piRaw = term(app.of()).normalize(state, NormalizeMode.WHNF);
+        var piRaw = whnf(term(app.of()));
         yield piRaw instanceof FormTerm.Pi pi ? pi.substBody(app.arg().term()) : ErrorTerm.typeOf(app);
       }
       case FormTerm.Sort sort -> sort.succ();
@@ -95,9 +95,9 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       case PrimTerm.Str str -> state.primFactory().getCall(PrimDef.ID.STRING);
       case LitTerm.ShapedInt shaped -> shaped.type();
       case LitTerm.ShapedList shaped -> shaped.type();
-      case FormTerm.PartTy ty -> FormTerm.Type.ZERO;
+      case FormTerm.PartTy ty -> term(ty.type());
       case IntroTerm.PartEl el -> new FormTerm.PartTy(el.rhsType(), el.partial().restr());
-      case FormTerm.Path path -> FormTerm.Type.ZERO;
+      case FormTerm.Path(var cube) -> term(cube.type());
       case IntroTerm.PathLam lam -> new FormTerm.Path(new FormTerm.Cube(
         lam.params(),
         term(lam.body()),
@@ -113,6 +113,10 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       case PrimTerm.HComp hComp -> throw new InternalException("TODO");
       case ErasedTerm erased -> erased.type();
     };
+  }
+
+  private @NotNull Term whnf(Term x) {
+    return x.normalize(state, NormalizeMode.WHNF);
   }
 
   private @NotNull Term defCall(@NotNull CallTerm.DefCall call) {

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -151,10 +151,10 @@ public record StmtTycker(@NotNull Reporter reporter, Trace.@Nullable Builder tra
 
   // Apply a simple checking strategy for maximal metavar inference.
   public @NotNull FnDef simpleFn(@NotNull ExprTycker tycker, TeleDecl.FnDecl fn) {
-    return traced(fn, tycker, (o, w) -> doSimpleFn(tycker, fn));
+    return traced(fn, tycker, this::doSimpleFn);
   }
 
-  private @NotNull FnDef doSimpleFn(@NotNull ExprTycker tycker, TeleDecl.FnDecl fn) {
+  private @NotNull FnDef doSimpleFn(TeleDecl.FnDecl fn, @NotNull ExprTycker tycker) {
     var okTele = checkTele(tycker, fn.telescope, null);
     var preresult = tycker.synthesize(fn.result).wellTyped();
     var bodyExpr = fn.body.getLeftValue();

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -106,7 +106,7 @@ public final class PatTycker {
    * corresponding telescope binding with the pattern.
    */
   private void addPatSubst(@NotNull AnyVar var, @NotNull Pat pat, @NotNull SourcePos pos) {
-    typeSubst.addDirectly(var, pat.toTerm());
+    typeSubst.add(var, pat.toTerm());
     bodySubst.put(var, pat.toExpr(pos));
   }
 

--- a/base/src/test/resources/failure/patterns/literal-conf.aya
+++ b/base/src/test/resources/failure/patterns/literal-conf.aya
@@ -1,6 +1,6 @@
 open data Nat | zero | suc Nat
 
-def overlap not-conf Nat
+def overlap not-conf Nat : Nat
   | zero => 1
   | 0 => 0
   | 1 => 1

--- a/base/src/test/resources/failure/patterns/literal-conf.aya.txt
+++ b/base/src/test/resources/failure/patterns/literal-conf.aya.txt
@@ -1,6 +1,6 @@
 In file $FILE:5:4 ->
 
-  3 | def overlap not-conf Nat
+  3 | def overlap not-conf Nat : Nat
   4 |   | zero => 1
   5 |   | 0 => 0
           ^----^
@@ -10,7 +10,7 @@ Warning: The 1st clause dominates the 2nd clause. The 2nd clause will be unreach
 In file $FILE:4:4 ->
 
   2 | 
-  3 | def overlap not-conf Nat
+  3 | def overlap not-conf Nat : Nat
   4 |   | zero => 1
           ^-------^
 
@@ -20,7 +20,7 @@ In file $FILE:3:12 ->
 
   1 | open data Nat | zero | suc Nat
   2 | 
-  3 | def overlap not-conf Nat
+  3 | def overlap not-conf Nat : Nat
   4 |   | zero => 1
           ^-------^ substituted to `1`
   5 |   | 0 => 0
@@ -44,7 +44,7 @@ In file $FILE:3:12 ->
 
   1 | open data Nat | zero | suc Nat
   2 | 
-  3 | def overlap not-conf Nat
+  3 | def overlap not-conf Nat : Nat
   4 |   | zero => 1
   5 |   | 0 => 0
   6 |   | 1 => 1

--- a/base/src/test/resources/failure/syntax/issue164.aya.txt
+++ b/base/src/test/resources/failure/syntax/issue164.aya.txt
@@ -16,54 +16,6 @@ In file $FILE:8:29 ->
 
 Error: Parser error: Cannot parse
 
-In file $FILE:1:4 ->
-
-  1 | def uncurry (A : Type) (B : Type) (C : Type)
-          ^-----^
-  2 |              (f : Pi A B -> C)
-  3 |              (p : Sig A  B) : C
-
-Error: The parameter:
-         (A : Type 0)
-         (Normalized: Type 0)
-       requires a binding in the patterns
-
-In file $FILE:1:4 ->
-
-  1 | def uncurry (A : Type) (B : Type) (C : Type)
-          ^-----^
-  2 |              (f : Pi A B -> C)
-  3 |              (p : Sig A  B) : C
-
-Error: The parameter:
-         (B : Type 0)
-         (Normalized: Type 0)
-       requires a binding in the patterns
-
-In file $FILE:1:4 ->
-
-  1 | def uncurry (A : Type) (B : Type) (C : Type)
-          ^-----^
-  2 |              (f : Pi A B -> C)
-  3 |              (p : Sig A  B) : C
-
-Error: The parameter:
-         (C : Type 0)
-         (Normalized: Type 0)
-       requires a binding in the patterns
-
-In file $FILE:1:4 ->
-
-  1 | def uncurry (A : Type) (B : Type) (C : Type)
-          ^-----^
-  2 |              (f : Pi A B -> C)
-  3 |              (p : Sig A  B) : C
-
-Error: The parameter:
-         (f : A -> B -> C)
-         (Normalized: A -> B -> C)
-       requires a binding in the patterns
-
 In file $FILE:1:0 ->
 
   1 | def uncurry (A : Type) (B : Type) (C : Type)
@@ -74,66 +26,6 @@ In file $FILE:1:0 ->
   5 | 
 
 Error: Unsolved meta _
-
-In file $FILE:6:4 ->
-
-  4 |   => f (p.1) (p.2)
-  5 | 
-  6 | def uncurry3 (A : Type) (B : Type) (C : Type) (D : Type)
-          ^------^
-
-Error: The parameter:
-         (A : Type 0)
-         (Normalized: Type 0)
-       requires a binding in the patterns
-
-In file $FILE:6:4 ->
-
-  4 |   => f (p.1) (p.2)
-  5 | 
-  6 | def uncurry3 (A : Type) (B : Type) (C : Type) (D : Type)
-          ^------^
-
-Error: The parameter:
-         (B : Type 0)
-         (Normalized: Type 0)
-       requires a binding in the patterns
-
-In file $FILE:6:4 ->
-
-  4 |   => f (p.1) (p.2)
-  5 | 
-  6 | def uncurry3 (A : Type) (B : Type) (C : Type) (D : Type)
-          ^------^
-
-Error: The parameter:
-         (C : Type 0)
-         (Normalized: Type 0)
-       requires a binding in the patterns
-
-In file $FILE:6:4 ->
-
-  4 |   => f (p.1) (p.2)
-  5 | 
-  6 | def uncurry3 (A : Type) (B : Type) (C : Type) (D : Type)
-          ^------^
-
-Error: The parameter:
-         (D : Type 0)
-         (Normalized: Type 0)
-       requires a binding in the patterns
-
-In file $FILE:6:4 ->
-
-  4 |   => f (p.1) (p.2)
-  5 | 
-  6 | def uncurry3 (A : Type) (B : Type) (C : Type) (D : Type)
-          ^------^
-
-Error: The parameter:
-         (f : A -> B -> C -> D)
-         (Normalized: A -> B -> C -> D)
-       requires a binding in the patterns
 
 In file $FILE:6:0 ->
 
@@ -146,5 +38,5 @@ In file $FILE:6:0 ->
 
 Error: Unsolved meta _
 
-13 error(s), 0 warning(s).
+4 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/tyck/issues/issue697.aya.txt
+++ b/base/src/test/resources/failure/tyck/issues/issue697.aya.txt
@@ -20,10 +20,10 @@ In file $FILE:17:65 ->
                                                                         ^^
 
 Error: Unsolved meta a'
-       in `idp {[| i |] A' {| ~ i := a | i := a' |}} {a'}`
-       in `idp {[| i |] A' {| ~ i := a | i := a' |}} {a'} <a>`
-       in `hcomp2d {A'} {a} {a'} {b} {a'} (idp {[| i |] A' {| ~ i := a | i := a'
-        |}} {a'} <a>) (idp {A} {a}) p`
+       in `idp {[| i |] A {| ~ i := a | i := a |}} {a'}`
+       in `idp {[| i |] A {| ~ i := a | i := a |}} {a'} <a>`
+       in `hcomp2d {A} {a} {a} {b} {a} (idp {[| i |] A {| ~ i := a | i := a |}} {a'}
+        <a>) (idp {A} {a}) p`
 
 In file $FILE:17:65 ->
 
@@ -33,9 +33,9 @@ In file $FILE:17:65 ->
                                                                         ^^
 
 Error: Unsolved meta a'
-       in `idp {[| i |] A' {| ~ i := a | i := a' |}} {a'} <a>`
-       in `hcomp2d {A'} {a} {a'} {b} {a'} (idp {[| i |] A' {| ~ i := a | i := a'
-        |}} {a'} <a>) (idp {A} {a}) p`
+       in `idp {[| i |] A {| ~ i := a | i := a |}} {a'} <a>`
+       in `hcomp2d {A} {a} {a} {b} {a} (idp {[| i |] A {| ~ i := a | i := a |}} {a'}
+        <a>) (idp {A} {a}) p`
 
 In file $FILE:17:65 ->
 
@@ -45,9 +45,9 @@ In file $FILE:17:65 ->
                                                                         ^^
 
 Error: Unsolved meta a'
-       in `idp {[| i |] A' {| ~ i := a | i := a' |}} {a'} <a>`
-       in `hcomp2d {A'} {a} {a'} {b} {a'} (idp {[| i |] A' {| ~ i := a | i := a'
-        |}} {a'} <a>) (idp {A} {a}) p`
+       in `idp {[| i |] A {| ~ i := a | i := a |}} {a'} <a>`
+       in `hcomp2d {A} {a} {a} {b} {a} (idp {[| i |] A {| ~ i := a | i := a |}} {a'}
+        <a>) (idp {A} {a}) p`
 
 4 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/success/src/Issues/495.aya
+++ b/base/src/test/resources/success/src/Issues/495.aya
@@ -1,5 +1,5 @@
 open data Unit
   | unit
 
-def bad (u : Unit)
+def bad (u : Unit) : Unit
   | _ => u

--- a/base/src/test/resources/success/src/Sorts.aya
+++ b/base/src/test/resources/success/src/Sorts.aya
@@ -17,9 +17,6 @@ open data Disj (A B : Prop) : Prop
 | inl (a : A)
 | inr (b : B)
 
-def bad (u : Unit)
-  | _ => u
-
 variable A : Type
 
 -- Leibniz equality using impredicative universe of propositions


### PR DESCRIPTION
Hoshino Tented

We cannot solve metas in result type from clauses, because when we're in the clauses, the result type is substituted, and it doesn't make sense to solve a "substituted meta"
In the future, we may generate a "constant" meta and try to solve it if the result type is a pure meta.