### PR TITLE
Update Folder in the concrete layer.

### DIFF
--- a/base/src/main/java/org/aya/concrete/visitor/ExprFolder.java
+++ b/base/src/main/java/org/aya/concrete/visitor/ExprFolder.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.concrete.visitor;
+
+import org.aya.concrete.Expr;
+import org.jetbrains.annotations.NotNull;
+
+public interface ExprFolder<R> extends PatternFolder<R> {
+  @NotNull R init();
+
+  default @NotNull R fold(@NotNull R acc, @NotNull Expr expr) {
+    return switch (expr) {
+      case Expr.Ref ref -> foldVarRef(acc, ref.resolvedVar(), ref.sourcePos());
+      case Expr.Lambda lam -> foldVarDecl(acc, lam.param().ref(), lam.param().sourcePos());
+      case Expr.Pi pi -> foldVarDecl(acc, pi.param().ref(), pi.param().sourcePos());
+      case Expr.Sigma sigma ->
+        sigma.params().foldLeft(acc, (ac, param) -> foldVarDecl(ac, param.ref(), param.sourcePos()));
+      case Expr.Path path -> path.params().foldLeft(acc, (ac, var) -> foldVarDecl(ac, var, var.definition()));
+      case Expr.Array array -> array.arrayBlock().fold(
+        left -> left.binds().foldLeft(acc, (ac, bind) -> foldVarDecl(ac, bind.var(), bind.sourcePos())),
+        right -> acc
+      );
+      case Expr.Let let -> foldVarDecl(acc, let.bind().bindName(), let.bind().sourcePos());
+      case Expr.Do du -> du.binds().foldLeft(acc, (ac, bind) -> foldVarDecl(ac, bind.var(), bind.sourcePos()));
+      case Expr.Proj proj when proj.ix().isRight() && proj.resolvedVar() != null ->
+        foldVarRef(acc, proj.resolvedVar(), proj.ix().getRightValue().sourcePos());
+      case Expr.Coe coe -> foldVarRef(acc, coe.resolvedVar(), coe.id().sourcePos());
+      case Expr.New neu -> neu.fields().view().foldLeft(acc, (ac, field) -> {
+        var acc1 = field.bindings().foldLeft(ac, (a, binding) -> foldVarDecl(a, binding.data(), binding.sourcePos()));
+        var fieldRef = field.resolvedField().get();
+        return fieldRef != null ? foldVarRef(acc1, fieldRef, field.name().sourcePos()) : acc1;
+      });
+      case Expr.Match match -> match.clauses().foldLeft(acc, (ac, clause) -> clause.patterns.foldLeft(ac,
+        (a, p) -> fold(a, p.term())));
+      default -> acc;
+    };
+  }
+}

--- a/base/src/main/java/org/aya/concrete/visitor/PatternFolder.java
+++ b/base/src/main/java/org/aya/concrete/visitor/PatternFolder.java
@@ -1,0 +1,44 @@
+// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.concrete.visitor;
+
+import kala.value.MutableValue;
+import org.aya.concrete.Pattern;
+import org.aya.ref.AnyVar;
+import org.aya.util.error.SourcePos;
+import org.jetbrains.annotations.NotNull;
+
+public interface PatternFolder<R> {
+  @NotNull R init();
+
+  default @NotNull R foldVar(@NotNull R acc, @NotNull AnyVar var, @NotNull SourcePos pos) {
+    return acc;
+  }
+
+  default @NotNull R foldVarRef(@NotNull R acc, @NotNull AnyVar var, @NotNull SourcePos pos) {
+    return foldVar(acc, var, pos);
+  }
+
+  default @NotNull R foldVarDecl(@NotNull R acc, @NotNull AnyVar var, @NotNull SourcePos pos) {
+    return foldVar(acc, var, pos);
+  }
+
+  default @NotNull R fold(@NotNull R acc, @NotNull Pattern pat) {
+    return switch (pat) {
+      case Pattern.Ctor ctor -> foldVarRef(acc, ctor.resolved().data(), ctor.resolved().sourcePos());
+      case Pattern.Bind bind -> foldVarDecl(acc, bind.bind(), bind.sourcePos());
+      case Pattern.As as -> foldVarDecl(acc, as.as(), as.as().definition());
+      default -> acc;
+    };
+  }
+
+  default @NotNull R apply(@NotNull Pattern pat) {
+    var acc = MutableValue.create(init());
+    new PatternConsumer() {
+      @Override public void pre(@NotNull Pattern pat) {
+        acc.set(fold(acc.get(), pat));
+      }
+    }.accept(pat);
+    return acc.get();
+  }
+}

--- a/base/src/main/java/org/aya/concrete/visitor/StmtFolder.java
+++ b/base/src/main/java/org/aya/concrete/visitor/StmtFolder.java
@@ -11,51 +11,17 @@ import org.aya.concrete.stmt.BindBlock;
 import org.aya.concrete.stmt.Command;
 import org.aya.concrete.stmt.CommonDecl;
 import org.aya.concrete.stmt.Stmt;
-import org.aya.ref.AnyVar;
-import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.MustBeInvokedByOverriders;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
 
