### PR TITLE
Fix a serious termination check bug

### DIFF
--- a/base/src/test/resources/success/src/FoetusLimitation.aya
+++ b/base/src/test/resources/success/src/FoetusLimitation.aya
@@ -5,3 +5,8 @@ def sum (List Nat) : Nat
   | nil => 0
   | suc x :< xs => suc (sum (x :< xs))
   | 0 :< xs => sum xs
+
+// interleaved arguments
+def add Nat Nat : Nat
+  | suc a, b => suc (add b a)   // swap arguments
+  | zero,  b => b

--- a/base/src/test/resources/success/src/Mutual.aya
+++ b/base/src/test/resources/success/src/Mutual.aya
@@ -32,21 +32,3 @@ open data Forest (A : Type) : Type
   | empty
   | infixr :< (Rose A) (Forest A)
 
-def ack Nat Nat : Nat
-  | 0, n      => suc n
-  | suc m, 0  => ack m 1
-  | suc m, suc n => ack m (ack (suc m) n)
-
-def f Nat : Nat
-  | 0 => zero
-  | suc n => g (suc n)
-
-def g Nat : Nat
-  | zero => 0
-  | suc n => f n
-
-// interleaved arguments
-def add Nat Nat : Nat
-  | suc a, b => suc (add b a)   // swap arguments
-  | zero,  b => b
-

--- a/base/src/test/resources/success/src/Termination.aya
+++ b/base/src/test/resources/success/src/Termination.aya
@@ -1,0 +1,20 @@
+open import Arith::Nat
+
+example def ack Nat Nat : Nat
+  | 0, n      => suc n
+  | suc m, 0  => ack m 1
+  | suc m, suc n => ack m (ack (suc m) n)
+
+example def f Nat : Nat
+  | 0 => zero
+  | suc n => g (suc n)
+
+example def g Nat : Nat
+  | zero => 0
+  | suc n => f n
+
+example def just-pred (n : Nat) : Nat => pred n
+example def pred Nat : Nat
+  | zero => zero
+  | suc n => just-pred n
+


### PR DESCRIPTION
Aya rejects

```aya
def just-pred (n : Nat) : Nat => pred n

def pred Nat : Nat
  | zero => zero
  | suc n => just-pred n
```
