### PR TITLE
Disallow using `coe` as function

### DIFF
--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -80,7 +80,7 @@ public final class PrimDef extends TopLevelDef<Term> {
 
   public static class Factory {
     private final class Initializer {
-      public final @NotNull PrimDef.PrimSeed coerce = new PrimSeed(ID.COE, this::coe, ref -> {
+      public final @NotNull PrimDef.PrimSeed coe = new PrimSeed(ID.COE, this::coe, ref -> {
         var varA = new LocalVar("A");
         var paramA = new Term.Param(varA, intervalToA(), true);
         var paramRestr = new Term.Param(new LocalVar("i"), IntervalTerm.INSTANCE, true);
@@ -217,7 +217,7 @@ public final class PrimDef extends TopLevelDef<Term> {
           init.stringConcat,
           init.intervalType,
           init.partialType,
-          init.coerce,
+          init.coe,
           init.hcomp
         ).map(seed -> Tuple.of(seed.name, seed))
         .toImmutableMap();

--- a/base/src/main/java/org/aya/resolve/error/PrimResolveError.java
+++ b/base/src/main/java/org/aya/resolve/error/PrimResolveError.java
@@ -47,9 +47,25 @@ public interface PrimResolveError extends Problem {
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
       assert lack.isNotEmpty();
       return Doc.sep(
-        Doc.english("The prim"), Doc.styled(Style.code(), Doc.plain(name)),
-        Doc.english("depends on undeclared prims:"),
+        Doc.english("The primitive"), Doc.styled(Style.code(), Doc.plain(name)),
+        Doc.english("depends on undeclared primitive(s):"),
         Doc.commaList(lack.map(name -> Doc.styled(Style.code(), Doc.plain(name.id)))));
+    }
+  }
+
+  record BadUsage(
+    @NotNull String name,
+    @NotNull SourcePos sourcePos
+  ) implements PrimResolveError {
+    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.sep(Doc.english("The primitive"),
+        Doc.styled(Style.code(), Doc.plain(name)),
+        Doc.english("is not designed to be used as a function"));
+    }
+
+    @Override public @NotNull Doc hint(@NotNull DistillerOptions options) {
+      return Doc.sep(Doc.english("Use the projection syntax instead, like:"),
+        Doc.styled(Style.code(), Doc.plain("." + name)));
     }
   }
 }

--- a/base/src/test/java/org/aya/core/NormalizeTest.java
+++ b/base/src/test/java/org/aya/core/NormalizeTest.java
@@ -49,8 +49,8 @@ public class NormalizeTest {
       prim I
       open data Nat : Type | zero | suc Nat
       prim coe
-      def xyr : Nat => coe (\\ i => Nat) 1 zero
-      def kiva : Nat => coe (\\ i => Nat) 1 (suc zero)""");
+      def xyr : Nat => (\\ i => Nat).coe zero freeze 1
+      def kiva : Nat => (\\ i => Nat).coe (suc zero) freeze 1""");
     var state = new TyckState(res._1);
     var defs = res._2;
     IntFunction<Term> normalizer = i -> ((FnDef) defs.get(i)).body.getLeftValue().normalize(state, NormalizeMode.NF);

--- a/base/src/test/java/org/aya/core/SuedeTest.java
+++ b/base/src/test/java/org/aya/core/SuedeTest.java
@@ -53,7 +53,7 @@ public class SuedeTest {
       prim coe
       def hcomp2d {a b c d : A}
         (p : a = b) (q : b = d) (r : a = c) : c = d
-        => \\i => coe (\\ k => r k = q k) 0 p i
+        => \\i => ((\\ k => r k = q k).coe p) i
       struct Monoid {A : Type} (op : A -> A -> A): Type
         | id : A
         | assoc (a b c : A) : op (op a b) c = op a (op b c)

--- a/base/src/test/resources/failure/syntax/bad-prim-usage.aya
+++ b/base/src/test/resources/failure/syntax/bad-prim-usage.aya
@@ -1,0 +1,4 @@
+prim I
+prim coe
+
+def test {A : I -> Type} (restr : I) : A 0 -> A 1 => coe A restr

--- a/base/src/test/resources/failure/syntax/bad-prim-usage.aya.txt
+++ b/base/src/test/resources/failure/syntax/bad-prim-usage.aya.txt
@@ -1,0 +1,13 @@
+In file $FILE:4:53 ->
+
+  2 | prim coe
+  3 | 
+  4 | def test {A : I -> Type} (restr : I) : A 0 -> A 1 => coe A restr
+                                                           ^-^
+
+Error: The primitive `coe` is not designed to be used as a function
+note: Use the projection syntax instead, like: `.coe`
+
+Resolving interrupted due to:
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/syntax/literate-unresolved.aya
+++ b/base/src/test/resources/failure/syntax/literate-unresolved.aya
@@ -1,4 +1,4 @@
 prim I
 prim coe
---| test `coe`
+--| test `I`
 --| test `unresolved`

--- a/base/src/test/resources/failure/syntax/literate-unresolved.aya.txt
+++ b/base/src/test/resources/failure/syntax/literate-unresolved.aya.txt
@@ -2,7 +2,7 @@ In file $FILE:3:0 ->
 
   1 | prim I
   2 | prim coe
-  3 | --| test `coe`
+  3 | --| test `I`
       ^-------------------^
   4 | --| test `unresolved`
 

--- a/base/src/test/resources/failure/tyck/issues/issue697.aya
+++ b/base/src/test/resources/failure/tyck/issues/issue697.aya
@@ -11,7 +11,7 @@ def hcomp2d
   (p : a = b)
   (q : b = d)
   (r : a = c) : c = d
-  => \i => coe (\ k => r k = q k) 0 p i
+  => \i => ((\ k => r k = q k).coe p) i
 def idp {a : A} : a = a => \i => a
 
 def sym {A : Type} {a b : A} (p : a = b) : b = a => hcomp2d (idp a) idp p

--- a/base/src/test/resources/success/common/src/Paths.aya
+++ b/base/src/test/resources/success/common/src/Paths.aya
@@ -22,7 +22,7 @@ def psqueeze {a b : A} (p : a = b) (i : I)
 
 def J {a : A} (B : Pi (b : A) -> a = b -> Type)
       (r : B a idp) {b : A} (p : a = b) : B b (\i => p i) =>
-      coe (\ i => B (p i) (\j => p (j /\ i))) 0 r
+      (\ i => B (p i) (\j => p (j /\ i))).coe r
 
 def transport {a b : A} (B : A -> Type) (p : a = b) (x : B a) : B b
   => J (\b' p' => B b') x p
@@ -48,7 +48,7 @@ def hcomp2d
   (p : a = b)
   (q : b = d)
   (r : a = c) : c = d
-  => \i => coe (\ k => r k = q k) 0 p i
+  => \i => ((\ k => r k = q k).coe p) i
 
 def infixr <==> {a b c : A} (p : a = b) (q : b = c) : a = c =>
   \k => hcomp2d p q idp k
@@ -57,5 +57,5 @@ def infixr <==>'
   (p : [| i |] A)
   (q : [| i |] A {| ~ i := p 1 |})
   : p 0 = q 1 =>
-  coe (\ k => p 0 = q k) 0 (λ j => p j)
+  (\ k => p 0 = q k).coe (λ j => p j)
   tighter <==>

--- a/base/src/test/resources/success/src/Refparo/Model.aya
+++ b/base/src/test/resources/success/src/Refparo/Model.aya
@@ -4,10 +4,10 @@ public open data Unit | unit
 
 -- we cannot eta-contract this, same problem as Cubical Agda
 def coe {A B : Type} (eq : A ↑ = B) (x : A) : B
-  => ↑ primCoe (\y => eq y) 0 x
+  => (\y => eq y).primCoe x
 
 def coeFill {A : Type} {x : A} : x = coe (↑ idp) x
-  => λ i => ↑ primCoe (λ j => A) (~ i) x
+  => λ i => (λ j => A).primCoe x freeze (~ i)
 
 -- *** Types
 


### PR DESCRIPTION
this is done by rejecting references to `coe` in the resolver.