-public interface StmtFolder<R> extends Function<Stmt, R> {
-  @NotNull R init();
-
-  default @NotNull R fold(@NotNull R acc, @NotNull AnyVar var, @NotNull SourcePos pos) {
-    return acc;
-  }
-
-  default @NotNull R fold(@NotNull R acc, @NotNull Pattern pat) {
-    return switch (pat) {
-      case Pattern.Ctor ctor -> fold(acc, ctor.resolved().data(), ctor.resolved().sourcePos());
-      case Pattern.Bind bind -> fold(acc, bind.bind(), bind.sourcePos());
-      case Pattern.As as -> fold(acc, as.as(), as.as().definition());
-      default -> acc;
-    };
-  }
-
-  default @NotNull R fold(@NotNull R acc, @NotNull Expr expr) {
-    return switch (expr) {
-      case Expr.Ref ref -> fold(acc, ref.resolvedVar(), ref.sourcePos());
-      case Expr.Proj proj when proj.ix().isRight() && proj.resolvedVar() != null ->
-        fold(acc, proj.resolvedVar(), proj.ix().getRightValue().sourcePos());
-      case Expr.Coe coe -> fold(acc, coe.resolvedVar(), coe.id().sourcePos());
-      case Expr.New neu -> neu.fields().view().foldLeft(acc, (ac, field) -> {
-        var acc1 = field.bindings().foldLeft(ac, (a, binding) -> fold(a, binding.data(), binding.sourcePos()));
-        var fieldRef = field.resolvedField().get();
-        return fieldRef != null ? fold(acc1, fieldRef, field.name().sourcePos()) : acc1;
-      });
-      case Expr.Match match -> match.clauses().foldLeft(acc, (ac, clause) -> clause.patterns.foldLeft(ac,
-        (a, p) -> fold(a, p.term())));
-      default -> acc;
-    };
-  }
-
+public interface StmtFolder<R> extends Function<Stmt, R>, ExprFolder<R> {
   private R bindBlock(@NotNull R acc, @NotNull BindBlock bb) {
     var t = Option.ofNullable(bb.resolvedTighters().get()).getOrElse(ImmutableSeq::empty);
     var l = Option.ofNullable(bb.resolvedLoosers().get()).getOrElse(ImmutableSeq::empty);
     return t.zipView(bb.tighters()).concat(l.zipView(bb.loosers()))
-      .foldLeft(acc, (ac, v) -> fold(ac, v._1, v._2.sourcePos()));
+      .foldLeft(acc, (ac, v) -> foldVarRef(ac, v._1, v._2.sourcePos()));
   }
 
   @MustBeInvokedByOverriders

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -287,6 +287,7 @@ public final class ExprTycker extends Tycker {
         } catch (NotPi notPi) {
           yield fail(expr, ErrorTerm.unexpected(notPi.what), BadTypeError.pi(state, expr, notPi.what));
         }
+        if (appF instanceof Expr.WithTerm withTerm) withTerm.theCore().set(new TermResult(app, pi));
         var elabArg = inherit(argument.term(), pi.param().type()).wellTyped();
         subst.addDirectly(pi.param().ref(), elabArg);
         var arg = new Arg<>(elabArg, argLicit);
@@ -688,7 +689,8 @@ public final class ExprTycker extends Tycker {
       builder.append(new Trace.TyckT(frozen.get(), expr.sourcePos()));
       builder.reduce();
     });
-    if (expr instanceof Expr.WithTerm withTerm) withTerm.theCore().set(frozen.get());
+    if (expr instanceof Expr.WithTerm withTerm)
+      withTerm.theCore().set(frozen.get());
   }
 
   public ExprTycker(@NotNull PrimDef.Factory primFactory, @NotNull AyaShape.Factory shapeFactory, @NotNull Reporter reporter, Trace.@Nullable Builder traceBuilder) {

--- a/cli/src/main/java/org/aya/cli/literate/SyntaxHighlight.java
+++ b/cli/src/main/java/org/aya/cli/literate/SyntaxHighlight.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** @implNote Use {@link MutableList} instead of {@link SeqView} for performance consideration. */
+// TODO: Simplify the logic on handling variable declaration by using the improved Folder API.
 public class SyntaxHighlight implements StmtFolder<MutableList<HighlightInfo>> {
   /**
    * @param sourceFile If not null, provide keyword highlights too
@@ -67,7 +68,7 @@ public class SyntaxHighlight implements StmtFolder<MutableList<HighlightInfo>> {
   }
 
   @Override
-  public @NotNull MutableList<HighlightInfo> fold(@NotNull MutableList<HighlightInfo> acc, @NotNull AnyVar var, @NotNull SourcePos pos) {
+  public @NotNull MutableList<HighlightInfo> foldVarRef(@NotNull MutableList<HighlightInfo> acc, @NotNull AnyVar var, @NotNull SourcePos pos) {
     return add(acc, linkRef(pos, var, varType(var)));
   }
 


### PR DESCRIPTION
This allows finer grain control on the handling of variables, which we can now distinguish between variable declaration and reference.
The first commit solves an immediate design problem noticed by @HoshinoTented.
I've then noticed some duplicated logic that can be better handled by the new API in the LSP highlighter and resolver.
If no one is working on that part of the code currently, I can clean that up in a follow up commit.