### PR TITLE
Properly escape css selectors

### DIFF
--- a/base/src/main/java/org/aya/concrete/remark/Literate.java
+++ b/base/src/main/java/org/aya/concrete/remark/Literate.java
@@ -6,7 +6,6 @@ import kala.collection.immutable.ImmutableSeq;
 import kala.value.MutableValue;
 import org.aya.concrete.Expr;
 import org.aya.core.def.UserDef;
-import org.aya.core.term.Term;
 import org.aya.pretty.backend.string.LinkId;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.doc.Docile;
@@ -14,7 +13,6 @@ import org.aya.pretty.doc.Style;
 import org.aya.ref.AnyVar;
 import org.aya.ref.DefVar;
 import org.aya.tyck.ExprTycker;
-import org.aya.tyck.TyckState;
 import org.aya.util.distill.DistillerOptions;
 import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
@@ -64,11 +62,6 @@ public sealed interface Literate extends Docile {
       this.code = code;
       this.sourcePos = sourcePos;
       this.options = options;
-    }
-
-    public @NotNull Doc normalize(@NotNull Term term, @NotNull TyckState state) {
-      var mode = options.mode();
-      return term.normalize(state, mode).toDoc(options.options());
     }
 
     @Override public @NotNull Doc toDoc() {

--- a/cli/src/main/java/org/aya/cli/literate/LiterateConsumer.java
+++ b/cli/src/main/java/org/aya/cli/literate/LiterateConsumer.java
@@ -5,7 +5,6 @@ package org.aya.cli.literate;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
 import org.aya.concrete.remark.Literate;
-import org.aya.pretty.doc.Doc;
 import org.jetbrains.annotations.MustBeInvokedByOverriders;
 import org.jetbrains.annotations.NotNull;
 
@@ -59,9 +58,5 @@ public interface LiterateConsumer extends Consumer<Literate> {
       }
       LiterateConsumer.super.accept(literate);
     }
-  }
-
-  record MarkdownDoc(@NotNull MutableList<Doc> docs) implements LiterateConsumer {
-
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
@@ -128,20 +128,6 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
     "\"", "&quot;"
   );
 
-  /**
-   * <a href="https://stackoverflow.com/a/45519999/9506898">Thank you!</a>
-   * <a href="https://jkorpela.fi/ucs.html8">ISO 10646 character listings</a>
-   * <p>
-   * In CSS, identifiers (including element names, classes, and IDs in selectors)
-   * can contain only the characters [a-zA-Z0-9] and ISO 10646 characters U+00A0 and higher,
-   * plus the hyphen (-) and the underscore (_);
-   * they cannot start with a digit, two hyphens, or a hyphen followed by a digit.
-   * Identifiers can also contain escaped characters and any ISO 10646 character as a numeric code (see next item).
-   * For instance, the identifier "B&W?" may be written as "B\&W\?" or "B\26 W\3F".
-   */
-  public static final @NotNull Pattern invalidQuerySelectorPattern = Pattern.compile("[^a-zA-Z0-9\\u00A0-\\uFFFF\\-_]");
-  public static final @NotNull String invalidQuerySelectorReplacement = "_";
-
   @Override protected void renderHeader(@NotNull Cursor cursor) {
     if (config.withHeader) cursor.invisibleContent(HEAD);
     else cursor.invisibleContent("<pre class=\"Aya\">");
@@ -189,9 +175,28 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
     };
   }
 
+  /**
+   * <a href="https://stackoverflow.com/a/45519999/9506898">Thank you!</a>
+   * <a href="https://jkorpela.fi/ucs.html8">ISO 10646 character listings</a>
+   * <p>
+   * In CSS, identifiers (including element names, classes, and IDs in selectors)
+   * can contain only the characters [a-zA-Z0-9] and ISO 10646 characters U+00A0 and higher,
+   * plus the hyphen (-) and the underscore (_);
+   * they cannot start with a digit, two hyphens, or a hyphen followed by a digit.
+   * Identifiers can also contain escaped characters and any ISO 10646 character as a numeric code (see next item).
+   * For instance, the identifier "B&W?" may be written as "B\&W\?" or "B\26 W\3F".
+   */
   public static @NotNull String normalizeQuerySelector(@NotNull String selector) {
-    return invalidQuerySelectorPattern.matcher(selector)
-      .replaceAll(invalidQuerySelectorReplacement);
+    selector = selector.replaceAll("::", "-"); // note: scope::name -> scope-name
+    // Java's `Pattern` assumes only ASCII text are matched, where `T²` will be incorrectly normalize to "T?".
+    // But according to CSS3, `T²` is a valid identifier.
+    var builder = new StringBuilder();
+    for (var c : selector.toCharArray()) {
+      if (Character.isLetterOrDigit(c) || c >= 0x00A0 || c == '-' || c == '_')
+        builder.append(c);
+      else builder.append(Integer.toHexString(c));
+    }
+    return builder.toString();
   }
 
   @Override protected void renderHardLineBreak(@NotNull Cursor cursor) {

--- a/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
@@ -128,6 +128,20 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
     "\"", "&quot;"
   );
 
+  /**
+   * <a href="https://stackoverflow.com/a/45519999/9506898">Thank you!</a>
+   * <a href="https://jkorpela.fi/ucs.html8">ISO 10646 character listings</a>
+   * <p>
+   * In CSS, identifiers (including element names, classes, and IDs in selectors)
+   * can contain only the characters [a-zA-Z0-9] and ISO 10646 characters U+00A0 and higher,
+   * plus the hyphen (-) and the underscore (_);
+   * they cannot start with a digit, two hyphens, or a hyphen followed by a digit.
+   * Identifiers can also contain escaped characters and any ISO 10646 character as a numeric code (see next item).
+   * For instance, the identifier "B&W?" may be written as "B\&W\?" or "B\26 W\3F".
+   */
+  public static final @NotNull Pattern invalidQuerySelectorPattern = Pattern.compile("[^a-zA-Z0-9\\u00A0-\\uFFFF\\-_]");
+  public static final @NotNull String invalidQuerySelectorReplacement = "_";
+
   @Override protected void renderHeader(@NotNull Cursor cursor) {
     if (config.withHeader) cursor.invisibleContent(HEAD);
     else cursor.invisibleContent("<pre class=\"Aya\">");
@@ -162,7 +176,7 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
   public static @NotNull String normalizeId(@NotNull LinkId linkId) {
     return switch (linkId) {
       case LinkId.DirectLink(var link) -> link;
-      case LinkId.LocalId(var id) -> id.fold(x -> x, x -> "v" + x);
+      case LinkId.LocalId(var id) -> id.fold(DocHtmlPrinter::normalizeQuerySelector, x -> "v" + x);
       // ^ CSS3 selector does not support IDs starting with a digit, so we prefix them with "v".
       // See https://stackoverflow.com/a/37271406/9506898 for more details.
     };
@@ -173,6 +187,11 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
       case LinkId.DirectLink(var link) -> link;
       case LinkId.LocalId localId -> "#" + normalizeId(localId);
     };
+  }
+
+  public static @NotNull String normalizeQuerySelector(@NotNull String selector) {
+    return invalidQuerySelectorPattern.matcher(selector)
+      .replaceAll(invalidQuerySelectorReplacement);
   }
 
   @Override protected void renderHardLineBreak(@NotNull Cursor cursor) {


### PR DESCRIPTION
this enables "jump to definition" for all names in vitepress