### PR TITLE
basic support for unary pretty print

### DIFF
--- a/base/src/main/java/org/aya/distill/BaseDistiller.java
+++ b/base/src/main/java/org/aya/distill/BaseDistiller.java
@@ -97,16 +97,20 @@ public abstract class BaseDistiller<Term extends AyaDocile> {
   ) {
     var visibleArgs = (showImplicits ? args : args.filter(BinOpParser.Elem::explicit)).toImmutableSeq();
     if (visibleArgs.isEmpty()) return assoc != null ? Doc.parened(fn) : fn;
-    // Print as a binary operator
-    if (assoc != null && assoc.isBinary()) {
+    if (assoc != null) {
       var firstArg = visibleArgs.first();
       if (!firstArg.explicit()) return prefix(Doc.parened(fn), fmt, outer, visibleArgs.view());
       var first = fmt.apply(Outer.BinOp, firstArg.term());
-      // If we're in a binApp/head/spine/etc., add parentheses
-      if (visibleArgs.sizeEquals(1)) return checkParen(outer, Doc.sep(first, fn), Outer.BinOp);
-      var triple = Doc.sep(first, fn, arg(fmt, visibleArgs.get(1), Outer.BinOp));
-      if (visibleArgs.sizeEquals(2)) return checkParen(outer, triple, Outer.BinOp);
-      return prefix(Doc.parened(triple), fmt, outer, visibleArgs.view().drop(2));
+      if (assoc.isBinary()) {
+        // If we're in a binApp/head/spine/etc., add parentheses
+        if (visibleArgs.sizeEquals(1)) return checkParen(outer, Doc.sep(first, fn), Outer.BinOp);
+        var triple = Doc.sep(first, fn, arg(fmt, visibleArgs.get(1), Outer.BinOp));
+        if (visibleArgs.sizeEquals(2)) return checkParen(outer, triple, Outer.BinOp);
+        return prefix(Doc.parened(triple), fmt, outer, visibleArgs.view().drop(2));
+      }
+      if (assoc.isUnary() && visibleArgs.sizeEquals(1)) {
+        return checkParen(outer, Doc.sep(fn, first), Outer.BinOp);
+      }
     }
     return prefix(fn, fmt, outer, visibleArgs.view());
   }

--- a/base/src/main/java/org/aya/ref/DefVar.java
+++ b/base/src/main/java/org/aya/ref/DefVar.java
@@ -8,6 +8,7 @@ import org.aya.concrete.stmt.Decl;
 import org.aya.core.def.Def;
 import org.aya.core.def.GenericDef;
 import org.aya.resolve.ResolveInfo;
+import org.aya.util.binop.Assoc;
 import org.aya.util.binop.OpDecl;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -34,9 +35,10 @@ public final class DefVar<Core extends GenericDef, Concrete extends Decl> implem
    */
   public @NotNull MutableMap<ImmutableSeq<String>, OpDecl> opDeclRename = MutableMap.create();
 
-
-  @Contract(pure = true) public boolean isInfix() {
-    return opDecl != null && opDecl.opInfo() != null;
+  @Contract(pure = true) public @Nullable Assoc assoc() {
+    if (opDecl == null) return null;
+    if (opDecl.opInfo() == null) return null;
+    return opDecl.opInfo().assoc();
   }
 
   @Contract(pure = true) public @NotNull String name() {
@@ -61,7 +63,7 @@ public final class DefVar<Core extends GenericDef, Concrete extends Decl> implem
     return new DefVar<>(null, null, name);
   }
 
-  public @Nullable OpDecl resolveOpDecl(@NotNull ImmutableSeq<String> moduleName){
+  public @Nullable OpDecl resolveOpDecl(@NotNull ImmutableSeq<String> moduleName) {
     return opDeclRename.getOrDefault(moduleName, opDecl);
   }
 

--- a/base/src/test/java/org/aya/core/DistillerTest.java
+++ b/base/src/test/java/org/aya/core/DistillerTest.java
@@ -116,6 +116,19 @@ public class DistillerTest {
     assertEquals("g (n ·)", t.toDoc(DistillerOptions.informative()).debugRender());
   }
 
+  @Test public void unary() {
+    var decls = TyckDeclTest.successTyckDecls("""
+      data False
+
+      def fixr ¬ (A : Type) => A -> False
+
+      def elim {A : Type} False : A | ()
+      def NonEmpty (A : Type) => ¬ ¬ A
+      """)._2;
+    var t = ((FnDef) decls.get(3)).body.getLeftValue();
+    assertEquals("¬ (¬ A)", t.toDoc(DistillerOptions.informative()).debugRender());
+  }
+
   @Test public void elimBinOP() {
     var decls = TyckDeclTest.successTyckDecls("""
       prim I


### PR DESCRIPTION
(partially) fixes https://github.com/aya-prover/aya-dev/issues/687

leftovers:

+ print `¬ ¬ A` instead of `¬ (¬ A)`