### PR TITLE
cli: remove a duplicate checkDeserialization() call

### DIFF
--- a/cli/src/main/java/org/aya/cli/library/json/LibraryConfigData.java
+++ b/cli/src/main/java/org/aya/cli/library/json/LibraryConfigData.java
@@ -42,7 +42,6 @@ public final class LibraryConfigData {
   }
 
   private @NotNull LibraryConfig asConfig(@NotNull Path libraryRoot) throws JsonParseException {
-    checkDeserialization(libraryRoot.resolve(Constants.AYA_JSON));
     return asConfig(libraryRoot, config -> libraryRoot.resolve("build"));
   }
 


### PR DESCRIPTION
It is already in `asConfig(@NotNull Path libraryRoot, @NotNull Function<String, Path> buildRootGen)`