### PR TITLE
fix(pattern): add check for absurd patterns

### DIFF
--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -245,7 +245,7 @@ public record StmtTycker(@NotNull Reporter reporter, Trace.@Nullable Builder tra
         // There might be patterns in the constructor
         if (ctor.patterns.isNotEmpty()) {
           var lhs = PatTycker.checkLhs(tycker,
-            new Pattern.Clause(ctor.sourcePos, ctor.patterns, Option.none()), sig, false);
+            new Pattern.Clause(ctor.sourcePos, ctor.patterns, Option.none()), sig, false, false);
           ctor.yetTyckedPat = lhs.preclause().patterns();
           // Revert to the "after patterns" state
           tycker.localCtx = lhs.gamma();

--- a/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
@@ -143,4 +143,20 @@ public sealed interface PatternProblem extends Problem {
         Doc.par(1, type.toDoc(options)));
     }
   }
+
+  record InvalidEmptyBody(
+    @NotNull Pattern.Clause match
+  ) implements PatternProblem {
+    @Override @NotNull public Pattern pattern() {
+      return match.patterns.first().term();
+    }
+
+    @Override @NotNull public SourcePos sourcePos() {
+      return match.sourcePos;
+    }
+
+    @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
+      return Doc.english("This match arm does not contain any absurd pattern but it has an empty body");
+    }
+  }
 }

--- a/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatternProblem.java
@@ -146,10 +146,7 @@ public sealed interface PatternProblem extends Problem {
 
   record InvalidEmptyBody(
     @NotNull Pattern.Clause match
-  ) implements PatternProblem {
-    @Override @NotNull public Pattern pattern() {
-      return match.patterns.first().term();
-    }
+  ) implements Problem {
 
     @Override @NotNull public SourcePos sourcePos() {
       return match.sourcePos;
@@ -157,6 +154,11 @@ public sealed interface PatternProblem extends Problem {
 
     @Override public @NotNull Doc describe(@NotNull DistillerOptions options) {
       return Doc.english("This match arm does not contain any absurd pattern but it has an empty body");
+    }
+
+    @Override
+    public @NotNull Severity level() {
+      return Severity.ERROR;
     }
   }
 }

--- a/base/src/test/resources/failure/patterns/issues2/issue775.aya
+++ b/base/src/test/resources/failure/patterns/issues2/issue775.aya
@@ -1,0 +1,5 @@
+data False
+open data Truth | rua
+def f Truth : False
+| rua
+def inconsistency : False => f rua

--- a/base/src/test/resources/failure/patterns/issues2/issue775.aya.txt
+++ b/base/src/test/resources/failure/patterns/issues2/issue775.aya.txt
@@ -1,0 +1,11 @@
+In file $FILE:4:2 ->
+
+  2 | open data Truth | rua
+  3 | def f Truth : False
+  4 | | rua
+        ^-^
+
+Error: This match arm does not contain any absurd pattern but it has an empty body
+
+1 error(s), 0 warning(s).
+What are you doing?

--- a/base/src/test/resources/success/src/Match.aya
+++ b/base/src/test/resources/success/src/Match.aya
@@ -8,8 +8,9 @@ example open data Int : Type
 
 example def abs (n : Int) : Nat
  => match n, n {
- | pos n, neg m
- | neg n, pos m
+ // TODO: handle impossible patterns
+ | pos n, neg m => n
+ | neg n, pos m => n
  | pos n, pos m => n
  | neg n, neg m => n
  | negpos _, _ => 0


### PR DESCRIPTION
- Gate away the reachable match arms with empty body from passing type-checking:
- Check: for those patterns used in elimination (rather than data decl), if Pattern.Absurd () does not appear on lhs, then we require a body

close #775 

