### PR TITLE
Fix my opinions

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -17,26 +17,27 @@ Aya is under active development, so please expect bugs, usability or performance
 
 ## Showcase
 
-+ Dependent types, including pi-types, sigma types, etc.
++ Dependent types, including pi-types, sigma types, indexed families, etc.
   You could write a [type-safe interpreter][gadt].
 + De Morgan cubical type theory with generalized path types
   similar to a bounded cubical subtype.
   + Implementation prototype: [Guest0x0].
+  + Demonstration of higher inductive types: [3-torus] (three dimensional torus!!).
 + Pattern matching with first-match semantics.
-  We can implement [red-black tree][rbtree] (without deletion) elegantly.
-+ Overlapping and order-independent patterns.
-  Very [useful][oop] in theorem proving.
+  Checkout the [red-black tree][rbtree] (without deletion yet).
++ Overlapping and order-independent patterns. Very [useful][oop] in theorem proving.
 + A literate programming mode with inline code fragment support.
   We already have a prototype, but we plan to revise it before sharing demos.
 + Binary operators, with precedence specified by a partial ordering
   (instead of a number, such as in Haskell or Agda)
   which is useful for [equation reasoning][assoc].
-+ Termination checker inspired by Andreas Abel's foetus.
++ A fairly good termination checker that does not assume predicativity.
   We adapted some code from Agda's implementation to accept
   [more definitions][foetus] (which are rejected by, e.g. Arend).
 + Inference of type checking order. That is to say,
