### PR TITLE
Fix tycking induction-recursion definitions

### DIFF
--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -150,14 +150,12 @@ public final class ExprTycker extends Tycker {
           var fieldName = sp.justName();
           if (!(projectee.type() instanceof StructCall structCall))
             return fail(struct, ErrorTerm.unexpected(projectee.type()), BadTypeError.structAcc(state, struct, fieldName, projectee.type()));
-          var structCore = structCall.ref().core;
-          if (structCore == null) throw new UnsupportedOperationException("TODO");
           // TODO[ice]: instantiate the type
           if (!(proj.resolvedVar() instanceof DefVar<?, ?> defVar && defVar.core instanceof FieldDef field))
             return fail(proj, new FieldError.UnknownField(sp.sourcePos(), fieldName));
           var fieldRef = field.ref();
 
-          var structSubst = DeltaExpander.buildSubst(structCore.telescope(), structCall.args());
+          var structSubst = DeltaExpander.buildSubst(Def.defTele(structCall.ref()), structCall.args());
           var tele = Term.Param.subst(fieldRef.core.selfTele, structSubst, 0);
           var teleRenamed = tele.map(Term.Param::rename);
           var access = new FieldTerm(projectee.wellTyped(), fieldRef, structCall.args(), teleRenamed.map(Term.Param::toArg));
@@ -298,7 +296,7 @@ public final class ExprTycker extends Tycker {
         var def = (DataDef) match._1;
 
         // preparing
-        var dataParam = def.telescope().first();
+        var dataParam = Def.defTele(def.ref).first();
         var sort = dataParam.type();    // the sort of type below.
         var hole = localCtx.freshHole(sort, arr.sourcePos());
         var type = new DataCall(def.ref(), 0, ImmutableSeq.of(

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -7,12 +7,12 @@ import org.aya.core.def.PrimDef;
 import org.aya.core.term.*;
 import org.aya.core.visitor.DeltaExpander;
 import org.aya.core.visitor.Subst;
-import org.aya.util.Arg;
 import org.aya.generic.Constants;
 import org.aya.generic.util.InternalException;
 import org.aya.generic.util.NormalizeMode;
 import org.aya.guest0x0.cubical.Partial;
 import org.aya.tyck.env.LocalCtx;
+import org.aya.util.Arg;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -35,10 +35,10 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       case FieldTerm access -> {
         var callRaw = whnf(term(access.of()));
         if (!(callRaw instanceof StructCall call)) yield ErrorTerm.typeOf(access);
-        var core = access.ref().core;
-        var subst = DeltaExpander.buildSubst(core.telescope(), access.fieldArgs())
-          .add(DeltaExpander.buildSubst(call.ref().core.telescope(), access.structArgs()));
-        yield core.result().subst(subst);
+        var field = access.ref();
+        var subst = DeltaExpander.buildSubst(Def.defTele(field), access.fieldArgs())
+          .add(DeltaExpander.buildSubst(Def.defTele(call.ref()), access.structArgs()));
+        yield Def.defResult(field).subst(subst);
       }
       case SigmaTerm sigma -> {
         var univ = sigma.params().view()

--- a/base/src/main/java/org/aya/tyck/unify/TermComparator.java
+++ b/base/src/main/java/org/aya/tyck/unify/TermComparator.java
@@ -254,12 +254,12 @@ public sealed abstract class TermComparator permits Unifier {
 
   private record Pair(Term lhs, Term rhs) {}
 
-  private @NotNull Term getType(@NotNull Callable lhs, @NotNull DefVar<? extends Def, ?> lhsRef) {
+  private @NotNull Term getType(@NotNull Callable lhs, @NotNull DefVar<? extends Def, ? extends Decl.Telescopic> lhsRef) {
     var substMap = MutableMap.<AnyVar, Term>create();
-    for (var pa : lhs.args().view().zip(lhsRef.core.telescope().view())) {
+    for (var pa : lhs.args().view().zip(Def.defTele(lhsRef))) {
       substMap.set(pa._2.ref(), pa._1.term());
     }
-    return lhsRef.core.result().subst(substMap);
+    return Def.defResult(lhsRef).subst(substMap);
   }
 
   private boolean doCompareTyped(@NotNull Term type, @NotNull Term lhs, @NotNull Term rhs, Sub lr, Sub rl) {
@@ -269,7 +269,7 @@ public sealed abstract class TermComparator permits Unifier {
       default -> compareUntyped(lhs, rhs, lr, rl) != null;
       case StructCall type1 -> {
         var fieldSigs = type1.ref().core.fields;
-        var paramSubst = type1.ref().core.telescope().view().zip(type1.args().view()).map(x ->
+        var paramSubst = Def.defTele(type1.ref()).view().zip(type1.args().view()).map(x ->
           Tuple.of(x._1.ref(), x._2.term())).<AnyVar, Term>toImmutableMap();
         var fieldSubst = new Subst(MutableHashMap.create());
         for (var fieldSig : fieldSigs) {

--- a/base/src/test/resources/success/src/Order.aya
+++ b/base/src/test/resources/success/src/Order.aya
@@ -9,6 +9,22 @@ def even Nat : Bool
   | zero => true
   | suc n => odd n
 
+def say (i : Universe) : Type
+  | nat => Nat
+  | pi a b => Pi (x : say a) -> say (b x)
+  | sig a b => Sig (x : say a) ** say (b x)
+
+open data Universe : Type
+  | nat
+  | pi (a : Universe) (b : say a -> Universe)
+  | sig (a : Universe) (b : say a -> Universe)
+
+def uSuc : Universe => pi  nat (\x => nat)
+def uTup : Universe => sig nat (\x => nat)
+
+def uSucVal : say uSuc => \x => suc x
+def uTupVal : say uTup => (0, 0)
+
 open data Rose (A : Type) : Type
   | infixr :> A (Forest A)
 


### PR DESCRIPTION
by using `Def.defTele(ref)` over `ref.core.telescope()`