### PR TITLE
KALA: upgrade to 0.59.0

### DIFF
--- a/gradle/deps.properties
+++ b/gradle/deps.properties
@@ -7,7 +7,7 @@ version.project=0.26-SNAPSHOT
 
 # https://github.com/JetBrains/java-annotations
 version.annotations=23.1.0
-version.kala=0.57.0
+version.kala=0.59.0
 version.guest0x0=0.18.0
 version.aya-upstream=0.0.9
 # https://github.com/jflex-de/jflex


### PR DESCRIPTION
New module : `org.glavo.kala:kala-common-gson`

Usage:

```java
var gson = KalaGson.registerKalaTypeAdapters(new GsonBuilder()).create();
```