### PR TITLE
cubical subtype

### DIFF
--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -421,22 +421,22 @@ public sealed interface Expr extends AyaDocile, SourceNode, Restr.TermLike<Expr>
     }
   }
 
-  /** Sugared overloaded projection as coercion syntax */
+  /** Sugared overloaded projection as coercion or hcomp syntax */
   record RawProj(
     @NotNull SourcePos sourcePos,
     @NotNull Expr tup,
     @NotNull QualifiedID id,
     @Nullable AnyVar resolvedVar,
-    @Nullable Expr coeLeft,
+    @Nullable Expr cubicalArg,
     @Nullable Expr restr
   ) implements Expr {
     public @NotNull Expr.RawProj update(@NotNull Expr tup, @Nullable Expr coeLeft, @Nullable Expr restr) {
-      return tup == tup() && coeLeft == coeLeft() && restr == restr() ? this
+      return tup == tup() && coeLeft == cubicalArg() && restr == restr() ? this
         : new RawProj(sourcePos, tup, id, resolvedVar, coeLeft, restr);
     }
 
     @Override public @NotNull Expr.RawProj descent(@NotNull UnaryOperator<@NotNull Expr> f) {
-      return update(f.apply(tup), coeLeft == null ? null : f.apply(coeLeft), restr == null ? null : f.apply(restr));
+      return update(f.apply(tup), cubicalArg == null ? null : f.apply(cubicalArg), restr == null ? null : f.apply(restr));
     }
   }
 
@@ -467,6 +467,22 @@ public sealed interface Expr extends AyaDocile, SourceNode, Restr.TermLike<Expr>
 
     @Override public @NotNull Expr.Coe descent(@NotNull UnaryOperator<@NotNull Expr> f) {
       return update(f.apply(type), f.apply(restr));
+    }
+  }
+
+  record HComp(
+    @Override @NotNull SourcePos sourcePos,
+    @NotNull QualifiedID id,
+    @NotNull DefVar<?, ?> resolvedVar,
+    @Override @NotNull Expr u,
+    @Override @NotNull Expr u0
+  ) implements Expr {
+    public @NotNull Expr.HComp update(@NotNull Expr u, @NotNull Expr u0) {
+      return u == u() && u0 == u0() ? this : new HComp(sourcePos, id, resolvedVar, u, u0);
+    }
+
+    @Override public @NotNull Expr.HComp descent(@NotNull UnaryOperator<@NotNull Expr> f) {
+      return update(f.apply(u), f.apply(u0));
     }
   }
 

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -212,7 +212,7 @@ public final class PrimDef extends TopLevelDef<Term> {
         var phi = prim.args().get(1).term();
         var u = prim.args().get(2).term();
         var u0 = prim.args().get(3).term();
-        return new HCompTerm(A, phi, u, u0);
+        return new HCompTerm(A, isOne(phi), u, u0);
       }
 
       /** /\ in Cubical Agda, should elaborate to {@link Formula.Conn} */