-  no syntax for forward-declarations is needed for [mutual recursions][mutual].
-+ See also stdlib candidates [style guide][stdlib-style].
+  no syntax for forward-declarations is needed for [mutual recursions][mutual],
+  induction-recursion, or induction-induction.
++ See also stdlib candidates [style guide][stdlib-style]. We have a grand plan!
 
 See also [use as a library](#use-as-a-library).
 
@@ -59,7 +60,8 @@ of IDE is IntelliJ IDEA, version 2022.3 or higher is required.
   ensure an inclusive and welcoming community atmosphere.
 + Ask [@ice1000] to become an organization member.
   + If you want to contribute, ask before doing anything.
-    We will tell you about our plans.
+    We are reluctant to accept PRs that contradict our design goals.
+    We value your time and enthusiasm, so we don't want to close your PRs :)
 
 [@ice1000]: https://github.com/ice1000
 [actions]: https://github.com/aya-prover/aya-dev/actions/workflows/gradle-check.yml/badge.svg
@@ -72,6 +74,7 @@ of IDE is IntelliJ IDEA, version 2022.3 or higher is required.
 [regularity]: ../base/src/test/resources/success/common/src/Paths.aya
 [funExt]: ../base/src/test/resources/success/common/src/Paths.aya
 [rbtree]: ../base/src/test/resources/success/common/src/Data/RedBlack.aya
+[3-torus]: ../base/src/test/resources/success/common/src/Spaces/Torus/T3.aya
 [assoc]: ../base/src/test/resources/success/src/Assoc.aya
 [foetus]: ../base/src/test/resources/success/src/FoetusLimitation.aya
 [mutual]: ../base/src/test/resources/success/src/Order.aya

--- a/base/src/test/java/org/aya/literate/LiterateTest.java
+++ b/base/src/test/java/org/aya/literate/LiterateTest.java
@@ -1,14 +1,15 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.literate;
 
 import kala.collection.Seq;
 import kala.collection.immutable.ImmutableSeq;
+import org.aya.cli.render.RenderOptions;
 import org.aya.cli.single.CompilerFlags;
 import org.aya.cli.single.SingleFileCompiler;
 import org.aya.cli.utils.MainArgs;
-import org.aya.pretty.style.AyaColorScheme;
 import org.aya.test.TestRunner;
+import org.aya.util.distill.DistillerOptions;
 import org.aya.util.error.Global;
 import org.aya.util.reporter.ThrowingReporter;
 import org.junit.jupiter.api.AfterAll;
@@ -35,7 +36,8 @@ public class LiterateTest {
     var distillInfo = new CompilerFlags.DistillInfo(
       MainArgs.DistillStage.scoped,
       MainArgs.DistillFormat.plain,
-      AyaColorScheme.INTELLIJ,
+      DistillerOptions.pretty(),
+      new RenderOptions(),
       literate);
     var flags = new CompilerFlags(CompilerFlags.Message.ASCII, false, false, distillInfo, ImmutableSeq.empty(), null);
     var compiler = new SingleFileCompiler(ThrowingReporter.INSTANCE, TestRunner.LOCATOR, null);

--- a/base/src/test/java/org/aya/literate/LiterateTest.java
+++ b/base/src/test/java/org/aya/literate/LiterateTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
 public class LiterateTest {
   @BeforeAll public static void enter() {
@@ -47,15 +48,8 @@ public class LiterateTest {
       .filter(path -> !strings.contains(path.getFileName().toString()))
       .forEachChecked(Files::delete);
     var actual = literate.resolve("test.txt");
-    var readString = Files.readAllLines(actual)
-      .stream()
-      .map(s -> s + "\n")
-      .toList();
+    var readString = Files.readAllLines(actual);
     Files.delete(actual);
-    assertEquals(Files.readAllLines(literate.resolve("standard-test.txt"))
-        .stream()
-        .map(s -> s + "\n")
-        .toList()
-      , readString);
+    assertLinesMatch(Files.readAllLines(literate.resolve("standard-test.txt")), readString);
   }
 }

--- a/base/src/test/java/org/aya/literate/LiterateTest.java
+++ b/base/src/test/java/org/aya/literate/LiterateTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
 public class LiterateTest {
@@ -35,12 +34,13 @@ public class LiterateTest {
   @Test public void literate() throws IOException {
     var literate = TestRunner.DEFAULT_TEST_DIR.resolve("literate");
     var distillInfo = new CompilerFlags.DistillInfo(
+      true,
       MainArgs.DistillStage.scoped,
       MainArgs.DistillFormat.plain,
       DistillerOptions.pretty(),
       new RenderOptions(),
       literate);
-    var flags = new CompilerFlags(CompilerFlags.Message.ASCII, false, false, distillInfo, ImmutableSeq.empty(), null);
+    var flags = new CompilerFlags(false, false, distillInfo, ImmutableSeq.empty(), null);
     var compiler = new SingleFileCompiler(ThrowingReporter.INSTANCE, TestRunner.LOCATOR, null);
     compiler.compile(literate.resolve("test.aya"), flags, null);
     var strings = List.of("test.txt", "test.aya", "standard-test.txt");

--- a/cli/src/main/java/module-info.java
+++ b/cli/src/main/java/module-info.java
@@ -26,11 +26,11 @@ module aya.cli {
   exports org.aya.cli.single;
   exports org.aya.cli.utils;
   exports org.aya.cli;
-  exports org.aya.cli.repl.render;
-  exports org.aya.cli.repl.render.vscode;
+  exports org.aya.cli.render;
+  exports org.aya.cli.render.vscode;
 
   opens org.aya.cli.library.json to com.google.gson;
   opens org.aya.cli.repl to aya.repl;
-  opens org.aya.cli.repl.render to aya.repl;
-  opens org.aya.cli.repl.render.vscode to aya.repl;
+  opens org.aya.cli.render to aya.repl;
+  opens org.aya.cli.render.vscode to aya.repl;
 }

--- a/cli/src/main/java/org/aya/cli/Main.java
+++ b/cli/src/main/java/org/aya/cli/Main.java
@@ -14,7 +14,6 @@ import org.aya.cli.single.SingleFileCompiler;
 import org.aya.cli.utils.MainArgs;
 import org.aya.core.def.PrimDef;
 import org.aya.pretty.printer.PrinterConfig;
-import org.aya.pretty.style.AyaColorScheme;
 import org.aya.tyck.trace.MarkdownTrace;
 import org.aya.tyck.trace.Trace;
 import org.jetbrains.annotations.NotNull;
@@ -53,16 +52,18 @@ public class Main extends MainArgs implements Callable<Integer> {
     var replConfig = ReplConfig.loadFromDefault();
     var distillOptions = replConfig.distillerOptions;
     var reporter = CliReporter.stdio(!asciiOnly, distillOptions, verbosity);
-    var colorScheme = switch (renderStyle) {
-      case emacs -> AyaColorScheme.EMACS;
-      case intellij -> AyaColorScheme.INTELLIJ;
-      case null -> replConfig.renderOptions.stylistOrDefault(RenderOptions.OutputTarget.Terminal).getColorScheme();
-    };
+    var renderOptions = replConfig.renderOptions;
+    switch (renderStyle) {
+      case emacs -> renderOptions.colorScheme = RenderOptions.ColorSchemeName.Emacs;
+      case intellij -> renderOptions.colorScheme = RenderOptions.ColorSchemeName.IntelliJ;
+      case null -> {}
+    }
     replConfig.close();
     var distillation = prettyStage != null ? new CompilerFlags.DistillInfo(
       prettyStage,
       prettyFormat,
-      colorScheme,
+      distillOptions,
+      renderOptions,
       Paths.get(prettyDir != null ? prettyDir : ".")
     ) : null;
     var flags = new CompilerFlags(message, interruptedTrace,
@@ -76,7 +77,7 @@ public class Main extends MainArgs implements Callable<Integer> {
       return LibraryCompiler.compile(new PrimDef.Factory(), reporter, flags, advisor, filePath);
     }
     var traceBuilder = enableTrace ? new Trace.Builder() : null;
-    var compiler = new SingleFileCompiler(reporter, null, traceBuilder, distillOptions);
+    var compiler = new SingleFileCompiler(reporter, null, traceBuilder);
     var status = compiler.compile(filePath, flags, null);
     if (traceBuilder != null)
       System.err.println(new MarkdownTrace(2, distillOptions, asciiOnly)

--- a/cli/src/main/java/org/aya/cli/Main.java
+++ b/cli/src/main/java/org/aya/cli/Main.java
@@ -5,6 +5,7 @@ package org.aya.cli;
 import org.aya.cli.library.LibraryCompiler;
 import org.aya.cli.library.incremental.CompilerAdvisor;
 import org.aya.cli.plct.PLCTReport;
+import org.aya.cli.render.RenderOptions;
 import org.aya.cli.repl.AyaRepl;
 import org.aya.cli.repl.ReplConfig;
 import org.aya.cli.single.CliReporter;
@@ -52,13 +53,11 @@ public class Main extends MainArgs implements Callable<Integer> {
     var replConfig = ReplConfig.loadFromDefault();
     var distillOptions = replConfig.distillerOptions;
     var reporter = CliReporter.stdio(!asciiOnly, distillOptions, verbosity);
-    var colorScheme = replConfig.renderOptions.buildColorScheme();
-    if (renderStyle != null) {
-      colorScheme = switch (renderStyle) {
-        case emacs -> AyaColorScheme.EMACS;
-        case intellij -> AyaColorScheme.INTELLIJ;
-      };
-    }
+    var colorScheme = switch (renderStyle) {
+      case emacs -> AyaColorScheme.EMACS;
+      case intellij -> AyaColorScheme.INTELLIJ;
+      case null -> replConfig.renderOptions.stylistOrDefault(RenderOptions.OutputTarget.Terminal).getColorScheme();
+    };
     replConfig.close();
     var distillation = prettyStage != null ? new CompilerFlags.DistillInfo(
       prettyStage,

--- a/cli/src/main/java/org/aya/cli/Main.java
+++ b/cli/src/main/java/org/aya/cli/Main.java
@@ -60,6 +60,7 @@ public class Main extends MainArgs implements Callable<Integer> {
     }
     replConfig.close();
     var distillation = prettyStage != null ? new CompilerFlags.DistillInfo(
+      asciiOnly,
       prettyStage,
       prettyFormat,
       distillOptions,

--- a/cli/src/main/java/org/aya/cli/render/Color.java
+++ b/cli/src/main/java/org/aya/cli/render/Color.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
-package org.aya.cli.repl.render;
+package org.aya.cli.render;
 
 import com.google.gson.*;
 import kala.control.Try;

--- a/cli/src/main/java/org/aya/cli/render/RenderOptions.java
+++ b/cli/src/main/java/org/aya/cli/render/RenderOptions.java
@@ -101,8 +101,8 @@ public class RenderOptions {
     }
   }
 
-  public @NotNull String render(@NotNull OutputTarget output, @NotNull Doc doc, boolean witHeader) {
-    return render(output, doc, StringPrinterConfig.INFINITE_SIZE, true, witHeader);
+  public @NotNull String render(@NotNull OutputTarget output, @NotNull Doc doc, boolean witHeader, boolean unicode) {
+    return render(output, doc, StringPrinterConfig.INFINITE_SIZE, unicode, witHeader);
   }
 
   public @NotNull String render(@NotNull OutputTarget output, @NotNull Doc doc, int pageWidth, boolean unicode, boolean witHeader) {

--- a/cli/src/main/java/org/aya/cli/render/RenderOptions.java
+++ b/cli/src/main/java/org/aya/cli/render/RenderOptions.java
@@ -18,6 +18,7 @@ import org.aya.pretty.printer.ColorScheme;
 import org.aya.pretty.printer.StyleFamily;
 import org.aya.pretty.style.AyaColorScheme;
 import org.aya.pretty.style.AyaStyleFamily;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
@@ -29,10 +30,16 @@ import java.util.Objects;
 /** Multi-target {@link org.aya.pretty.printer.Stylist}, usually created from json files. */
 public class RenderOptions {
   public enum OutputTarget {
-    Terminal,
-    LaTeX,
-    HTML,
-    Plain,
+    Terminal(".txt"),
+    LaTeX(".tex"),
+    HTML(".html"),
+    Plain(".txt");
+
+    public final @NotNull @NonNls String fileExt;
+
+    OutputTarget(@NotNull String fileExt) {
+      this.fileExt = fileExt;
+    }
   }
 
   public enum ColorSchemeName {

--- a/cli/src/main/java/org/aya/cli/render/adapter/EitherAdapter.java
+++ b/cli/src/main/java/org/aya/cli/render/adapter/EitherAdapter.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
-package org.aya.cli.repl.render.adapter;
+package org.aya.cli.render.adapter;
 
 import com.google.gson.*;
 import kala.control.Either;

--- a/cli/src/main/java/org/aya/cli/render/vscode/ColorTheme.java
+++ b/cli/src/main/java/org/aya/cli/render/vscode/ColorTheme.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
-package org.aya.cli.repl.render.vscode;
+package org.aya.cli.render.vscode;
 
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
@@ -12,8 +12,8 @@ import kala.control.Either;
 import kala.control.Option;
 import kala.control.Try;
 import kala.value.LazyValue;
-import org.aya.cli.repl.render.Color;
-import org.aya.cli.repl.render.adapter.EitherAdapter;
+import org.aya.cli.render.Color;
+import org.aya.cli.render.adapter.EitherAdapter;
 import org.aya.pretty.printer.ColorScheme;
 import org.aya.pretty.style.AyaColorScheme;
 import org.jetbrains.annotations.NotNull;

--- a/cli/src/main/java/org/aya/cli/render/vscode/VscColorTheme.java
+++ b/cli/src/main/java/org/aya/cli/render/vscode/VscColorTheme.java
@@ -1,12 +1,12 @@
 // Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
-package org.aya.cli.repl.render.vscode;
+package org.aya.cli.render.vscode;
 
 import kala.collection.Seq;
 import kala.collection.immutable.ImmutableMap;
 import kala.collection.mutable.MutableMap;
 import kala.control.Either;
-import org.aya.cli.repl.render.Color;
+import org.aya.cli.render.Color;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;

--- a/cli/src/main/java/org/aya/cli/repl/ReplCommands.java
+++ b/cli/src/main/java/org/aya/cli/repl/ReplCommands.java
@@ -7,7 +7,7 @@ import kala.collection.Seq;
 import kala.collection.immutable.ImmutableArray;
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.cli.parse.AyaParserImpl;
-import org.aya.cli.repl.render.RenderOptions;
+import org.aya.cli.render.RenderOptions;
 import org.aya.distill.Codifier;
 import org.aya.generic.util.NormalizeMode;
 import org.aya.pretty.doc.Doc;

--- a/cli/src/main/java/org/aya/cli/repl/ReplConfig.java
+++ b/cli/src/main/java/org/aya/cli/repl/ReplConfig.java
@@ -35,7 +35,7 @@ public class ReplConfig implements AutoCloseable {
    * DO NOT modify this directly, use setRenderOptions instead.
    */
   public @UnknownNullability RenderOptions renderOptions = new RenderOptions();
-  public transient @NotNull StringStylist stylist;
+  public transient @NotNull UnixTermStylist stylist;
   public static final UnixTermStylist DEFAULT_STYLIST = new UnixTermStylist(AyaColorScheme.EMACS, AyaStyleFamily.ADAPTIVE_CLI);
 
   public ReplConfig(@NotNull Path file) {

--- a/cli/src/main/java/org/aya/cli/repl/ReplConfig.java
+++ b/cli/src/main/java/org/aya/cli/repl/ReplConfig.java
@@ -9,7 +9,6 @@ import org.aya.cli.render.Color;
 import org.aya.cli.render.RenderOptions;
 import org.aya.generic.util.AyaHome;
 import org.aya.generic.util.NormalizeMode;
-import org.aya.pretty.backend.string.StringStylist;
 import org.aya.util.distill.DistillerOptions;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -34,11 +33,9 @@ public class ReplConfig implements AutoCloseable {
    * DO NOT modify this directly, use setRenderOptions instead.
    */
   public @UnknownNullability RenderOptions renderOptions = new RenderOptions();
-  public transient @NotNull StringStylist stylist;
 
   public ReplConfig(@NotNull Path file) {
     this.configFile = file;
-    this.stylist = renderOptions.defaultStylist(DEFAULT_OUTPUT_TARGET);
   }
 
   private void checkInitialization() throws JsonParseException {
@@ -46,15 +43,7 @@ public class ReplConfig implements AutoCloseable {
 
     // maintain the Nullability, renderOptions is probably null after deserializing
     if (renderOptions == null) renderOptions = new RenderOptions();
-    try {
-      renderOptions.checkInitialize();
-      stylist = renderOptions.stylist(DEFAULT_OUTPUT_TARGET);
-    } catch (IOException | JsonParseException ex) {
-      // don't halt loading
-      // use default stylist but not change the user's settings.
-      // TODO: report error but don't stop
-      stylist = renderOptions.defaultStylist(DEFAULT_OUTPUT_TARGET);
-    }
+    renderOptions.checkInitialize();
   }
 
   public static @NotNull ReplConfig loadFromDefault() throws IOException, JsonParseException {
@@ -86,7 +75,6 @@ public class ReplConfig implements AutoCloseable {
 
   public void setRenderOptions(@NotNull RenderOptions options) throws IOException, JsonParseException {
     this.renderOptions = options;
-    this.stylist = options.stylist(DEFAULT_OUTPUT_TARGET);
   }
 
   @SuppressWarnings("MethodDoesntCallSuperMethod")
@@ -98,9 +86,5 @@ public class ReplConfig implements AutoCloseable {
     newOne.path = this.renderOptions.path;
 
     return newOne;
-  }
-
-  public @NotNull StringStylist getStylist() {
-    return this.stylist;
   }
 }

--- a/cli/src/main/java/org/aya/cli/repl/ReplConfig.java
+++ b/cli/src/main/java/org/aya/cli/repl/ReplConfig.java
@@ -75,6 +75,8 @@ public class ReplConfig implements AutoCloseable {
 
   public void setRenderOptions(@NotNull RenderOptions options) throws IOException, JsonParseException {
     this.renderOptions = options;
+    // trigger a load for instantly reporting errors to users
+    renderOptions.stylist(RenderOptions.OutputTarget.Terminal);
   }
 
   @SuppressWarnings("MethodDoesntCallSuperMethod")

--- a/cli/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
+++ b/cli/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
@@ -78,10 +78,7 @@ public final class JlineRepl extends AyaRepl {
   }
 
   @Override public @NotNull String renderDoc(@NotNull Doc doc) {
-    var printerConfig = new StringPrinterConfig(
-      config.getStylist(),
-      prettyPrintWidth,
-      config.enableUnicode);
+    var printerConfig = new StringPrinterConfig(config.getStylist(), prettyPrintWidth, config.enableUnicode);
     return doc.renderToString(printerConfig);
   }
 

--- a/cli/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
+++ b/cli/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
@@ -4,12 +4,12 @@ package org.aya.cli.repl.jline;
 
 import com.intellij.lexer.FlexLexer;
 import kala.collection.immutable.ImmutableSeq;
+import org.aya.cli.render.RenderOptions;
 import org.aya.cli.repl.AyaRepl;
 import org.aya.cli.repl.ReplConfig;
 import org.aya.distill.BaseDistiller;
 import org.aya.generic.util.AyaHome;
 import org.aya.parser.AyaParserDefinitionBase;
-import org.aya.pretty.backend.string.StringPrinterConfig;
 import org.aya.pretty.doc.Doc;
 import org.aya.repl.CmdCompleter;
 import org.aya.repl.ReplUtil;
@@ -78,8 +78,8 @@ public final class JlineRepl extends AyaRepl {
   }
 
   @Override public @NotNull String renderDoc(@NotNull Doc doc) {
-    var printerConfig = new StringPrinterConfig(config.getStylist(), prettyPrintWidth, config.enableUnicode);
-    return doc.renderToString(printerConfig);
+    return config.renderOptions.render(RenderOptions.OutputTarget.Terminal,
+      doc, prettyPrintWidth, config.enableUnicode, true);
   }
 
   @Override public void println(@NotNull String x) {

--- a/cli/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
+++ b/cli/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
@@ -26,9 +26,7 @@ import org.jline.reader.impl.completer.AggregateCompleter;
 import org.jline.reader.impl.history.DefaultHistory;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
-import org.jline.terminal.impl.AbstractWindowsTerminal;
 import org.jline.terminal.impl.DumbTerminal;
-import org.jline.utils.AttributedString;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -88,8 +86,7 @@ public final class JlineRepl extends AyaRepl {
   }
 
   @Override public void println(@NotNull String x) {
-    if (terminal instanceof AbstractWindowsTerminal) terminal.writer().println(AttributedString.fromAnsi(x));
-    else terminal.writer().println(x);
+    terminal.writer().println(x);
     terminal.flush();
   }
 

--- a/cli/src/main/java/org/aya/cli/single/CompilerFlags.java
+++ b/cli/src/main/java/org/aya/cli/single/CompilerFlags.java
@@ -1,10 +1,11 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.cli.single;
 
 import kala.collection.SeqLike;
+import org.aya.cli.render.RenderOptions;
 import org.aya.cli.utils.MainArgs;
-import org.aya.pretty.printer.ColorScheme;
+import org.aya.util.distill.DistillerOptions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,7 +22,8 @@ public record CompilerFlags(
   public record DistillInfo(
     @NotNull MainArgs.DistillStage distillStage,
     @NotNull MainArgs.DistillFormat distillFormat,
-    @NotNull ColorScheme scheme,
+    @NotNull DistillerOptions distillerOptions,
+    @NotNull RenderOptions renderOptions,
     @NotNull Path distillDir
   ) {
   }

--- a/cli/src/main/java/org/aya/cli/single/CompilerFlags.java
+++ b/cli/src/main/java/org/aya/cli/single/CompilerFlags.java
@@ -19,7 +19,13 @@ public record CompilerFlags(
   @NotNull SeqLike<Path> modulePaths,
   @Nullable Path outputFile
 ) {
+  public CompilerFlags(boolean interruptedTrace, boolean remake, @NotNull DistillInfo distillInfo, @NotNull SeqLike<Path> modulePaths, @Nullable Path outputFile) {
+    this(distillInfo.ascii ? Message.ASCII : Message.EMOJI,
+      interruptedTrace, remake, distillInfo, modulePaths, outputFile);
+  }
+
   public record DistillInfo(
+    boolean ascii,
     @NotNull MainArgs.DistillStage distillStage,
     @NotNull MainArgs.DistillFormat distillFormat,
     @NotNull DistillerOptions distillerOptions,

--- a/cli/src/main/java/org/aya/cli/single/SingleFileCompiler.java
+++ b/cli/src/main/java/org/aya/cli/single/SingleFileCompiler.java
@@ -13,7 +13,9 @@ import org.aya.core.def.PrimDef;
 import org.aya.core.serde.Serializer;
 import org.aya.generic.AyaDocile;
 import org.aya.pretty.backend.html.DocHtmlPrinter;
+import org.aya.pretty.backend.html.Html5Stylist;
 import org.aya.pretty.backend.latex.DocTeXPrinter;
+import org.aya.pretty.backend.latex.TeXStylist;
 import org.aya.pretty.backend.string.StringPrinterConfig;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.printer.PrinterConfig;
@@ -98,9 +100,9 @@ public record SingleFileCompiler(
     var scm = flags.scheme();
     switch (flags.distillFormat()) {
       case html -> doWrite(doc, distillDir, fileName, ".html", (d, b) -> d.render(new DocHtmlPrinter(),
-        new DocHtmlPrinter.Config(scm, AyaStyleFamily.DEFAULT, b)));
+        new DocHtmlPrinter.Config(new Html5Stylist(scm, AyaStyleFamily.DEFAULT), b)));
       case latex -> doWrite(doc, distillDir, fileName, ".tex", (d, $) -> d.render(new DocTeXPrinter(),
-        new DocTeXPrinter.Config(scm, AyaStyleFamily.DEFAULT)));
+        new DocTeXPrinter.Config(new TeXStylist(scm, AyaStyleFamily.DEFAULT))));
       case plain -> doWrite(doc, distillDir, fileName, ".txt", (d, $) -> d.debugRender());
       case unix -> doWrite(doc, distillDir, fileName, ".txt", (d, $) -> d.renderToString(
         StringPrinterConfig.unixTerminal(scm, AyaStyleFamily.DEFAULT, PrinterConfig.INFINITE_SIZE, true)));

--- a/cli/src/main/java/org/aya/cli/single/SingleFileCompiler.java
+++ b/cli/src/main/java/org/aya/cli/single/SingleFileCompiler.java
@@ -88,7 +88,7 @@ public record SingleFileCompiler(
     var renderOptions = flags.renderOptions();
     var out = flags.distillFormat().target;
     doWrite(doc, distillDir, flags.distillerOptions(), fileName, out.fileExt,
-      (d, hdr) -> renderOptions.render(out, d, hdr));
+      (d, hdr) -> renderOptions.render(out, d, hdr, !flags.ascii()));
   }
 
   private @NotNull String escape(@NotNull String s) {

--- a/cli/src/main/java/org/aya/cli/single/SingleFileCompiler.java
+++ b/cli/src/main/java/org/aya/cli/single/SingleFileCompiler.java
@@ -4,9 +4,7 @@ package org.aya.cli.single;
 
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
-import kala.tuple.Tuple;
 import org.aya.cli.parse.AyaParserImpl;
-import org.aya.cli.render.RenderOptions;
 import org.aya.cli.utils.AyaCompiler;
 import org.aya.cli.utils.MainArgs;
 import org.aya.concrete.stmt.Decl;
@@ -88,14 +86,9 @@ public record SingleFileCompiler(
     if (!Files.exists(distillDir)) Files.createDirectories(distillDir);
     var fileName = escape(ayaFileName.substring(0, dotIndex > 0 ? dotIndex : ayaFileName.length()));
     var renderOptions = flags.renderOptions();
-    var out = switch (flags.distillFormat()) {
-      case html -> Tuple.of(".html",RenderOptions.OutputTarget.HTML);
-      case latex -> Tuple.of(".tex",RenderOptions.OutputTarget.LaTeX);
-      case plain -> Tuple.of(".txt",RenderOptions.OutputTarget.Plain);
-      case unix -> Tuple.of(".txt",RenderOptions.OutputTarget.Terminal);
-    };
-    doWrite(doc, distillDir, flags.distillerOptions(), fileName, out._1,
-      (d, hdr) -> renderOptions.render(out._2, d, hdr));
+    var out = flags.distillFormat().target;
+    doWrite(doc, distillDir, flags.distillerOptions(), fileName, out.fileExt,
+      (d, hdr) -> renderOptions.render(out, d, hdr));
   }
 
   private @NotNull String escape(@NotNull String s) {

--- a/cli/src/main/java/org/aya/cli/utils/MainArgs.java
+++ b/cli/src/main/java/org/aya/cli/utils/MainArgs.java
@@ -3,8 +3,10 @@
 package org.aya.cli.utils;
 
 import kala.collection.immutable.ImmutableSeq;
+import org.aya.cli.render.RenderOptions;
 import org.aya.prelude.GeneratedVersion;
 import org.aya.util.reporter.Problem;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -106,10 +108,16 @@ public class MainArgs {
   }
 
   public enum DistillFormat {
-    html,
-    plain,
-    latex,
-    unix,
+    html(RenderOptions.OutputTarget.HTML),
+    plain(RenderOptions.OutputTarget.Plain),
+    latex(RenderOptions.OutputTarget.LaTeX),
+    unix(RenderOptions.OutputTarget.Terminal);
+
+    public final @NotNull RenderOptions.OutputTarget target;
+
+    DistillFormat(RenderOptions.@NotNull OutputTarget target) {
+      this.target = target;
+    }
   }
 
   public enum ReplType {

--- a/cli/src/test/java/org/aya/cli/ImGuiTrace.java
+++ b/cli/src/test/java/org/aya/cli/ImGuiTrace.java
@@ -168,9 +168,9 @@ public class ImGuiTrace {
   public static void main(String[] args) throws IOException {
     var traceBuilder = new Trace.Builder();
     var compiler = new SingleFileCompiler(CliReporter.stdio(true, DistillerOptions.informative(), Problem.Severity.WARN),
-      null, traceBuilder, DistillerOptions.informative());
+      null, traceBuilder);
     var sourceFile = Paths.get("test.aya");
-    var status = compiler.compile(sourceFile,
+    compiler.compile(sourceFile,
       new CompilerFlags(CompilerFlags.Message.EMOJI,
         true, true, null, Seq.of(), null
       ), null);

--- a/cli/src/test/java/org/aya/cli/RenderOptionsTest.java
+++ b/cli/src/test/java/org/aya/cli/RenderOptionsTest.java
@@ -2,8 +2,8 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.cli;
 
+import org.aya.cli.render.RenderOptions;
 import org.aya.cli.repl.ReplConfig;
-import org.aya.cli.repl.render.RenderOptions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/cli/src/test/java/org/aya/cli/VscColorThemeTest.java
+++ b/cli/src/test/java/org/aya/cli/VscColorThemeTest.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.cli;
 
-import org.aya.cli.repl.render.vscode.ColorTheme;
+import org.aya.cli.render.vscode.ColorTheme;
 import org.aya.pretty.style.AyaColorScheme;
 import org.junit.jupiter.api.Test;
 

--- a/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
@@ -6,10 +6,6 @@ import org.aya.pretty.backend.string.Cursor;
 import org.aya.pretty.backend.string.StringPrinter;
 import org.aya.pretty.backend.string.StringPrinterConfig;
 import org.aya.pretty.doc.Doc;
-import org.aya.pretty.printer.ColorScheme;
-import org.aya.pretty.printer.StyleFamily;
-import org.aya.pretty.style.AyaColorScheme;
-import org.aya.pretty.style.AyaStyleFamily;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NotNull;
 
@@ -83,11 +79,11 @@ public class DocHtmlPrinter extends StringPrinter<DocHtmlPrinter.Config> {
     public final boolean withHeader;
 
     public Config(boolean withHeader) {
-      this(AyaColorScheme.EMACS, AyaStyleFamily.DEFAULT, withHeader);
+      this(Html5Stylist.DEFAULT, withHeader);
     }
 
-    public Config(ColorScheme colorScheme, StyleFamily styleFamily, boolean withHeader) {
-      super(new Html5Stylist(colorScheme, styleFamily), INFINITE_SIZE, true);
+    public Config(@NotNull Html5Stylist stylist, boolean withHeader) {
+      super(stylist, INFINITE_SIZE, true);
       this.withHeader = withHeader;
     }
   }

--- a/pretty/src/main/java/org/aya/pretty/backend/html/Html5Stylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/Html5Stylist.java
@@ -6,9 +6,13 @@ import org.aya.pretty.backend.string.style.ClosingStylist;
 import org.aya.pretty.doc.Style;
 import org.aya.pretty.printer.ColorScheme;
 import org.aya.pretty.printer.StyleFamily;
+import org.aya.pretty.style.AyaColorScheme;
+import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 public class Html5Stylist extends ClosingStylist {
+  public static final @NotNull Html5Stylist DEFAULT = new Html5Stylist(AyaColorScheme.EMACS, AyaStyleFamily.DEFAULT);
+
   public Html5Stylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
     super(colorScheme, styleFamily);
   }

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -8,10 +8,6 @@ import kala.tuple.Tuple2;
 import org.aya.pretty.backend.string.Cursor;
 import org.aya.pretty.backend.string.StringPrinter;
 import org.aya.pretty.backend.string.StringPrinterConfig;
-import org.aya.pretty.printer.ColorScheme;
-import org.aya.pretty.printer.StyleFamily;
-import org.aya.pretty.style.AyaColorScheme;
-import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -78,10 +74,10 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
    */
   public static class Config extends StringPrinterConfig {
     public Config() {
-      this(AyaColorScheme.INTELLIJ, AyaStyleFamily.DEFAULT);
+      this(TeXStylist.DEFAULT);
     }
-    public Config(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
-      super(new TeXStylist(colorScheme, styleFamily), INFINITE_SIZE, false);
+    public Config(@NotNull TeXStylist stylist) {
+      super(stylist, INFINITE_SIZE, false);
     }
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/TeXStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/TeXStylist.java
@@ -6,9 +6,13 @@ import org.aya.pretty.backend.string.style.ClosingStylist;
 import org.aya.pretty.doc.Style;
 import org.aya.pretty.printer.ColorScheme;
 import org.aya.pretty.printer.StyleFamily;
+import org.aya.pretty.style.AyaColorScheme;
+import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 public class TeXStylist extends ClosingStylist {
+  public static final @NotNull TeXStylist DEFAULT = new TeXStylist(AyaColorScheme.INTELLIJ, AyaStyleFamily.DEFAULT);
+
   public TeXStylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
     super(colorScheme, styleFamily);
   }

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinterConfig.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinterConfig.java
@@ -2,12 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.string;
 
-import org.aya.pretty.backend.string.style.UnixTermStylist;
-import org.aya.pretty.printer.ColorScheme;
 import org.aya.pretty.printer.PrinterConfig;
-import org.aya.pretty.printer.StyleFamily;
-import org.aya.pretty.style.AyaColorScheme;
-import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 public class StringPrinterConfig extends PrinterConfig.Basic {
@@ -20,23 +15,5 @@ public class StringPrinterConfig extends PrinterConfig.Basic {
 
   @Override public @NotNull StringStylist getStylist() {
     return (StringStylist) super.getStylist();
-  }
-
-  public static @NotNull StringPrinterConfig unixTerminal(
-    @NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily,
-    int pageWidth, boolean unicode) {
-    return new StringPrinterConfig(new UnixTermStylist(colorScheme, styleFamily), pageWidth, unicode);
-  }
-
-  public static @NotNull StringPrinterConfig unixTerminal(@NotNull StyleFamily styleFamily, int pageWidth, boolean unicode) {
-    return new StringPrinterConfig(new UnixTermStylist(AyaColorScheme.EMACS, styleFamily), pageWidth, unicode);
-  }
-
-  public static @NotNull StringPrinterConfig unixTerminal(int pageWidth) {
-    return unixTerminal(AyaStyleFamily.DEFAULT, pageWidth, true);
-  }
-
-  public static @NotNull StringPrinterConfig unixTerminal() {
-    return unixTerminal(INFINITE_SIZE);
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/string/style/AdaptiveCliStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/style/AdaptiveCliStylist.java
@@ -1,0 +1,32 @@
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.pretty.backend.string.style;
+
+import kala.collection.mutable.MutableMap;
+import kala.tuple.Tuple;
+import org.aya.pretty.backend.string.custom.UnixTermStyle;
+import org.aya.pretty.doc.Style;
+import org.aya.pretty.printer.ColorScheme;
+import org.aya.pretty.printer.StyleFamily;
+import org.aya.pretty.style.AyaStyleFamily;
+import org.jetbrains.annotations.NotNull;
+
+/** use colors from terminal instead of absolute colors to protect eyes */
+public class AdaptiveCliStylist extends UnixTermStylist {
+  public static final @NotNull AdaptiveCliStylist INSTANCE = new AdaptiveCliStylist();
+
+  public AdaptiveCliStylist() {
+    super(MutableMap::create, ADAPTIVE_CLI);
+  }
+
+  private static final @NotNull StyleFamily ADAPTIVE_CLI = new AyaStyleFamily(MutableMap.ofEntries(
+    Tuple.of(AyaStyleFamily.Key.Keyword.key(), Style.color(ColorScheme.colorOf(1.0f, 0.43f, 0)).and()),
+    Tuple.of(AyaStyleFamily.Key.PrimCall.key(), Style.color(ColorScheme.colorOf(1.0f, 0.43f, 0)).and()),
+    Tuple.of(AyaStyleFamily.Key.FnCall.key(), UnixTermStyle.TerminalYellow.and()),
+    Tuple.of(AyaStyleFamily.Key.DataCall.key(), UnixTermStyle.TerminalGreen.and()),
+    Tuple.of(AyaStyleFamily.Key.StructCall.key(), UnixTermStyle.TerminalGreen.and()),
+    Tuple.of(AyaStyleFamily.Key.ConCall.key(), UnixTermStyle.TerminalBlue.and()),
+    Tuple.of(AyaStyleFamily.Key.FieldCall.key(), UnixTermStyle.TerminalBlue.and()),
+    Tuple.of(AyaStyleFamily.Key.Generalized.key(), Style.italic().and())
+  ));
+}

--- a/pretty/src/main/java/org/aya/pretty/backend/string/style/AdaptiveCliStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/style/AdaptiveCliStylist.java
@@ -7,7 +7,6 @@ import kala.tuple.Tuple;
 import org.aya.pretty.backend.string.custom.UnixTermStyle;
 import org.aya.pretty.doc.Style;
 import org.aya.pretty.printer.ColorScheme;
-import org.aya.pretty.printer.StyleFamily;
 import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
 
@@ -15,18 +14,16 @@ import org.jetbrains.annotations.NotNull;
 public class AdaptiveCliStylist extends UnixTermStylist {
   public static final @NotNull AdaptiveCliStylist INSTANCE = new AdaptiveCliStylist();
 
-  public AdaptiveCliStylist() {
-    super(MutableMap::create, ADAPTIVE_CLI);
+  private AdaptiveCliStylist() {
+    super(MutableMap::create, new AyaStyleFamily(MutableMap.ofEntries(
+      Tuple.of(AyaStyleFamily.Key.Keyword.key(), Style.color(ColorScheme.colorOf(1.0f, 0.43f, 0)).and()),
+      Tuple.of(AyaStyleFamily.Key.PrimCall.key(), Style.color(ColorScheme.colorOf(1.0f, 0.43f, 0)).and()),
+      Tuple.of(AyaStyleFamily.Key.FnCall.key(), UnixTermStyle.TerminalYellow.and()),
+      Tuple.of(AyaStyleFamily.Key.DataCall.key(), UnixTermStyle.TerminalGreen.and()),
+      Tuple.of(AyaStyleFamily.Key.StructCall.key(), UnixTermStyle.TerminalGreen.and()),
+      Tuple.of(AyaStyleFamily.Key.ConCall.key(), UnixTermStyle.TerminalBlue.and()),
+      Tuple.of(AyaStyleFamily.Key.FieldCall.key(), UnixTermStyle.TerminalBlue.and()),
+      Tuple.of(AyaStyleFamily.Key.Generalized.key(), Style.italic().and())
+    )));
   }
-
-  private static final @NotNull StyleFamily ADAPTIVE_CLI = new AyaStyleFamily(MutableMap.ofEntries(
-    Tuple.of(AyaStyleFamily.Key.Keyword.key(), Style.color(ColorScheme.colorOf(1.0f, 0.43f, 0)).and()),
-    Tuple.of(AyaStyleFamily.Key.PrimCall.key(), Style.color(ColorScheme.colorOf(1.0f, 0.43f, 0)).and()),
-    Tuple.of(AyaStyleFamily.Key.FnCall.key(), UnixTermStyle.TerminalYellow.and()),
-    Tuple.of(AyaStyleFamily.Key.DataCall.key(), UnixTermStyle.TerminalGreen.and()),
-    Tuple.of(AyaStyleFamily.Key.StructCall.key(), UnixTermStyle.TerminalGreen.and()),
-    Tuple.of(AyaStyleFamily.Key.ConCall.key(), UnixTermStyle.TerminalBlue.and()),
-    Tuple.of(AyaStyleFamily.Key.FieldCall.key(), UnixTermStyle.TerminalBlue.and()),
-    Tuple.of(AyaStyleFamily.Key.Generalized.key(), Style.italic().and())
-  ));
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/string/style/DebugStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/style/DebugStylist.java
@@ -6,6 +6,8 @@ import kala.collection.Seq;
 import org.aya.pretty.backend.string.Cursor;
 import org.aya.pretty.backend.string.StringStylist;
 import org.aya.pretty.doc.Style;
+import org.aya.pretty.printer.ColorScheme;
+import org.aya.pretty.printer.StyleFamily;
 import org.aya.pretty.style.AyaColorScheme;
 import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
@@ -14,10 +16,10 @@ import org.jetbrains.annotations.NotNull;
  * @author kiva, ice1000
  */
 public class DebugStylist extends StringStylist {
-  public static final DebugStylist INSTANCE = new DebugStylist();
+  public static final DebugStylist DEFAULT = new DebugStylist(AyaColorScheme.INTELLIJ, AyaStyleFamily.DEFAULT);
 
-  private DebugStylist() {
-    super(AyaColorScheme.INTELLIJ, AyaStyleFamily.DEFAULT);
+  public DebugStylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
+    super(colorScheme, styleFamily);
   }
 
   @Override public void format(@NotNull Seq<Style> style, @NotNull Cursor cursor, @NotNull Runnable inside) {

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -71,7 +71,7 @@ public sealed interface Doc extends Docile {
   }
 
   default @NotNull String renderWithPageWidth(int pageWidth, boolean unicode) {
-    var config = new StringPrinterConfig(DebugStylist.INSTANCE, pageWidth, unicode);
+    var config = new StringPrinterConfig(DebugStylist.DEFAULT, pageWidth, unicode);
     return this.renderToString(config);
   }
 

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -55,7 +55,11 @@ public sealed interface Doc extends Docile {
   }
 
   default @NotNull String renderToTerminal() {
-    return renderToString(new StringPrinterConfig(AdaptiveCliStylist.INSTANCE, INFINITE_SIZE, true));
+    return renderToTerminal(INFINITE_SIZE, true);
+  }
+
+  default @NotNull String renderToTerminal(int pageWidth, boolean unicode) {
+    return renderToString(new StringPrinterConfig(AdaptiveCliStylist.INSTANCE, pageWidth, unicode));
   }
 
   default @NotNull String renderToHtml() {

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -11,6 +11,7 @@ import org.aya.pretty.backend.latex.DocTeXPrinter;
 import org.aya.pretty.backend.string.LinkId;
 import org.aya.pretty.backend.string.StringPrinter;
 import org.aya.pretty.backend.string.StringPrinterConfig;
+import org.aya.pretty.backend.string.style.AdaptiveCliStylist;
 import org.aya.pretty.backend.string.style.DebugStylist;
 import org.aya.pretty.printer.Printer;
 import org.aya.pretty.printer.PrinterConfig;
@@ -51,6 +52,10 @@ public sealed interface Doc extends Docile {
   default @NotNull String renderToString(@NotNull StringPrinterConfig config) {
     var printer = new StringPrinter<>();
     return this.render(printer, config);
+  }
+
+  default @NotNull String renderToTerminal() {
+    return renderToString(new StringPrinterConfig(AdaptiveCliStylist.INSTANCE, INFINITE_SIZE, true));
   }
 
   default @NotNull String renderToHtml() {

--- a/pretty/src/main/java/org/aya/pretty/printer/Stylist.java
+++ b/pretty/src/main/java/org/aya/pretty/printer/Stylist.java
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.printer;
 
-import org.aya.pretty.style.AyaColorScheme;
-import org.aya.pretty.style.AyaStyleFamily;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -13,16 +11,12 @@ public abstract class Stylist {
   protected @NotNull ColorScheme colorScheme;
   protected @NotNull StyleFamily styleFamily;
 
-  public Stylist() {
-    this(AyaColorScheme.EMACS, AyaStyleFamily.DEFAULT);
-  }
-
   public Stylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
     this.colorScheme = colorScheme;
     this.styleFamily = styleFamily;
   }
 
-  public void setStyleFamily(@NotNull StyleFamily styleFamily) {
-    this.styleFamily = styleFamily;
+  public @NotNull ColorScheme getColorScheme() {
+    return colorScheme;
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/printer/Stylist.java
+++ b/pretty/src/main/java/org/aya/pretty/printer/Stylist.java
@@ -15,8 +15,4 @@ public abstract class Stylist {
     this.colorScheme = colorScheme;
     this.styleFamily = styleFamily;
   }
-
-  public @NotNull ColorScheme getColorScheme() {
-    return colorScheme;
-  }
 }

--- a/pretty/src/main/java/org/aya/pretty/style/AyaColorScheme.java
+++ b/pretty/src/main/java/org/aya/pretty/style/AyaColorScheme.java
@@ -52,6 +52,4 @@ public record AyaColorScheme(
     Tuple.of(Key.ConCall.key(), 0x067D17),
     Tuple.of(Key.FieldCall.key(), 0x871094)
   ));
-
-  public static final @NotNull AyaColorScheme EMPTY = new AyaColorScheme(MutableMap.create());
 }

--- a/pretty/src/main/java/org/aya/pretty/style/AyaStyleFamily.java
+++ b/pretty/src/main/java/org/aya/pretty/style/AyaStyleFamily.java
@@ -4,7 +4,6 @@ package org.aya.pretty.style;
 
 import kala.collection.mutable.MutableMap;
 import kala.tuple.Tuple;
-import org.aya.pretty.backend.string.custom.UnixTermStyle;
 import org.aya.pretty.doc.Style;
 import org.aya.pretty.doc.Styles;
 import org.aya.pretty.printer.StyleFamily;
@@ -43,17 +42,5 @@ public record AyaStyleFamily(
     Tuple.of(Key.ConCall.key(), Style.color(AyaColorScheme.Key.ConCall.key()).and()),
     Tuple.of(Key.FieldCall.key(), Style.color(AyaColorScheme.Key.FieldCall.key()).and()),
     Tuple.of(Key.Generalized.key(), Style.color(AyaColorScheme.Key.Generalized.key()).and())
-  ));
-
-  /** use colors from terminal instead of absolute colors to protect eyes */
-  public static final @NotNull StyleFamily ADAPTIVE_CLI = new AyaStyleFamily(MutableMap.ofEntries(
-    Tuple.of(Key.Keyword.key(), Style.color(AyaColorScheme.Key.Keyword.key()).and()),
-    Tuple.of(Key.PrimCall.key(), Style.color(AyaColorScheme.Key.Keyword.key()).and()),
-    Tuple.of(Key.FnCall.key(), UnixTermStyle.TerminalYellow.and()),
-    Tuple.of(Key.DataCall.key(), UnixTermStyle.TerminalGreen.and()),
-    Tuple.of(Key.StructCall.key(), UnixTermStyle.TerminalGreen.and()),
-    Tuple.of(Key.ConCall.key(), UnixTermStyle.TerminalBlue.and()),
-    Tuple.of(Key.FieldCall.key(), UnixTermStyle.TerminalBlue.and()),
-    Tuple.of(Key.Generalized.key(), Style.italic().and())
   ));
 }

--- a/pretty/src/test/java/org/aya/pretty/Reproduction.java
+++ b/pretty/src/test/java/org/aya/pretty/Reproduction.java
@@ -1,8 +1,7 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty;
 
-import org.aya.pretty.backend.string.StringPrinterConfig;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.doc.Style;
 import org.junit.jupiter.api.Test;
@@ -12,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class Reproduction {
   @Test public void mock() {
     var doc = Doc.nest(2, Doc.styled(Style.code(), Doc.plain("hey")));
-    assertEquals("  `hey'", doc.renderToString(StringPrinterConfig.unixTerminal()));
+    assertEquals("  `hey'", doc.renderToTerminal());
     assertEquals("\\noindent\\hspace*{1.0em}\\fbox{hey}", doc.renderToTeX());
   }
 }

--- a/pretty/src/test/java/org/aya/pretty/UnixStyleTest.java
+++ b/pretty/src/test/java/org/aya/pretty/UnixStyleTest.java
@@ -1,8 +1,7 @@
-// Copyright (c) 2020-2021 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty;
 
-import org.aya.pretty.backend.string.StringPrinterConfig;
 import org.aya.pretty.backend.string.custom.UnixTermStyle;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.doc.Style;
@@ -31,6 +30,6 @@ public class UnixStyleTest {
       Doc.styled(UnixTermStyle.TerminalPurple, "purple"),
       Doc.styled(UnixTermStyle.TerminalCyan, "cyan")
     );
-    assertFalse(f.renderToString(StringPrinterConfig.unixTerminal()).isEmpty());
+    assertFalse(f.renderToTerminal().isEmpty());
   }
 }

--- a/tools-repl/src/main/java/org/aya/repl/gk/ReplHighlighter.java
+++ b/tools-repl/src/main/java/org/aya/repl/gk/ReplHighlighter.java
@@ -3,7 +3,6 @@
 package org.aya.repl.gk;
 
 import com.intellij.lexer.FlexLexer;
-import org.aya.pretty.backend.string.StringPrinterConfig;
 import org.aya.pretty.doc.Doc;
 import org.jetbrains.annotations.NotNull;
 import org.jline.reader.LineReader;
@@ -19,12 +18,10 @@ public abstract class ReplHighlighter extends DefaultHighlighter {
 
   protected abstract @NotNull Doc highlight(String text, @NotNull FlexLexer.Token t);
 
-  @Override
-  public AttributedString highlight(LineReader reader, String buffer) {
+  @Override public AttributedString highlight(LineReader reader, String buffer) {
     lexer.reset(buffer, 0, buffer.length(), 0);
     var tokens = lexer.allTheWayDown();
-
     return AttributedString.fromAnsi(Doc.cat(tokens.map(t -> highlight(t.range().substring(buffer), t)))
-      .renderToString(StringPrinterConfig.unixTerminal()));
+      .renderToTerminal());
   }
 }

--- a/tools/src/main/java/org/aya/util/reporter/ThrowingReporter.java
+++ b/tools/src/main/java/org/aya/util/reporter/ThrowingReporter.java
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.util.reporter;
 
-import org.aya.pretty.backend.string.StringPrinterConfig;
-import org.aya.pretty.backend.string.style.AdaptiveCliStylist;
 import org.aya.util.distill.DistillerOptions;
 import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
@@ -18,11 +16,9 @@ public record ThrowingReporter() implements CountingReporter {
     boolean unicode, boolean supportAnsi, int pageWidth
   ) {
     var doc = problem.sourcePos() == SourcePos.NONE ? problem.describe(options) : problem.toPrettyError(options).toDoc();
-    if (supportAnsi) {
-      var config = new StringPrinterConfig(AdaptiveCliStylist.INSTANCE, pageWidth, unicode);
-      return doc.renderToString(config);
-    }
-    return doc.renderWithPageWidth(pageWidth, unicode);
+    return supportAnsi
+      ? doc.renderToTerminal(pageWidth, unicode)
+      : doc.renderWithPageWidth(pageWidth, unicode);
   }
 
   @Override public void report(@NotNull Problem problem) {

--- a/tools/src/main/java/org/aya/util/reporter/ThrowingReporter.java
+++ b/tools/src/main/java/org/aya/util/reporter/ThrowingReporter.java
@@ -1,9 +1,9 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.util.reporter;
 
 import org.aya.pretty.backend.string.StringPrinterConfig;
-import org.aya.pretty.style.AyaStyleFamily;
+import org.aya.pretty.backend.string.style.AdaptiveCliStylist;
 import org.aya.util.distill.DistillerOptions;
 import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
@@ -19,7 +19,7 @@ public record ThrowingReporter() implements CountingReporter {
   ) {
     var doc = problem.sourcePos() == SourcePos.NONE ? problem.describe(options) : problem.toPrettyError(options).toDoc();
     if (supportAnsi) {
-      var config = StringPrinterConfig.unixTerminal(AyaStyleFamily.ADAPTIVE_CLI, pageWidth, unicode);
+      var config = new StringPrinterConfig(AdaptiveCliStylist.INSTANCE, pageWidth, unicode);
       return doc.renderToString(config);
     }
     return doc.renderWithPageWidth(pageWidth, unicode);


### PR DESCRIPTION
- `Doc.renderXXX` now uses the default configuration for each "output target".
- `RenderOptions.render()` now renders the `Doc` with configurable colors and styles.
- Whenever outputting to a terminal, use `AdaptiveCli` (by default) or `UnixTermStylist` (if either color or style is changed), which is guaranteed now by `RenderOptions.stylist()` and `RenderOptions.defaultStylist()`
- `AdaptiveCli` is now a standalone `Stylist` (instead of a `StyleFamily`)
- `Stylist` can be viewed as the frozen `Sig CS ** SF ** OutputTarget`, while `RenderOptions` reads user-configured `CS` and `SF` and create the `Stylist` according to "output target". 