### PR TITLE
Constant check for `coeFill`, `coeInv` and `coeInvFill`

### DIFF
--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -442,7 +442,7 @@ public sealed interface Expr extends AyaDocile, SourceNode, Restr.TermLike<Expr>
    *
    * @param resolvedVar will be set to the primitive coe's DefVar during resolving
    * @param restr       The cofibration under which the type should be constant
-   * @see org.aya.core.def.PrimDef.ID#isCoercion(PrimDef.ID)
+   * @see org.aya.core.def.PrimDef.ID#projSyntax(PrimDef.ID)
    */
   record Coe(
     @Override @NotNull SourcePos sourcePos,

--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -8,6 +8,7 @@ import kala.control.Either;
 import kala.tuple.Tuple2;
 import kala.value.MutableValue;
 import org.aya.concrete.stmt.QualifiedID;
+import org.aya.core.def.PrimDef;
 import org.aya.core.pat.Pat;
 import org.aya.distill.BaseDistiller;
 import org.aya.distill.ConcreteDistiller;
@@ -430,10 +431,18 @@ public sealed interface Expr extends AyaDocile, SourceNode, Restr.TermLike<Expr>
   }
 
   /**
-   * calls to {@link org.aya.core.def.PrimDef.ID#COE}, desugared from {@link Proj} for simplicity
+   * calls to
+   * <ul>
+   *   <li>{@link org.aya.core.def.PrimDef.ID#COE}</li>
+   *   <li>{@link org.aya.core.def.PrimDef.ID#COEFILL}</li>
+   *   <li>{@link org.aya.core.def.PrimDef.ID#COEINV}</li>
+   *   <li>{@link org.aya.core.def.PrimDef.ID#COEINVFILL}</li>
+   * </ul>
+   * desugared from {@link RawProj} for simplicity.
    *
    * @param resolvedVar will be set to the primitive coe's DefVar during resolving
    * @param restr       The cofibration under which the type should be constant
+   * @see org.aya.core.def.PrimDef.ID#isCoercion(PrimDef.ID)
    */
   record Coe(
     @Override @NotNull SourcePos sourcePos,

--- a/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
+++ b/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
@@ -54,7 +54,7 @@ public record Desugarer(@NotNull ResolveInfo info) implements StmtConsumer {
       case Expr.RawProj proj -> {
         if (proj.resolvedVar() instanceof DefVar<?, ?> defVar
           && defVar.core instanceof PrimDef primDef
-          && primDef.id == PrimDef.ID.COE) {
+          && PrimDef.ID.isCoercion(primDef.id)) {
           var restr = proj.restr() != null ? proj.restr() : new Expr.LitInt(proj.sourcePos(), 0);
           var coe = new Expr.Coe(proj.sourcePos(), proj.id(), defVar, proj.tup(), restr);
           yield pre(proj.coeLeft() != null

--- a/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
+++ b/base/src/main/java/org/aya/concrete/desugar/Desugarer.java
@@ -54,7 +54,7 @@ public record Desugarer(@NotNull ResolveInfo info) implements StmtConsumer {
       case Expr.RawProj proj -> {
         if (proj.resolvedVar() instanceof DefVar<?, ?> defVar
           && defVar.core instanceof PrimDef primDef
-          && PrimDef.ID.isCoercion(primDef.id)) {
+          && PrimDef.ID.projSyntax(primDef.id)) {
           var restr = proj.restr() != null ? proj.restr() : new Expr.LitInt(proj.sourcePos(), 0);
           var coe = new Expr.Coe(proj.sourcePos(), proj.id(), defVar, proj.tup(), restr);
           yield pre(proj.coeLeft() != null

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -101,25 +101,7 @@ public final class PrimDef extends TopLevelDef<Term> {
 
       public final @NotNull PrimDef.PrimSeed coeFill = new PrimSeed(ID.COEFILL, this::coeFill, ref -> {
         // coeFill (A : I -> Type) (phi : I) : Pi (u : A 0) -> Path A u (coe A phi u)
-        var varA = new LocalVar("A");
-        var paramA = new Term.Param(varA, intervalToType(), true);
-        var varPhi = new LocalVar("phi");
-        var paramPhi = new Term.Param(varPhi, IntervalTerm.INSTANCE, true);
-        var varU = new LocalVar("u");
-        var paramU = new Term.Param(varU, new AppTerm(new RefTerm(varA), new Arg<>(FormulaTerm.LEFT, true)), true);
-        var i = new LocalVar("i");
-        var path = new PathTerm(new PathTerm.Cube(
-          ImmutableSeq.of(i),
-          new AppTerm(new RefTerm(varA), new Arg<>(new RefTerm(i), true)),
-          new Partial.Split<>(ImmutableSeq.of(
-            new Restr.Side<>(new Restr.Conj<>(ImmutableSeq.of(new Restr.Cond<>(new RefTerm(i), false))), new RefTerm(varU)),
-            new Restr.Side<>(new Restr.Conj<>(ImmutableSeq.of(new Restr.Cond<>(new RefTerm(i), true))), new AppTerm(getCall(ID.COE, ImmutableSeq.of(
-              new Arg<>(new RefTerm(varA), true),
-              new Arg<>(new RefTerm(varPhi), true))),
-              new Arg<>(new RefTerm(varU), true)))
-          ))));
-        var result = new PiTerm(paramU, path);
-        return new PrimDef(ref, ImmutableSeq.of(paramA, paramPhi), result, ID.COEFILL);
+        return coeFillFactory(ref, ID.COEFILL, ID.COE, FormulaTerm.LEFT);
       }, ImmutableSeq.of(ID.I, ID.COE));
 
       private @NotNull Term coeFill(@NotNull PrimCall prim, @NotNull TyckState state) {
@@ -148,25 +130,7 @@ public final class PrimDef extends TopLevelDef<Term> {
 
       public final @NotNull PrimDef.PrimSeed eocFill = new PrimSeed(ID.COEINVFILL, this::eocFill, ref -> {
         // coeInvFill (A : I -> Type) (phi : I) : Pi (u : A 1) -> Path A u (coeInv A phi u)
-        var varA = new LocalVar("A");
-        var paramA = new Term.Param(varA, intervalToType(), true);
-        var varPhi = new LocalVar("phi");
-        var paramPhi = new Term.Param(varPhi, IntervalTerm.INSTANCE, true);
-        var varU = new LocalVar("u");
-        var paramU = new Term.Param(varU, new AppTerm(new RefTerm(varA), new Arg<>(FormulaTerm.RIGHT, true)), true);
-        var i = new LocalVar("i");
-        var path = new PathTerm(new PathTerm.Cube(
-          ImmutableSeq.of(i),
-          new AppTerm(new RefTerm(varA), new Arg<>(new RefTerm(i), true)),
-          new Partial.Split<>(ImmutableSeq.of(
-            new Restr.Side<>(new Restr.Conj<>(ImmutableSeq.of(new Restr.Cond<>(new RefTerm(i), false))), new RefTerm(varU)),
-            new Restr.Side<>(new Restr.Conj<>(ImmutableSeq.of(new Restr.Cond<>(new RefTerm(i), true))), new AppTerm(getCall(ID.COEINV, ImmutableSeq.of(
-              new Arg<>(new RefTerm(varA), true),
-              new Arg<>(new RefTerm(varPhi), true))),
-              new Arg<>(new RefTerm(varU), true)))
-          ))));
-        var result = new PiTerm(paramU, path);
-        return new PrimDef(ref, ImmutableSeq.of(paramA, paramPhi), result, ID.COEINVFILL);
+        return coeFillFactory(ref, ID.COEINVFILL, ID.COEINV, FormulaTerm.RIGHT);
       }, ImmutableSeq.of(ID.I, ID.COEINV));
 
       private @NotNull Term eocFill(@NotNull PrimCall prim, @NotNull TyckState state) {
@@ -174,6 +138,29 @@ public final class PrimDef extends TopLevelDef<Term> {
         var restr = prim.args().get(1).term();
         var j = new LocalVar("j");
         return CoeTerm.coeFillInv(type, isOne(restr), new RefTerm(j));
+      }
+
+      private @NotNull PrimDef coeFillFactory(DefVar<PrimDef, TeleDecl.PrimDecl> ref, ID coeFill, ID coe, FormulaTerm start) {
+        // <coeFill> (A : I -> Type) (phi : I) : Pi (u : A <start>) -> Path A u (<coe> A phi u)
+        var varA = new LocalVar("A");
+        var paramA = new Term.Param(varA, intervalToType(), true);
+        var varPhi = new LocalVar("phi");
+        var paramPhi = new Term.Param(varPhi, IntervalTerm.INSTANCE, true);
+        var varU = new LocalVar("u");
+        var paramU = new Term.Param(varU, new AppTerm(new RefTerm(varA), new Arg<>(start, true)), true);
+        var i = new LocalVar("i");
+        var path = new PathTerm(new PathTerm.Cube(
+          ImmutableSeq.of(i),
+          new AppTerm(new RefTerm(varA), new Arg<>(new RefTerm(i), true)),
+          new Partial.Split<>(ImmutableSeq.of(
+            new Restr.Side<>(new Restr.Conj<>(ImmutableSeq.of(new Restr.Cond<>(new RefTerm(i), false))), new RefTerm(varU)),
+            new Restr.Side<>(new Restr.Conj<>(ImmutableSeq.of(new Restr.Cond<>(new RefTerm(i), true))), new AppTerm(getCall(coe, ImmutableSeq.of(
+              new Arg<>(new RefTerm(varA), true),
+              new Arg<>(new RefTerm(varPhi), true))),
+              new Arg<>(new RefTerm(varU), true)))
+          ))));
+        var result = new PiTerm(paramU, path);
+        return new PrimDef(ref, ImmutableSeq.of(paramA, paramPhi), result, coeFill);
       }
 
       private final @NotNull PrimDef.PrimSeed hcomp = new PrimSeed(ID.HCOMP, this::hcomp, ref -> {

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -395,7 +395,7 @@ public final class PrimDef extends TopLevelDef<Term> {
       this.id = id;
     }
 
-    public static boolean isCoercion(@NotNull ID id) {
+    public static boolean projSyntax(@NotNull ID id) {
       return id == COE || id == COEFILL || id == COEINV || id == COEINVFILL;
     }
   }

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -407,6 +407,10 @@ public final class PrimDef extends TopLevelDef<Term> {
     ID(@NotNull String id) {
       this.id = id;
     }
+
+    public static boolean isCoercion(@NotNull ID id) {
+      return id == COE || id == COEFILL || id == COEINV || id == COEINVFILL;
+    }
   }
 
   public final @NotNull DefVar<@NotNull PrimDef, TeleDecl.PrimDecl> ref;

--- a/base/src/main/java/org/aya/core/term/CoeTerm.java
+++ b/base/src/main/java/org/aya/core/term/CoeTerm.java
@@ -11,7 +11,7 @@ import static org.aya.guest0x0.cubical.CofThy.isOne;
 
 public record CoeTerm(@NotNull Term type, @NotNull Restr<Term> restr) implements Term {
   /**
-   * <code>coeFill (A: I -> Type) (phi: I) : Path A u (coe A phi u)</code>
+   * <code>coeFill (A : I -> Type) (phi : I) : Pi (u : A 0) -> Path A u (coe A phi u)</code>
    *
    * @param ri the interval abstraction or its inverse
    */
@@ -25,7 +25,7 @@ public record CoeTerm(@NotNull Term type, @NotNull Restr<Term> restr) implements
     return new CoeTerm(a, cofib);
   }
 
-  // forward (A: I -> Type) (r: I): A r -> A 1
+  // forward (A : I -> Type) (r : I) : A r -> A 1
   private static @NotNull Term forward(@NotNull Term A, @NotNull Term r) {
     var varI = new LocalVar("i");
     var varU = new LocalVar("u");
@@ -54,12 +54,12 @@ public record CoeTerm(@NotNull Term type, @NotNull Restr<Term> restr) implements
       AppTerm.make(A, new Arg<>(invertedI, true)));
   }
 
-  // coeInv (A : I -> Type) (phi: I) (u: A 1) : A 0
-  private static @NotNull Term coeInv(@NotNull Term A, @NotNull Restr<Term> phi, @NotNull Term u) {
-    return AppTerm.make(new CoeTerm(invertA(A), phi), new Arg<>(u, true));
+  // coeInv (A : I -> Type) (phi : I) : A 1 -> A 0
+  public static @NotNull Term coeInv(@NotNull Term A, @NotNull Restr<Term> phi) {
+    return new CoeTerm(invertA(A), phi);
   }
 
-  // coeFillInv
+  // coeInvFill (A : I -> Type) (phi : I) : Pi (u : A 1) -> Path A u (coeInv A phi u)
   public static @NotNull Term coeFillInv(@NotNull Term type, @NotNull Restr<Term> phi, @NotNull Term ri) {
     return coeFill(invertA(type), phi, FormulaTerm.inv(ri));
   }

--- a/base/src/main/java/org/aya/resolve/visitor/ExprResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/ExprResolver.java
@@ -159,7 +159,7 @@ public record ExprResolver(
           // Collecting tyck order for tycked terms is unnecessary, just skip.
           if (def.concrete == null) assert def.core != null;
           else if (def.concrete instanceof TyckUnit unit) addReference(unit);
-          if (def.core instanceof PrimDef prim && prim.id == PrimDef.ID.COE)
+          if (def.core instanceof PrimDef prim && PrimDef.ID.isCoercion(prim.id))
             ctx.reportAndThrow(new PrimResolveError.BadUsage(name.join(), pos));
           yield new Expr.Ref(pos, def);
         }

--- a/base/src/main/java/org/aya/resolve/visitor/ExprResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/ExprResolver.java
@@ -159,7 +159,7 @@ public record ExprResolver(
           // Collecting tyck order for tycked terms is unnecessary, just skip.
           if (def.concrete == null) assert def.core != null;
           else if (def.concrete instanceof TyckUnit unit) addReference(unit);
-          if (def.core instanceof PrimDef prim && PrimDef.ID.isCoercion(prim.id))
+          if (def.core instanceof PrimDef prim && PrimDef.ID.projSyntax(prim.id))
             ctx.reportAndThrow(new PrimResolveError.BadUsage(name.join(), pos));
           yield new Expr.Ref(pos, def);
         }

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -167,7 +167,7 @@ public final class ExprTycker extends Tycker {
       }
       case Expr.Coe coe -> {
         assert coe.resolvedVar() instanceof DefVar<?, ?> defVar
-          && defVar.core instanceof PrimDef def && def.id == PrimDef.ID.COE : "desugar bug";
+          && defVar.core instanceof PrimDef def && PrimDef.ID.isCoercion(def.id) : "desugar bug";
         var defVar = coe.resolvedVar();
         var mockApp = new Expr.App(coe.sourcePos(), new Expr.App(coe.sourcePos(),
           new Expr.Ref(coe.id().sourcePos(), defVar),

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -167,7 +167,7 @@ public final class ExprTycker extends Tycker {
       }
       case Expr.Coe coe -> {
         assert coe.resolvedVar() instanceof DefVar<?, ?> defVar
-          && defVar.core instanceof PrimDef def && PrimDef.ID.isCoercion(def.id) : "desugar bug";
+          && defVar.core instanceof PrimDef def && PrimDef.ID.projSyntax(def.id) : "desugar bug";
         var defVar = coe.resolvedVar();
         var mockApp = new Expr.App(coe.sourcePos(), new Expr.App(coe.sourcePos(),
           new Expr.Ref(coe.id().sourcePos(), defVar),

--- a/base/src/main/java/org/aya/tyck/unify/TermComparator.java
+++ b/base/src/main/java/org/aya/tyck/unify/TermComparator.java
@@ -376,14 +376,15 @@ public sealed abstract class TermComparator permits Unifier {
   }
 
   private boolean compareCube(@NotNull PathTerm.Cube lhs, @NotNull PathTerm.Cube rhs, Sub lr, Sub rl) {
-    return TermComparator.withIntervals(lhs.params(), rhs.params(), lr, rl, rhs.params(), (lsub, rsub) -> {
+    var tyVars = rhs.params();
+    return ctx.withIntervals(tyVars.view(), () -> TermComparator.withIntervals(lhs.params(), rhs.params(), lr, rl, tyVars, (lsub, rsub) -> {
       var lPar = (PartialTerm) new PartialTerm(lhs.partial(), lhs.type()).subst(lsub);
       var rPar = (PartialTerm) new PartialTerm(rhs.partial(), rhs.type()).subst(rsub);
       var lType = new PartialTyTerm(lPar.rhsType(), lPar.partial().restr());
       var rType = new PartialTyTerm(rPar.rhsType(), rPar.partial().restr());
       if (!compare(lType, rType, lr, rl, null)) return false;
       return comparePartial(lPar, rPar, lType, lr, rl);
-    });
+    }));
   }
 
   private boolean compareRestr(@NotNull Restr<Term> lhs, @NotNull Restr<Term> rhs) {

--- a/base/src/main/java/org/aya/tyck/unify/TermComparator.java
+++ b/base/src/main/java/org/aya/tyck/unify/TermComparator.java
@@ -486,7 +486,7 @@ public sealed abstract class TermComparator permits Unifier {
       case CoeTerm lhs -> {
         if (!(preRhs instanceof CoeTerm rhs)) yield null;
         if (!compareRestr(lhs.restr(), rhs.restr())) yield null;
-        yield compare(lhs.type(), rhs.type(), lr, rl, PrimDef.intervalToA()) ?
+        yield compare(lhs.type(), rhs.type(), lr, rl, PrimDef.intervalToType()) ?
           PrimDef.familyLeftToRight(lhs.type()) : null;
       }
       case ConCall lhs -> switch (preRhs) {

--- a/base/src/test/resources/success/common/src/Paths.aya
+++ b/base/src/test/resources/success/common/src/Paths.aya
@@ -5,6 +5,9 @@ public open import Primitives using
   , intervalMin as infix /\ tighter \/
   , intervalMax as infix \/
   , coe
+  , eoc
+  , coeFill
+  , eocFill
   )
 
 variable A B C D : Type

--- a/base/src/test/resources/success/common/src/Primitives.aya
+++ b/base/src/test/resources/success/common/src/Primitives.aya
@@ -6,3 +6,6 @@ prim intervalMax (i j : I) : I
 prim String: Type
 prim strcat (str1 str2: String) : String
 prim coe (A : I -> Type) (i : I) : A 0 -> A 1
+prim coeFill
+prim eoc (A : I -> Type) (i : I) : A 1 -> A 0
+prim eocFill

--- a/base/src/test/resources/success/src/CubicalBasics.aya
+++ b/base/src/test/resources/success/src/CubicalBasics.aya
@@ -19,11 +19,16 @@ def transport-constant (A : I -> Type) (a : A 0) (i : I) : A i
   => (\j => A (i /\ j)).coe a freeze ~ i
 -- ^ `A (i /\ j)` normalizes to `A 0` under cofibration `~ i`, which is a constant.
 
-def transport  (A : I -> Type) (a : A 0) : A 1 => A.coe a
-def transport' (A : I -> Type) (a : A 0) : A 1 => A.coe a freeze 0
+def transp  (A : I -> Type) (a : A 0) : A 1 => A.coe a
+def transp' (A : I -> Type) (a : A 0) : A 1 => A.coe a freeze 0
+def transpInv  (A : I -> Type) (a : A 1) : A 0 => A.eoc a
+def transpInv' (A : I -> Type) (a : A 1) : A 0 => A.eoc a freeze 0
+
+example def coeFillLeft (A : I -> Type) (u : A 0) : (A.coeFill u) 0 = u => idp
+example def coeFillRight (A : I -> Type) (u : A 0) : (A.coeFill u) 1 = transp A u => idp
 
 def id {A : Type} (a: A) : A => a
-def transportID {A : Type} (a: A) : A => (transport' (\ i => A -> A) id) a
+def transportID {A : Type} (a: A) : A => (transp (\ i => A -> A) id) a
 
 def coePi (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
     (f : Pi (a : A 0) -> B 0 a) : Pi (a : A 1) -> B 1 a

--- a/base/src/test/resources/success/src/CubicalBasics.aya
+++ b/base/src/test/resources/success/src/CubicalBasics.aya
@@ -24,6 +24,9 @@ def transp' (A : I -> Type) (a : A 0) : A 1 => A.coe a freeze 0
 def transpInv  (A : I -> Type) (a : A 1) : A 0 => A.eoc a
 def transpInv' (A : I -> Type) (a : A 1) : A 0 => A.eoc a freeze 0
 
+example def coeFill0  (A : I -> Type) (u : A 0) : Path (\i => A i)     u (A.coe u) => A.coeFill u
+example def eocFill0  (A : I -> Type) (u : A 1) : Path (\i => A (~ i)) u (A.eoc u) => A.eocFill u
+
 example def coeFillLeft (A : I -> Type) (u : A 0) : (A.coeFill u) 0 = u => idp
 example def coeFillRight (A : I -> Type) (u : A 0) : (A.coeFill u) 1 = transp A u => idp
 
@@ -48,3 +51,16 @@ example def coeSigmaEq (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
     (t : Sig (x : A 0) ** B 0 x)
     : coeSigma A B t = (\i => Sig (x : A i) ** B i x).coe t
     => idp
+
+-- is my coeFill primitive elaborated correctly?
+example def coeFillAlt (A : I -> Type) (u : A 0)
+  : [| i |] A i {| ~ i := u | i := A.coe u freeze 0 |}
+  => \i => (\j => A (i /\ j)).coe u freeze (0 \/ ~ i)
+
+example def coeFillAltLeft (A : I -> Type) (u : A 0) : (coeFillAlt A u) 0 = u => idp
+example def coeFillAltRight (A : I -> Type) (u : A 0) : (coeFillAlt A u) 1 = A.coe u => idp
+
+example def coeFillAlt=coeFillPrim (A : I -> Type) (u : A 0)
+  : coeFillAlt A u = A.coeFill u
+  => idp
+

--- a/base/src/test/resources/success/src/Refparo/Demo.aya
+++ b/base/src/test/resources/success/src/Refparo/Demo.aya
@@ -1,4 +1,4 @@
-open import Paths hiding (coe)
+open import Paths hiding (coe, coeFill)
 
 open import Refparo::Model
 


### PR DESCRIPTION
This PR also changed signature of `coeFill` and `coeInvFill` to:
- `coeFill (A : I -> Type) (phi : I) : Pi (u : A 0) -> Path A u (coe A phi u)`
- `coeInvFill (A : I -> Type) (phi : I) : Pi (u : A 1) -> Path (\i => A (~ i)) u (coeInv A phi u)`

so they are desugared in the same way as `coe` and `coeInv`:
- `coe (A : I -> Type) (phi : I) : A 0 -> A 1`
- `coeInv (A : I -> Type) (phi : I) : A 1 -> A 0`