### PR TITLE
Pat.Meta in Pat.Meta

### DIFF
--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -91,6 +91,14 @@ public sealed interface Pat extends AyaDocile {
     }
   }
 
+
+  /**
+   * Meta for Hole
+   *
+   * @param fakeBind is used when inline if there is no solution.
+   *                 So don't add this to {@link LocalCtx} too early
+   *                 and remember to inline Meta in {@link PatTycker#checkLhs}
+   */
   record Meta(
     boolean explicit,
     @NotNull MutableValue<Pat> solution,
@@ -117,7 +125,9 @@ public sealed interface Pat extends AyaDocile {
         solution.set(bind);
         ctx.put(fakeBind, type);
         return bind;
-      } else return value;
+      } else {
+        return value.inline(ctx);
+      }
     }
 
     @Override

--- a/base/src/main/java/org/aya/core/pat/Pat.java
+++ b/base/src/main/java/org/aya/core/pat/Pat.java
@@ -48,6 +48,8 @@ public sealed interface Pat extends AyaDocile {
   @Override default @NotNull Doc toDoc(@NotNull DistillerOptions options) {
     return new CoreDistiller(options).pat(this, BaseDistiller.Outer.Free);
   }
+
+  // TODO[hoshino]: useless now
   @NotNull Pat rename(@NotNull Subst subst, @NotNull LocalCtx localCtx, boolean explicit);
   @NotNull Pat zonk(@NotNull Tycker tycker);
   /**

--- a/base/src/main/java/org/aya/core/pat/PatMatcher.java
+++ b/base/src/main/java/org/aya/core/pat/PatMatcher.java
@@ -26,6 +26,8 @@ import java.util.function.UnaryOperator;
  * @author ice1000
  * @apiNote Use {@link PatMatcher#tryBuildSubstTerms} instead of instantiating the class directly.
  * @implNote The substitution built is made from parallel substitutions.
+ *
+ * FIXME[hoshino]: localCtx is useless now, it can be replaced with a {@code (inferable : Boolean)}
  */
 public record PatMatcher(@NotNull Subst subst, @Nullable LocalCtx localCtx, @NotNull UnaryOperator<@NotNull Term> pre) {
   public static Result<Subst, Boolean> tryBuildSubstTerms(

--- a/base/src/main/java/org/aya/core/visitor/PatTraversal.java
+++ b/base/src/main/java/org/aya/core/visitor/PatTraversal.java
@@ -32,7 +32,7 @@ public interface PatTraversal extends Function<Pat, Pat> {
       case Pat.Ctor ctor -> {
         var params = ctor.params().map(this);
 
-        if (params.sameElements(ctor.params())) yield ctor;
+        if (params.sameElements(ctor.params(), true)) yield ctor;
         yield new Pat.Ctor(ctor.explicit(), ctor.ref(), ctor.ownerArgs(), params, ctor.type());
       }
       case Pat.End end -> end;
@@ -51,7 +51,7 @@ public interface PatTraversal extends Function<Pat, Pat> {
       case Pat.Tuple tuple -> {
         var pats = tuple.pats().map(this);
 
-        if (pats.sameElements(tuple.pats())) yield tuple;
+        if (pats.sameElements(tuple.pats(), true)) yield tuple;
         yield new Pat.Tuple(tuple.explicit(), pats);
       }
     };

--- a/base/src/main/java/org/aya/core/visitor/PatTraversal.java
+++ b/base/src/main/java/org/aya/core/visitor/PatTraversal.java
@@ -74,6 +74,8 @@ public interface PatTraversal extends Function<Pat, Pat> {
 
   /**
    * subst all binding to corresponding MetaPat
+   *
+   * TODO[hoshino]: A PatTraversal or a method of Pat?
    */
   class MetaBind implements NoMeta {
     public final @NotNull Subst subst;

--- a/base/src/main/java/org/aya/core/visitor/PatTraversal.java
+++ b/base/src/main/java/org/aya/core/visitor/PatTraversal.java
@@ -1,0 +1,104 @@
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.core.visitor;
+
+import kala.value.MutableValue;
+import org.aya.core.pat.Pat;
+import org.aya.generic.util.InternalException;
+import org.aya.ref.LocalVar;
+import org.aya.util.error.SourcePos;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+
+public interface PatTraversal extends Function<Pat, Pat> {
+  default @NotNull Pat pre(@NotNull Pat pat) {
+    return pat;
+  }
+
+  default @NotNull Pat post(@NotNull Pat pat) {
+    return pat;
+  }
+
+  @Override
+  default @NotNull Pat apply(@NotNull Pat pat) {
+    return post(descent(pre(pat)));
+  }
+
+  default @NotNull Pat descent(@NotNull Pat pat) {
+    return switch (pat) {
+      case Pat.Absurd absurd -> absurd;
+      case Pat.Bind bind -> bind;
+      case Pat.Ctor ctor -> {
+        var params = ctor.params().map(this);
+
+        if (params.sameElements(ctor.params())) yield ctor;
+        yield new Pat.Ctor(ctor.explicit(), ctor.ref(), ctor.ownerArgs(), params, ctor.type());
+      }
+      case Pat.End end -> end;
+      case Pat.Meta meta -> {
+        var solution = meta.solution().get();
+        if (solution != null) {
+          var newSolution = apply(solution);
+
+          if (newSolution == solution) yield meta;
+          yield new Pat.Meta(meta.explicit(), MutableValue.create(solution), meta.fakeBind(), meta.type());
+        } else {
+          yield meta;
+        }
+      }
+      case Pat.ShapedInt shapedInt -> shapedInt;
+      case Pat.Tuple tuple -> {
+        var pats = tuple.pats().map(this);
+
+        if (pats.sameElements(tuple.pats())) yield tuple;
+        yield new Pat.Tuple(tuple.explicit(), pats);
+      }
+    };
+  }
+
+  /**
+   * A traversal that disallow Pat.Meta
+   */
+  interface NoMeta extends PatTraversal {
+    @Override
+    @NotNull
+    default Pat descent(@NotNull Pat pat) {
+      if (pat instanceof Pat.Meta) {
+        throw new InternalException("expected: no Pat.Meta, but actual: Pat.Meta");
+      }
+
+      return PatTraversal.super.descent(pat);
+    }
+  }
+
+  /**
+   * subst all binding to corresponding MetaPat
+   */
+  class MetaBind implements NoMeta {
+    public final @NotNull Subst subst;
+    public final @NotNull SourcePos definition;
+
+    public MetaBind(@NotNull Subst subst, @NotNull SourcePos definition) {
+      this.subst = subst;
+      this.definition = definition;
+    }
+
+    @Override
+    public @NotNull Pat post(@NotNull Pat pat) {
+      if (pat instanceof Pat.Bind bind) {
+        // every new var use the same definition location
+        var newVar = new LocalVar(bind.bind().name(), definition);
+        // we are no need to add newVar to some localCtx, this will be done when we inline the Pat.Meta
+        var meta = new Pat.Meta(bind.explicit(), MutableValue.create(), newVar, bind.type());
+
+        // add to subst
+        subst.addDirectly(bind.bind(), meta.toTerm());
+
+        return meta;
+      }
+
+      return NoMeta.super.post(pat);
+    }
+  }
+}

--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -468,11 +468,13 @@ public final class PatTycker {
     var ref = data.param.ref();
     Pat bind;
     var freshVar = new LocalVar(ref.name(), ref.definition());
-    if (data.param.type().normalize(exprTycker.state, NormalizeMode.WHNF) instanceof CallTerm.Data dataCall)
+    if (data.param.type().normalize(exprTycker.state, NormalizeMode.WHNF) instanceof CallTerm.Data dataCall) {
       bind = new Pat.Meta(false, MutableValue.create(), freshVar, dataCall);
-    else bind = new Pat.Bind(false, freshVar, data.param.type());
+    } else {
+      bind = new Pat.Bind(false, freshVar, data.param.type());
+      exprTycker.localCtx.put(freshVar, data.param.type());
+    }
     data.results.append(bind);
-    exprTycker.localCtx.put(freshVar, data.param.type());
     addSigSubst(data.param(), bind);
 
     return afterTyck(data).sig();

--- a/base/src/test/resources/failure/holes/no-more-var.aya
+++ b/base/src/test/resources/failure/holes/no-more-var.aya
@@ -1,0 +1,4 @@
+open data Nat | O | S Nat
+
+def justMatch {n : Nat} (m : Nat) : Nat
+| m => {??}

--- a/base/src/test/resources/failure/holes/no-more-var.aya.txt
+++ b/base/src/test/resources/failure/holes/no-more-var.aya.txt
@@ -1,0 +1,25 @@
+In file $FILE:4:7 ->
+
+  2 | 
+  3 | def justMatch {n : Nat} (m : Nat) : Nat
+  4 | | m => {??}
+             ^--^
+
+Goal: Goal of type
+        Nat
+        (Normalized: Nat)
+      Context:
+        {m : Nat}
+        {n : Nat} (not in scope)
+
+In file $FILE:4:7 ->
+
+  2 | 
+  3 | def justMatch {n : Nat} (m : Nat) : Nat
+  4 | | m => {??}
+             ^--^
+
+Error: Unsolved meta _
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/success/src/MetaInMeta.aya
+++ b/base/src/test/resources/success/src/MetaInMeta.aya
@@ -1,0 +1,14 @@
+open import Paths
+
+open data Nat | O | S Nat
+open data INat (n : Nat)
+| O => zero
+| S n' => +-one
+| S (S n') => +-two
+
+def yes {n : Nat} (a : INat n) (b : INat n) : Nat
+| +-one, +-two => O
+| _, _ => S O
+
+def test0 : yes {2} +-one +-two = 0 => idp
+def test1 : yes {1} +-one +-one = 1 => idp


### PR DESCRIPTION
This PR allows this code compiles:

```aya
open data Nat | O | S Nat
open data INat (n : Nat)
| O => zero
| S n' => +-one
| S (S n') => +-two

def yes {n : Nat} (a : INat n) (b : INat n) : Nat
| +-one, +-two => O
| _, _ => S O
```

The `yes` function is equivalent to:

```aya
def yes {n : Nat} (a : INat n) (b : INat n) : Nat
| {S (S n')}, +-one, +-two => O
| {n}, _, _ => S O
```