--- a/base/src/main/java/org/aya/core/def/PrimDef.java
+++ b/base/src/main/java/org/aya/core/def/PrimDef.java
@@ -146,6 +146,30 @@ public final class PrimDef extends TopLevelDef<Term> {
   }
 
   public static class Factory {
+    public Factory() {
+      var init = new Initializer();
+      seeds = ImmutableSeq.of(
+          init.intervalMin,
+          init.intervalMax,
+          init.intervalInv,
+          init.stringType,
+          init.stringConcat,
+          init.intervalType,
+          init.partialType,
+          init.coe,
+          init.coeFill,
+          init.eoc,
+          init.eocFill,
+          init.hcomp,
+          init.sub
+        ).map(seed -> Tuple.of(seed.name, seed))
+        .toImmutableMap();
+    }
+
+    private final @NotNull EnumMap<@NotNull ID, @NotNull PrimDef> defs = new EnumMap<>(ID.class);
+
+    private final @NotNull Map<@NotNull ID, @NotNull PrimSeed> seeds;
+
     private final class Initializer {
       public final @NotNull PrimDef.PrimSeed coe = new PrimSeed(ID.COE, this::coe, ref -> {
         // coe (A : I -> Type) (phi : I) : A 0 -> A 1
@@ -264,6 +288,7 @@ public final class PrimDef extends TopLevelDef<Term> {
         var result = new PiTerm(paramU, path);
         return new PrimDef(ref, ImmutableSeq.of(paramA, paramPhi), result, coeFill);
       }
+
       public final @NotNull PrimDef.PrimSeed partialType =
         new PrimSeed(ID.PARTIAL,
           (prim, state) -> {
@@ -328,9 +353,14 @@ public final class PrimDef extends TopLevelDef<Term> {
       private Term sub(@NotNull PrimCall prim, @NotNull TyckState tyckState) {
         var A = prim.args().get(0).term();
         var phi = prim.args().get(1).term();
-        var u = (PartialTerm) prim.args().get(2).term();
-        return new SubTerm(A, AyaRestrSimplifier.INSTANCE.isOne(phi), u.partial());
+        var u = prim.args().get(2).term();
+
+        if (u instanceof PartialTerm partialTerm)
+          return new SubTerm(A, AyaRestrSimplifier.INSTANCE.isOne(phi), partialTerm.partial());
+        else
+          return prim;
       }
+
       public final @NotNull PrimDef.PrimSeed stringConcat =
         new PrimSeed(ID.STRCONCAT, Initializer::concat, ref -> new PrimDef(
           ref,
@@ -367,29 +397,6 @@ public final class PrimDef extends TopLevelDef<Term> {
         var u0 = prim.args().get(3).term();
         return new HCompTerm(A, AyaRestrSimplifier.INSTANCE.isOne(phi), u, u0);
       }
-    }
-
-    private final @NotNull EnumMap<@NotNull ID, @NotNull PrimDef> defs = new EnumMap<>(ID.class);
-
-    private final @NotNull Map<@NotNull ID, @NotNull PrimSeed> seeds;
-
-    public Factory() {
-      var init = new Initializer();
-      seeds = ImmutableSeq.of(
-          init.intervalMin,
-          init.intervalMax,
-          init.intervalInv,
-          init.stringType,
-          init.stringConcat,
-          init.intervalType,
-          init.partialType,
-          init.coe,
-          init.coeFill,
-          init.eoc,
-          init.eocFill,
-          init.hcomp
-        ).map(seed -> Tuple.of(seed.name, seed))
-        .toImmutableMap();
     }
 
     public @NotNull PrimDef factory(@NotNull ID name, @NotNull DefVar<PrimDef, TeleDecl.PrimDecl> ref) {

--- a/base/src/main/java/org/aya/core/serde/SerTerm.java
+++ b/base/src/main/java/org/aya/core/serde/SerTerm.java
@@ -304,6 +304,22 @@ public sealed interface SerTerm extends Serializable, Restr.TermLike<SerTerm> {
     }
   }
 
+  record inS(@NotNull SerTerm phi, @NotNull SerTerm u) implements SerTerm {
+
+    @Override
+    public @NotNull Term de(@NotNull DeState state) {
+      return new InSTerm(phi.de(state), u.de(state));
+    }
+  }
+
+  record outS(@NotNull SerTerm phi, @NotNull SerTerm u) implements SerTerm {
+
+    @Override
+    public @NotNull Term de(@NotNull DeState state) {
+      return new OutSTerm(phi.de(state), u.de(state));
+    }
+  }
+
   record SerCube(
     @NotNull ImmutableSeq<SimpVar> params,
     @NotNull SerTerm type,

--- a/base/src/main/java/org/aya/core/serde/SerTerm.java
+++ b/base/src/main/java/org/aya/core/serde/SerTerm.java
@@ -297,6 +297,13 @@ public sealed interface SerTerm extends Serializable, Restr.TermLike<SerTerm> {
     }
   }
 
+  record Sub(@NotNull SerTerm type, @NotNull Restr<SerTerm> restr,
+             @NotNull Partial<SerTerm> partial) implements SerTerm {
+    @Override public @NotNull Term de(@NotNull DeState state) {
+      return new SubTerm(type.de(state), restr.fmap(t -> t.de(state)), partial.fmap(t -> t.de(state)));
+    }
+  }
+
   record SerCube(
     @NotNull ImmutableSeq<SimpVar> params,
     @NotNull SerTerm type,

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -131,6 +131,8 @@ public record Serializer(@NotNull Serializer.State state) {
       case HCompTerm hComp -> throw new InternalException("TODO");
       case SubTerm sub ->
         new SerTerm.Sub(serialize(sub.type()), sub.restr().fmap(this::serialize), sub.partial().fmap(this::serialize));
+      case InSTerm inS -> new SerTerm.inS(serialize(inS.phi()), serialize(inS.u()));
+      case OutSTerm outS -> new SerTerm.outS(serialize(outS.phi()), serialize(outS.u()));
     };
   }
 

--- a/base/src/main/java/org/aya/core/serde/Serializer.java
+++ b/base/src/main/java/org/aya/core/serde/Serializer.java
@@ -129,6 +129,8 @@ public record Serializer(@NotNull Serializer.State state) {
       case MetaLitTerm err -> throw new InternalException("Shall not have metaLiterals serialized.");
       case SortTerm sort -> serialize(sort);
       case HCompTerm hComp -> throw new InternalException("TODO");
+      case SubTerm sub ->
+        new SerTerm.Sub(serialize(sub.type()), sub.restr().fmap(this::serialize), sub.partial().fmap(this::serialize));
     };
   }
 

--- a/base/src/main/java/org/aya/core/term/HCompTerm.java
+++ b/base/src/main/java/org/aya/core/term/HCompTerm.java
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.term;
 
+import org.aya.guest0x0.cubical.Restr;
 import org.jetbrains.annotations.NotNull;
 
-public record HCompTerm(@NotNull Term type, @NotNull Term phi, @NotNull Term u, @NotNull Term u0) implements Term {}
+public record HCompTerm(@NotNull Term type, @NotNull Restr<Term> phi, @NotNull Term u,
+                        @NotNull Term u0) implements Term {}

--- a/base/src/main/java/org/aya/core/term/InSTerm.java
+++ b/base/src/main/java/org/aya/core/term/InSTerm.java
@@ -2,10 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.term;
 
-import org.aya.guest0x0.cubical.Partial;
-import org.aya.guest0x0.cubical.Restr;
 import org.jetbrains.annotations.NotNull;
 
-public record SubTerm(@NotNull Term type, @NotNull Restr<Term> restr, @NotNull Partial<Term> partial) implements Term {
+public record InSTerm(@NotNull Term phi, @NotNull Term u) implements Term {
 }
-

--- a/base/src/main/java/org/aya/core/term/OutSTerm.java
+++ b/base/src/main/java/org/aya/core/term/OutSTerm.java
@@ -2,10 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.term;
 
-import org.aya.guest0x0.cubical.Partial;
-import org.aya.guest0x0.cubical.Restr;
 import org.jetbrains.annotations.NotNull;
 
-public record SubTerm(@NotNull Term type, @NotNull Restr<Term> restr, @NotNull Partial<Term> partial) implements Term {
+public record OutSTerm(@NotNull Term phi, @NotNull Term u) implements Term {
 }
-

--- a/base/src/main/java/org/aya/core/term/PiTerm.java
+++ b/base/src/main/java/org/aya/core/term/PiTerm.java
@@ -50,7 +50,7 @@ public record PiTerm(@NotNull Term.Param param, @NotNull Term body) implements S
     };
   }
 
-  public @NotNull LamTerm coe(CoeTerm coe, LocalVar varI) {
+  public @NotNull LamTerm coe(@NotNull CoeTerm coe, @NotNull LocalVar varI) {
     var u0Var = new LocalVar("u0");
     var vVar = new LocalVar("v");
     var A = new LamTerm(new Param(varI, IntervalTerm.INSTANCE, true), param.type());

--- a/base/src/main/java/org/aya/core/term/SigmaTerm.java
+++ b/base/src/main/java/org/aya/core/term/SigmaTerm.java
@@ -32,7 +32,7 @@ public record SigmaTerm(@NotNull ImmutableSeq<@NotNull Param> params) implements
   }
 
   private static final Term I = IntervalTerm.INSTANCE;
-  public @NotNull LamTerm coe(CoeTerm coe, LocalVar i) {
+  public @NotNull LamTerm coe(@NotNull CoeTerm coe, @NotNull LocalVar i) {
     var t = new RefTerm(new LocalVar("t"));
     assert params.sizeGreaterThanOrEquals(2);
     var items = MutableArrayList.<Term>create(params.size());

--- a/base/src/main/java/org/aya/core/term/SubTerm.java
+++ b/base/src/main/java/org/aya/core/term/SubTerm.java
@@ -1,0 +1,10 @@
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.core.term;
+
+import org.aya.guest0x0.cubical.Partial;
+import org.aya.guest0x0.cubical.Restr;
+import org.jetbrains.annotations.NotNull;
+
+public record SubTerm(@NotNull Term type, @NotNull Restr<Term> restr, @NotNull Partial<Term> partial) implements Term {
+}

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -40,7 +40,7 @@ import java.util.function.UnaryOperator;
  * @author ice1000
  */
 public sealed interface Term extends AyaDocile, Restr.TermLike<Term>
-  permits Callable, CoeTerm, Elimination, FormulaTerm, HCompTerm, IntervalTerm, MatchTerm, MetaLitTerm, MetaPatTerm, PartialTerm, PiTerm, RefTerm, RefTerm.Field, SigmaTerm, StableWHNF {
+  permits Callable, CoeTerm, Elimination, FormulaTerm, HCompTerm, IntervalTerm, MatchTerm, MetaLitTerm, MetaPatTerm, PartialTerm, PiTerm, RefTerm, RefTerm.Field, SigmaTerm, StableWHNF, SubTerm {
   default @NotNull Term descent(@NotNull UnaryOperator<@NotNull Term> f) {
     return switch (this) {
       case PiTerm pi -> {
@@ -190,6 +190,14 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term>
         var restr = coe.restr().map(f);
         if (type == coe.type() && restr == coe.restr()) yield coe;
         yield new CoeTerm(type, AyaRestrSimplifier.INSTANCE.normalizeRestr(restr));
+      }
+
+      case SubTerm sub -> {
+        var type = f.apply(sub.type());
+        var restr = sub.restr().map(f);
+        var partial = sub.partial().map(f);
+        if (type == sub.type() && restr == sub.restr() && partial == sub.partial()) yield sub;
+        yield new SubTerm(type, AyaRestrSimplifier.INSTANCE.normalizeRestr(restr), partial);
       }
       case RefTerm ref -> ref;
       case MetaPatTerm metaPat -> metaPat;

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -40,7 +40,7 @@ import java.util.function.UnaryOperator;
  * @author ice1000
  */
 public sealed interface Term extends AyaDocile, Restr.TermLike<Term>
-  permits Callable, CoeTerm, Elimination, FormulaTerm, HCompTerm, IntervalTerm, MatchTerm, MetaLitTerm, MetaPatTerm, PartialTerm, PiTerm, RefTerm, RefTerm.Field, SigmaTerm, StableWHNF, SubTerm {
+  permits Callable, CoeTerm, Elimination, FormulaTerm, HCompTerm, IntervalTerm, MatchTerm, MetaLitTerm, MetaPatTerm, PartialTerm, PiTerm, RefTerm, RefTerm.Field, SigmaTerm, StableWHNF, SubTerm, InSTerm, OutSTerm {
   default @NotNull Term descent(@NotNull UnaryOperator<@NotNull Term> f) {
     return switch (this) {
       case PiTerm pi -> {
@@ -204,6 +204,18 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term>
       case RefTerm.Field field -> field;
       case ErrorTerm error -> error;
       case HCompTerm hComp -> hComp; //TODO
+      case InSTerm inSTerm -> {
+        var phi = f.apply(inSTerm.phi());
+        var u = f.apply(inSTerm.u());
+        if (phi == inSTerm.phi() && u == inSTerm.u()) yield inSTerm;
+        yield new InSTerm(phi, u);
+      }
+      case OutSTerm outSTerm -> {
+        var phi = f.apply(outSTerm.phi());
+        var u = f.apply(outSTerm.u());
+        if (phi == outSTerm.phi() && u == outSTerm.u()) yield outSTerm;
+        yield new OutSTerm(phi, u);
+      }
     };
   }
 

--- a/base/src/main/java/org/aya/distill/ConcreteDistiller.java
+++ b/base/src/main/java/org/aya/distill/ConcreteDistiller.java
@@ -112,10 +112,16 @@ public class ConcreteDistiller extends BaseDistiller<Expr> {
               clause.expr.map(t -> Doc.cat(Doc.symbol("=>"), term(Outer.Free, t))).getOrDefault(Doc.empty())))
             .toImmutableSeq()));
       case Expr.RawProj expr -> Doc.sepNonEmpty(Doc.cat(term(Outer.ProjHead, expr.tup()), Doc.symbol("."),
-          Doc.plain(expr.id().join())), expr.coeLeft() != null ? term(Outer.AppSpine, expr.coeLeft()) : Doc.empty(),
+          Doc.plain(expr.id().join())), expr.cubicalArg() != null ? term(Outer.AppSpine, expr.cubicalArg()) : Doc.empty(),
         expr.restr() != null ? Doc.sep(Doc.styled(KEYWORD, "freeze"), term(Outer.AppSpine, expr.restr())) : Doc.empty());
       case Expr.Coe expr -> visitCalls(expr.resolvedVar(), PRIM_CALL,
         ImmutableSeq.of(new Arg<>(expr.type(), true), new Arg<>(expr.restr(), true)),
+        outer, options.map.get(DistillerOptions.Key.ShowImplicitArgs));
+
+      case Expr.HComp expr -> visitCalls(expr.resolvedVar(), PRIM_CALL,
+        ImmutableSeq.of(
+          new Arg<>(expr.u(), true),
+          new Arg<>(expr.u0(), true)),
         outer, options.map.get(DistillerOptions.Key.ShowImplicitArgs));
       case Expr.Unresolved expr -> Doc.plain(expr.name().join());
       case Expr.Ref expr -> {

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -195,6 +195,8 @@ public class CoreDistiller extends BaseDistiller<Term> {
       case CoeTerm coe -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "coe"),
         term(Outer.AppSpine, coe.type()), Doc.parened(restr(options, coe.restr()))), Outer.AppSpine);
       case HCompTerm hComp -> throw new InternalException("TODO");
+      case SubTerm(var ty, var restr, var partial) -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "Sub"),
+        term(Outer.AppSpine, ty), Doc.parened(restr(options, restr)), Doc.parened(partial(options, partial, true))), Outer.AppSpine);
     };
   }
 

--- a/base/src/main/java/org/aya/distill/CoreDistiller.java
+++ b/base/src/main/java/org/aya/distill/CoreDistiller.java
@@ -197,6 +197,10 @@ public class CoreDistiller extends BaseDistiller<Term> {
       case HCompTerm hComp -> throw new InternalException("TODO");
       case SubTerm(var ty, var restr, var partial) -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "Sub"),
         term(Outer.AppSpine, ty), Doc.parened(restr(options, restr)), Doc.parened(partial(options, partial, true))), Outer.AppSpine);
+      case InSTerm(var phi, var u) -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "inS"),
+        term(Outer.AppSpine, phi), term(Outer.AppSpine, u)), Outer.AppSpine);
+      case OutSTerm(var phi, var u) -> checkParen(outer, Doc.sep(Doc.styled(KEYWORD, "outS"),
+        term(Outer.AppSpine, phi), term(Outer.AppSpine, u)), Outer.AppSpine);
     };
   }
 

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -236,6 +236,13 @@ public final class ExprTycker extends Tycker {
         }
         yield res;
       }
