### PR TITLE
Purge `raiseError`

### DIFF
--- a/tools/src/main/java/org/aya/util/reporter/CollectingReporter.java
+++ b/tools/src/main/java/org/aya/util/reporter/CollectingReporter.java
@@ -3,7 +3,6 @@
 package org.aya.util.reporter;
 
 import kala.collection.mutable.MutableList;
-import org.aya.pretty.doc.Doc;
 import org.jetbrains.annotations.NotNull;
 
 public interface CollectingReporter extends CountingReporter {
@@ -15,9 +14,5 @@ public interface CollectingReporter extends CountingReporter {
 
   @Override default void clear() {
     problems().clear();
-  }
-
-  @Override default void raiseError() {
-    problems().append(Reporter.dummyProblem(Doc.empty(), Problem.Severity.ERROR));
   }
 }

--- a/tools/src/main/java/org/aya/util/reporter/CountingReporter.java
+++ b/tools/src/main/java/org/aya/util/reporter/CountingReporter.java
@@ -3,7 +3,6 @@
 package org.aya.util.reporter;
 
 import org.aya.util.error.SourcePos;
-import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -41,7 +40,6 @@ public interface CountingReporter extends Reporter {
   static @NotNull CountingReporter delegate(@NotNull Reporter reporter) {
     return new Delegated(reporter);
   }
-  @Contract(mutates = "this") void raiseError();
 
   record Delegated(
     @NotNull Reporter delegated,
@@ -57,10 +55,6 @@ public interface CountingReporter extends Reporter {
 
     @Override public void clear() {
       Arrays.fill(count, 0);
-    }
-
-    @Override public void raiseError() {
-      count[Problem.Severity.ERROR.ordinal()]++;
     }
 
     @Override public void report(@NotNull Problem problem) {


### PR DESCRIPTION
Aya should stop the compilation when the dependent library fails to build.