### PR TITLE
KALA: upgrade to 0.57.0

### DIFF
--- a/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
@@ -71,7 +71,7 @@ public record AyaSccTycker(
   }
 
   private void checkMutual(@NotNull ImmutableSeq<TyckOrder> scc) {
-    var unit = scc.stream().map(TyckOrder::unit).distinct().collect(ImmutableSeq.factory());
+    var unit = scc.view().map(TyckOrder::unit).distinct().toImmutableSeq();
     // the flattened dependency graph (FDG) lose information about header order, in other words,
     // FDG treats all order as body order, so it allows all kinds of mutual recursion to be generated.
     // To detect circular dependency in signatures which we forbid, we have to apply the old way,

--- a/gradle/deps.properties
+++ b/gradle/deps.properties
@@ -7,7 +7,7 @@ version.project=0.25-SNAPSHOT
 
 # https://github.com/JetBrains/java-annotations
 version.annotations=23.0.0
-version.kala=0.56.0
+version.kala=0.57.0
 version.guest0x0=0.18.0
 version.aya-upstream=0.0.9
 # https://github.com/jflex-de/jflex

--- a/lsp/src/test/java/org/aya/lsp/LspTest.java
+++ b/lsp/src/test/java/org/aya/lsp/LspTest.java
@@ -85,8 +85,8 @@ public class LspTest {
     var actual = advisor.lastCompiled()
       .map(s -> s.moduleName().joinToString(Constants.SCOPE_SEPARATOR))
       .concat(actualInDep)
-      .stream().distinct()
-      .collect(ImmutableSeq.factory());
+      .distinct()
+      .toImmutableSeq();
     var expected = ImmutableSeq.from(modules);
     assertEquals(expected.sorted(), actual.sorted());
   }


### PR DESCRIPTION
New features:

* `CollectionLike::distinct()`
* `CollectionLike::zip(Iterable<U>, BiFunction<E, U, R>)`
* `Traversable::mapToIntTo(IntGrowable, ToIntFunction<E>)`