+
+      case Expr.HComp(var sourcePos, var id, var resolvedVar, var u, var u0) -> {
+        // 1. infer A and phi
+        // 2. check freezing condition
+        throw new InternalException("unimplemented");
+      }
+
       case Expr.App(var sourcePos, var appF, var argument) -> {
         var f = synthesize(appF);
         if (f.wellTyped() instanceof ErrorTerm || f.type() instanceof ErrorTerm) yield f;

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -117,6 +117,7 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       }
       case CoeTerm coe -> PrimDef.familyLeftToRight(coe.type());
       case HCompTerm hComp -> throw new InternalException("TODO");
+      case SubTerm subTerm -> throw new InternalException("TODO");
     };
   }
 

--- a/base/src/main/java/org/aya/tyck/LittleTyper.java
+++ b/base/src/main/java/org/aya/tyck/LittleTyper.java
@@ -118,6 +118,8 @@ public record LittleTyper(@NotNull TyckState state, @NotNull LocalCtx localCtx) 
       case CoeTerm coe -> PrimDef.familyLeftToRight(coe.type());
       case HCompTerm hComp -> throw new InternalException("TODO");
       case SubTerm subTerm -> throw new InternalException("TODO");
+      case InSTerm inSTerm -> throw new InternalException("TODO");
+      case OutSTerm outSTerm -> throw new InternalException("TODO");
     };
   }
 


### PR DESCRIPTION
## Tasks: implement cubical subtype
- [x] syntax definitions for `Sub`, `inS`, `outS`
- [ ] typing rules
- [ ] computation rules
- [ ] rewrite tests and reimplement `coe` due to subtypes

Will update progress here.

**Note: this branch includes preliminary code for `hcomp`. This will be cleaned up because we are using cubical subtype now.**