### PR TITLE
Improve pushing telescopes

### DIFF
--- a/base/src/main/java/org/aya/tyck/pat/PatTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatTycker.java
@@ -367,7 +367,7 @@ public final class PatTycker {
           if (body == null) {
             var errorPattern = lastPat != null ? lastPat.term() : outerPattern;
             assert errorPattern != null;
-            foundError(new PatternProblem.CannotPush(results.toImmutableSeq(), errorPattern, param));
+            foundError(new PatternProblem.CannotPush(results.toImmutableSeq(), errorPattern, outerPattern, param));
             return done(results, sig.result(), null);
           }
           // Type explicit, does not have pattern, and failed to obtain pattern from lambda

--- a/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
@@ -2,7 +2,9 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck.pat;
 
+import kala.collection.immutable.ImmutableSeq;
 import org.aya.concrete.Pattern;
+import org.aya.core.pat.Pat;
 import org.aya.core.term.ConCall;
 import org.aya.core.term.DataCall;
 import org.aya.core.term.Term;
@@ -109,11 +111,18 @@ public sealed interface PatternProblem extends Problem {
     }
   }
 
-  record InsufficientPattern(@Override @NotNull Pattern pattern, @NotNull Term.Param param) implements PatternProblem {
+  record CannotPush(
+    @NotNull ImmutableSeq<Pat> results,
+    @Override @NotNull Pattern pattern,
+    @NotNull Term.Param param
+  ) implements PatternProblem {
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
-      return Doc.vcat(
-        Doc.english("There is no pattern for the parameter"),
-        Doc.par(1, param.toDoc(options)));
+      return Doc.vcat(Doc.english("Cannot push this parameter:"),
+        Doc.par(1, param.toDoc(options)),
+        Doc.english("to the match result of this pattern:"),
+        Doc.par(1, Doc.commaList(results.view().map(p -> p.toDoc(options)))),
+        Doc.english("as no match result is provided.")
+      );
     }
   }
 

--- a/base/src/test/resources/failure/patterns/issues2/issue597.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues2/issue597.aya.txt
@@ -4,8 +4,10 @@ In file $FILE:2:22 ->
   2 | def bad Nat : Nat | S S O => O | _ => O
                             ^^
 
-Error: There is no pattern for the parameter
+Error: Cannot push this parameter:
          (_ : Nat)
+       to the match result, as this pattern is a sub-pattern of:
+         S
 
 In file $FILE:2:24 ->
 

--- a/base/src/test/resources/failure/patterns/not-enough-pat-2.aya
+++ b/base/src/test/resources/failure/patterns/not-enough-pat-2.aya
@@ -1,0 +1,7 @@
+open data Nat | zero | suc Nat
+open data Fin (n : Nat)
+  | suc n => fzero
+  | suc n => fsuc (Fin n)
+
+def test : Pi {x : Nat} (fin : Fin x) (z : Nat) -> Nat
+  | {0}, ()

--- a/base/src/test/resources/failure/patterns/not-enough-pat-2.aya.txt
+++ b/base/src/test/resources/failure/patterns/not-enough-pat-2.aya.txt
@@ -1,0 +1,15 @@
+In file $FILE:7:9 ->
+
+  5 | 
+  6 | def test : Pi {x : Nat} (fin : Fin x) (z : Nat) -> Nat
+  7 |   | {0}, ()
+               ^^
+
+Error: Cannot push this parameter:
+         (z : Nat)
+       to the match result of this pattern:
+         {0}, ()
+       as no match result is provided.
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/failure/patterns/not-enough-pat.aya.txt
+++ b/base/src/test/resources/failure/patterns/not-enough-pat.aya.txt
@@ -1,12 +1,15 @@
-In file $FILE:4:9 ->
+In file $FILE:4:14 ->
 
   2 | 
   3 | def ifElse {A : Type} (b : Bool) (x y : A) : A
   4 |  | true, x => x
-               ^^
+                    ^^
 
-Error: There is no pattern for the parameter
-         (y : A)
+Error: Unable to apply the expression
+         x y
+       because the type of what you applied is not a Pi type, but instead:
+         A
+         (Normalized: A)
 
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/success/src/Issues/564.aya
+++ b/base/src/test/resources/success/src/Issues/564.aya
@@ -9,4 +9,17 @@ def +-assoc-redo2 (n : Nat) : Pi (m p : Nat) → n + (m + p) = (n + m) + p
 | zero, m, p => idp
 | suc n, m, p => pmap suc (+-assoc-redo2 n m p)
 
-// TODO: test implicit patterns and implicit lambdas
+def +-redo : Pi (a : Nat) {b : Nat} -> Nat
+  | zero  => \{i} => i
+  | suc n => \{i} => suc (+-redo n {i})
+
+def id {A : Type} (a : A) => a
+def +-redo2 : Pi (a : Nat) (b : Nat) -> Nat
+  | zero  => id
+  | suc n => \i => suc (+-redo2 n i)
+
+// TODO: make this work
+//def +-redo3 : Pi (a : Nat) {b : Nat} -> Nat
+//  | zero  => id
+//  | suc n => \{i} => suc (+-redo3 n {i})
+


### PR DESCRIPTION
We generate a bind pattern when the right-hand side is not a lambda. So the following code
```aya
def overlap infix + : Nat -> Nat -> Nat
  | 0     => id
  | suc a => \b => suc (a + b)
```
is desugared to

```aya
def overlap infix + Nat Nat : Nat
  | 0,     x => id x
  | suc a, b => suc (a + b)
```

which works with overlapping patterns.