### PR TITLE
Fix Highlighter

### DIFF
--- a/base/src/main/java/org/aya/generic/Constants.java
+++ b/base/src/main/java/org/aya/generic/Constants.java
@@ -56,7 +56,7 @@ public interface Constants {
     return new LocalVar(ANONYMOUS_PREFIX, SourcePos.NONE);
   }
   static @NotNull LocalVar randomlyNamed(@NotNull SourcePos pos) {
-    return new LocalVar(randomName(pos), pos);
+    return new LocalVar(randomName(pos), pos, true);
   }
   static @NotNull String randomName(@NotNull Object pos) {
     if (Global.NO_RANDOM_NAME) return ANONYMOUS_PREFIX;

--- a/base/src/main/java/org/aya/ref/LocalVar.java
+++ b/base/src/main/java/org/aya/ref/LocalVar.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
  * @author ice1000
  */
 public record LocalVar(@NotNull String name, @NotNull SourcePos definition, boolean isGenerated) implements AnyVar {
-  public static final @NotNull LocalVar IGNORED = new LocalVar(Constants.ANONYMOUS_PREFIX, SourcePos.NONE);
+  public static final @NotNull LocalVar IGNORED = new LocalVar(Constants.ANONYMOUS_PREFIX, SourcePos.NONE, true);
 
   public LocalVar(@NotNull String name, @NotNull SourcePos definition) {
     this(name, definition, false);

--- a/base/src/main/java/org/aya/ref/LocalVar.java
+++ b/base/src/main/java/org/aya/ref/LocalVar.java
@@ -11,8 +11,12 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author ice1000
  */
-public record LocalVar(@NotNull String name, @NotNull SourcePos definition) implements AnyVar {
+public record LocalVar(@NotNull String name, @NotNull SourcePos definition, boolean isGenerated) implements AnyVar {
   public static final @NotNull LocalVar IGNORED = new LocalVar(Constants.ANONYMOUS_PREFIX, SourcePos.NONE);
+
+  public LocalVar(@NotNull String name, @NotNull SourcePos definition) {
+    this(name, definition, false);
+  }
 
   public LocalVar(@NotNull String name) {
     this(name, SourcePos.NONE);

--- a/cli/src/main/java/org/aya/cli/literate/SyntaxHighlight.java
+++ b/cli/src/main/java/org/aya/cli/literate/SyntaxHighlight.java
@@ -96,7 +96,7 @@ public class SyntaxHighlight implements StmtFolder<MutableList<HighlightInfo>> {
         if (decl instanceof Decl.Telescopic teleDecl) {
           teleDecl.telescope().view()
             .map(Expr.Param::ref)
-            .filter(x -> !x.isGenerated())
+            .filterNot(LocalVar::isGenerated)
             .forEach(def -> add(acc, linkDef(def.definition(), def)));
         }
 

--- a/cli/src/main/java/org/aya/cli/literate/SyntaxHighlight.java
+++ b/cli/src/main/java/org/aya/cli/literate/SyntaxHighlight.java
@@ -93,9 +93,8 @@ public class SyntaxHighlight implements StmtFolder<MutableList<HighlightInfo>> {
         if (decl instanceof Decl.Telescopic teleDecl) {
           teleDecl.telescope().view()
             .map(Expr.Param::ref)
-            .filter(x -> x != LocalVar.IGNORED && !x.isGenerated())
-            .forEach(def ->
-              add(acc, linkDef(def.definition(), def)));
+            .filter(x -> !x.isGenerated())
+            .forEach(def -> add(acc, linkDef(def.definition(), def)));
         }
 
         yield add(acc, linkDef(decl.sourcePos(), decl.ref()));

--- a/cli/src/main/java/org/aya/cli/literate/SyntaxHighlight.java
+++ b/cli/src/main/java/org/aya/cli/literate/SyntaxHighlight.java
@@ -24,7 +24,10 @@ import org.jetbrains.annotations.NotNull;
 
 /** @implNote Use {@link MutableList} instead of {@link SeqView} for performance consideration. */
 public class SyntaxHighlight implements StmtFolder<MutableList<HighlightInfo>> {
-  /** @param sourceFile If not null, provide keyword highlights too */
+  /**
+   * @param sourceFile If not null, provide keyword highlights too
+   * @return a list of {@link HighlightInfo}, no order was expected, the elements may be duplicated
+   */
   public static @NotNull ImmutableSeq<HighlightInfo> highlight(
     @NotNull Option<SourceFile> sourceFile,
     @NotNull ImmutableSeq<Stmt> program

--- a/cli/src/test/java/org/aya/cli/HighlighterTest.java
+++ b/cli/src/test/java/org/aya/cli/HighlighterTest.java
@@ -94,4 +94,37 @@ public class HighlighterTest {
       keyword(24, 27, "data"),
       def(29, 29, "Y", "y", HighlightInfo.DefKind.Data));
   }
+
+  @Test public void params() {
+    @Language("Aya") String code = """
+      open data Either (A B : Type)
+      | Left A
+      | Right B
+            
+      def constA {A : Type} (a b : A) : A => a
+      """;
+
+    highlightAndTest(code,
+      keyword(0, 3, "open"),
+      keyword(5, 8, "data"),
+      def(10, 15, "Either", "DefEither", HighlightInfo.DefKind.Data),
+      localDef(18, 18, "A", "LocalA"),
+      localDef(20, 20, "B", "LocalB"),
+      keyword(24, 27, "Type"),
+      def(32, 35, "Left", HighlightInfo.DefKind.Con),
+      localRef(37, 37, "A", "LocalA"),
+      def(41, 45, "Right", HighlightInfo.DefKind.Con),
+      localRef(47, 47, "B", "LocalB"),
+
+      keyword(50, 52, "def"),
+      def(54, 59, "constA", HighlightInfo.DefKind.Fn),
+      localDef(62, 62, "A", "LocalA'"),
+      keyword(66, 69, "Type"),
+      localDef(73, 73, "a", "Locala"),
+      localDef(75, 75, "b"),
+      localRef(79, 79, "A", "LocalA'"),
+      localRef(79, 79, "A", "LocalA'"),   // TODO: .distinct in tester
+      localRef(84, 84, "A", "LocalA'"),
+      localRef(89, 89, "a", "Locala"));
+  }
 }

--- a/cli/src/test/java/org/aya/cli/HighlighterTest.java
+++ b/cli/src/test/java/org/aya/cli/HighlighterTest.java
@@ -123,7 +123,6 @@ public class HighlighterTest {
       localDef(73, 73, "a", "Locala"),
       localDef(75, 75, "b"),
       localRef(79, 79, "A", "LocalA'"),
-      localRef(79, 79, "A", "LocalA'"),   // TODO: .distinct in tester
       localRef(84, 84, "A", "LocalA'"),
       localRef(89, 89, "a", "Locala"));
   }

--- a/cli/src/test/java/org/aya/cli/HighlighterTester.java
+++ b/cli/src/test/java/org/aya/cli/HighlighterTester.java
@@ -4,6 +4,7 @@ package org.aya.cli;
 
 import kala.collection.Seq;
 import kala.collection.immutable.ImmutableSeq;
+import kala.collection.immutable.ImmutableSet;
 import kala.collection.mutable.MutableMap;
 import kala.control.Option;
 import kala.tuple.Tuple;
@@ -92,7 +93,7 @@ public class HighlighterTester {
   }
 
   public void runTest() {
-    runTest(actual.sorted(), Seq.of(expected));
+    runTest(ImmutableSet.from(actual).toImmutableSeq().sorted(), Seq.of(expected));
   }
 
   public void runTest(@NotNull Seq<HighlightInfo> actuals, @NotNull Seq<ExpectedHighlightInfo> expecteds) {


### PR DESCRIPTION
There are some problems with `Highlighter`

* `Expr.Param#ref`s didn't highlight (so no definitions)
* For the parameters that share the same type, like `(a b : A)`, the type will be highlighted twice, we can perform `.distinct` after `.sort` to solve this problem