### PR TITLE
KALA: upgrade to 0.61.0

### DIFF
--- a/base/src/main/java/org/aya/concrete/Expr.java
+++ b/base/src/main/java/org/aya/concrete/Expr.java
@@ -568,12 +568,12 @@ public sealed interface Expr extends AyaDocile, SourceNode, Restr.TermLike<Expr>
     @NotNull ImmutableSeq<Tuple2<Expr, Expr>> clauses
   ) implements Expr {
     public @NotNull PartEl update(@NotNull ImmutableSeq<Tuple2<Expr, Expr>> clauses) {
-      return clauses.allMatchWith(clauses(), (l, r) -> l._1 == r._1 && l._2 == r._2) ? this
+      return clauses.allMatchWith(clauses(), (l, r) -> l.component1() == r.component1() && l.component2() == r.component2()) ? this
         : new PartEl(sourcePos, clauses);
     }
 
     @Override public @NotNull PartEl descent(@NotNull UnaryOperator<@NotNull Expr> f) {
-      return update(clauses.map(cls -> kala.tuple.Tuple.of(f.apply(cls._1), f.apply(cls._2))));
+      return update(clauses.map(cls -> kala.tuple.Tuple.of(f.apply(cls.component1()), f.apply(cls.component2()))));
     }
   }
 

--- a/base/src/main/java/org/aya/concrete/visitor/StmtFolder.java
+++ b/base/src/main/java/org/aya/concrete/visitor/StmtFolder.java
@@ -34,7 +34,7 @@ public interface StmtFolder<R> extends Function<Stmt, R>, ExprFolder<R> {
     var t = Option.ofNullable(bb.resolvedTighters().get()).getOrElse(ImmutableSeq::empty);
     var l = Option.ofNullable(bb.resolvedLoosers().get()).getOrElse(ImmutableSeq::empty);
     return t.zipView(bb.tighters()).concat(l.zipView(bb.loosers()))
-      .foldLeft(acc, (ac, v) -> foldVarRef(ac, v._1, v._2.sourcePos(), lazyType(v._1)));
+      .foldLeft(acc, (ac, v) -> foldVarRef(ac, v.component1(), v.component2().sourcePos(), lazyType(v.component1())));
   }
 
   @MustBeInvokedByOverriders
@@ -52,8 +52,8 @@ public interface StmtFolder<R> extends Function<Stmt, R>, ExprFolder<R> {
       case Decl decl -> {
         acc = fold(acc, decl.bindBlock());
         var declType = declType(decl);
-        acc = declType._2.foldLeft(acc, (ac, p) -> foldVarDecl(ac, p._1, p._1.definition(), p._2));
-        yield foldVarDecl(acc, decl.ref(), decl.sourcePos(), declType._1);
+        acc = declType.component2().foldLeft(acc, (ac, p) -> foldVarDecl(ac, p.component1(), p.component1().definition(), p.component2()));
+        yield foldVarDecl(acc, decl.ref(), decl.sourcePos(), declType.component1());
       }
     };
   }

--- a/base/src/main/java/org/aya/core/repr/AyaShape.java
+++ b/base/src/main/java/org/aya/core/repr/AyaShape.java
@@ -57,7 +57,7 @@ public sealed interface AyaShape {
 
     public @NotNull ImmutableSeq<Tuple2<GenericDef, ShapeRecognition>> findImpl(@NotNull AyaShape shape) {
       return discovered.view().map(Tuple::of)
-        .filter(t -> t._2.shape() == shape)
+        .filter(t -> t.component2().shape() == shape)
         .toImmutableSeq();
     }
 

--- a/base/src/main/java/org/aya/core/serde/CompiledAya.java
+++ b/base/src/main/java/org/aya/core/serde/CompiledAya.java
@@ -87,9 +87,9 @@ public record CompiledAya(
       serialization.serOps.toImmutableSeq(),
       resolveInfo.opRename().view().map((k, v) -> {
           var name = state.def(k);
-          var info = v._1.opInfo();
-          var renamed = new SerDef.SerRenamedOp(info.name(), info.assoc(), serialization.serBind(v._2));
-          return Tuple.of(v._3, name, renamed);
+          var info = v.component1().opInfo();
+          var renamed = new SerDef.SerRenamedOp(info.name(), info.assoc(), serialization.serBind(v.component2()));
+          return Tuple.of(v.component3(), name, renamed);
         })
         .filter(Tuple3::head) // should not serialize publicly renamed ops from upstreams
         .map(Tuple3::tail)
@@ -200,7 +200,7 @@ public record CompiledAya(
     opRename.view().forEach((name, serOp) -> {
       var defVar = state.resolve(name);
       var asBind = serOp.bind();
-      var opDecl = resolveInfo.opRename().get(defVar)._1;
+      var opDecl = resolveInfo.opRename().get(defVar).component1();
       deBindDontCare(resolveInfo, state, opDecl, asBind);
     });
   }
@@ -226,7 +226,7 @@ public record CompiledAya(
   private @NotNull OpDecl resolveOp(@NotNull ResolveInfo resolveInfo, @NotNull SerTerm.DeState state, @NotNull SerDef.QName name) {
     var original = state.resolve(name);
     var renamed = resolveInfo.opRename().getOrNull(original);
-    var opDecl = renamed != null ? renamed._1 : original.opDecl;
+    var opDecl = renamed != null ? renamed.component1() : original.opDecl;
     if (opDecl != null) return opDecl;
     resolveInfo.opSet().reporter.report(new NameProblem.OperatorNameNotFound(SourcePos.SER, name.toString()));
     throw new Context.ResolvingInterruptedException();

--- a/base/src/main/java/org/aya/core/term/MetaLitTerm.java
+++ b/base/src/main/java/org/aya/core/term/MetaLitTerm.java
@@ -19,10 +19,10 @@ public record MetaLitTerm(
 ) implements Term {
   @SuppressWarnings("unchecked") public @NotNull Term inline() {
     if (!(type instanceof DataCall dataCall)) return this;
-    return candidates.find(t -> t._1.ref() == dataCall.ref()).flatMap(t -> {
-      var shape = t._2.shape();
-      if (shape == AyaShape.NAT_SHAPE) return Option.some(new IntegerTerm((int) repr, t._2, dataCall));
-      if (shape == AyaShape.LIST_SHAPE) return Option.some(new ListTerm((ImmutableSeq<Term>) repr, t._2, dataCall));
+    return candidates.find(t -> t.component1().ref() == dataCall.ref()).flatMap(t -> {
+      var shape = t.component2().shape();
+      if (shape == AyaShape.NAT_SHAPE) return Option.some(new IntegerTerm((int) repr, t.component2(), dataCall));
+      if (shape == AyaShape.LIST_SHAPE) return Option.some(new ListTerm((ImmutableSeq<Term>) repr, t.component2(), dataCall));
       return Option.<Term>none();
     }).getOrDefault(this);
   }

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -288,7 +288,7 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term>
     }
 
     public static @NotNull ImmutableSeq<@NotNull Param> fromBuffer(@NotNull MutableList<Tuple3<LocalVar, Boolean, Term>> buf) {
-      return buf.view().map(tup -> new Param(tup._1, tup._3, tup._2)).toImmutableSeq();
+      return buf.view().map(tup -> new Param(tup.component1(), tup.component3(), tup.component2())).toImmutableSeq();
     }
 
     public @NotNull Param descent(@NotNull UnaryOperator<@NotNull Term> f) {

--- a/base/src/main/java/org/aya/core/visitor/DeltaExpander.java
+++ b/base/src/main/java/org/aya/core/visitor/DeltaExpander.java
@@ -25,7 +25,7 @@ public interface DeltaExpander extends EndoTerm {
   static @NotNull Subst buildSubst(@NotNull SeqLike<Term.Param> self, @NotNull SeqLike<Arg<Term>> args) {
     assert self.sizeEquals(args);
     return new Subst(MutableMap.from(
-      self.zipView(args).map(t -> Tuple.of(t._1.ref(), t._2.term()))));
+      self.zipView(args).map(t -> Tuple.of(t.component1().ref(), t.component2().term()))));
   }
 
   @Override default @NotNull Term post(@NotNull Term term) {

--- a/base/src/main/java/org/aya/core/visitor/Zonker.java
+++ b/base/src/main/java/org/aya/core/visitor/Zonker.java
@@ -82,7 +82,7 @@ public record Zonker(
         Doc.english("Unable to solve the type of this literal:"),
         Doc.par(1, lit.toDoc(options)),
         Doc.plain("I'm confused about the following candidates, please help me!"),
-        Doc.par(1, Doc.join(Doc.plain(", "), lit.candidates().map(d -> Doc.code(d._1.ref().name()))))
+        Doc.par(1, Doc.join(Doc.plain(", "), lit.candidates().map(d -> Doc.code(d.component1().ref().name()))))
       );
     }
 

--- a/base/src/main/java/org/aya/prettier/ConcretePrettier.java
+++ b/base/src/main/java/org/aya/prettier/ConcretePrettier.java
@@ -194,8 +194,8 @@ public class ConcretePrettier extends BasePrettier<Expr> {
       );
       case Expr.Let let -> {
         var letsAndBody = sugarLet(let);
-        var lets = letsAndBody._1;
-        var body = letsAndBody._2;
+        var lets = letsAndBody.component1();
+        var body = letsAndBody.component2();
         var oneLine = lets.sizeEquals(1);
         var letSeq = oneLine
           ? visitLetBind(lets.first())
@@ -231,7 +231,7 @@ public class ConcretePrettier extends BasePrettier<Expr> {
 
   private Doc partial(Expr.PartEl el) {
     return Doc.join(Doc.spaced(Doc.symbol("|")), el.clauses().map(cl -> Doc.sep(
-      term(Outer.Free, cl._1), Doc.symbol(":="), term(Outer.Free, cl._2))
+      term(Outer.Free, cl.component1()), Doc.symbol(":="), term(Outer.Free, cl.component2()))
     ));
   }
 

--- a/base/src/main/java/org/aya/resolve/ResolveInfo.java
+++ b/base/src/main/java/org/aya/resolve/ResolveInfo.java
@@ -88,8 +88,8 @@ public record ResolveInfo(
         // if it is `public open`, make renamed operators transitively accessible by storing
         // them in my `opRename` bc "my importers" cannot access `other.opRename`.
         // see: https://github.com/aya-prover/aya-dev/issues/519
-        renameOp(defVar, tuple._1, tuple._2, false);
-      } else defVar.opDeclRename.put(thisModule().moduleName(), tuple._1);
+        renameOp(defVar, tuple.component1(), tuple.component2(), false);
+      } else defVar.opDeclRename.put(thisModule().moduleName(), tuple.component1());
     });
   }
 

--- a/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
@@ -176,8 +176,8 @@ public interface StmtResolver {
   static void resolveBind(@NotNull SeqLike<@NotNull Stmt> contents, @NotNull ResolveInfo info) {
     contents.forEach(s -> resolveBind(s, info));
     info.opRename().forEach((k, v) -> {
-      if (v._2 == BindBlock.EMPTY) return;
-      bind(v._2, info.opSet(), v._1);
+      if (v.component2() == BindBlock.EMPTY) return;
+      bind(v.component2(), info.opSet(), v.component1());
     });
   }
 

--- a/base/src/main/java/org/aya/terck/CallResolver.java
+++ b/base/src/main/java/org/aya/terck/CallResolver.java
@@ -5,6 +5,7 @@ package org.aya.terck;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableSet;
 import kala.tuple.Tuple;
+import kala.tuple.Tuple2;
 import kala.value.MutableValue;
 import org.aya.core.def.Def;
 import org.aya.core.def.FnDef;
@@ -68,8 +69,8 @@ public record CallResolver(
     var codomThings = callable.args().zip(callee.telescope());
     for (var domThing : domThings) {
       for (var codomThing : codomThings) {
-        var relation = compare(codomThing._1.term(), domThing._1.term());
-        matrix.set(domThing._2, codomThing._2, relation);
+        var relation = compare(codomThing.component1().term(), domThing.component1().term());
+        matrix.set(domThing.component2(), codomThing.component2(), relation);
       }
     }
   }
@@ -120,7 +121,7 @@ public record CallResolver(
   }
 
   private Relation compareConArgs(@NotNull ImmutableSeq<Arg<Term>> conArgs, @NotNull Pat.Ctor ctor) {
-    var subCompare = conArgs.zipView(ctor.params()).map(sub -> compare(sub._1.term(), sub._2.term()));
+    var subCompare = conArgs.zipView(ctor.params()).map(sub -> compare(sub.component1().term(), sub.component2().term()));
     return subCompare.foldLeft(Relation.eq(), Relation::mul);
   }
 

--- a/base/src/main/java/org/aya/tyck/error/Goal.java
+++ b/base/src/main/java/org/aya/tyck/error/Goal.java
@@ -37,9 +37,9 @@ public record Goal(
           ImmutableSeq.of(Doc.plain("To ensure confluence:"))
             .concat(meta.conditions.toImmutableSeq().map(tup -> Doc.par(1, Doc.cat(
               Doc.plain("Given "),
-              Doc.parened(tup._1.toDoc(options)),
+              Doc.parened(tup.component1().toDoc(options)),
               Doc.plain(", we should have: "),
-              tup._2.toDoc(options)
+              tup.component2().toDoc(options)
             )))))
         : Doc.empty()
     );

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -105,12 +105,12 @@ public record PatClassifier(
         var rhsInfo = contents.get(i);
         var lhsSubst = new Subst(MutableMap.create());
         var rhsSubst = new Subst(MutableMap.create());
-        var ctx = PatUnify.unifyPat(lhsInfo._2.patterns().map(Arg::term), rhsInfo._2.patterns().map(Arg::term),
+        var ctx = PatUnify.unifyPat(lhsInfo.component2().patterns().map(Arg::term), rhsInfo.component2().patterns().map(Arg::term),
           lhsSubst, rhsSubst, tycker.localCtx.deriveMap());
-        domination(ctx, rhsSubst, tycker.reporter, lhsInfo._1, rhsInfo._1, rhsInfo._2);
-        domination(ctx, lhsSubst, tycker.reporter, rhsInfo._1, lhsInfo._1, lhsInfo._2);
-        var lhsTerm = lhsInfo._2.body().subst(lhsSubst);
-        var rhsTerm = rhsInfo._2.body().subst(rhsSubst);
+        domination(ctx, rhsSubst, tycker.reporter, lhsInfo.component1(), rhsInfo.component1(), rhsInfo.component2());
+        domination(ctx, lhsSubst, tycker.reporter, rhsInfo.component1(), lhsInfo.component1(), lhsInfo.component2());
+        var lhsTerm = lhsInfo.component2().body().subst(lhsSubst);
+        var rhsTerm = rhsInfo.component2().body().subst(rhsSubst);
         // TODO: Currently all holes at this point are in an ErrorTerm
         if (lhsTerm instanceof ErrorTerm error && error.description() instanceof MetaTerm hole) {
           hole.ref().conditions.append(Tuple.of(lhsSubst, rhsTerm));
@@ -118,8 +118,8 @@ public record PatClassifier(
           hole.ref().conditions.append(Tuple.of(rhsSubst, lhsTerm));
         }
         tycker.unifyReported(lhsTerm, rhsTerm, result, pos, ctx, comparison ->
-          new ClausesProblem.Confluence(pos, rhsInfo._1 + 1, lhsInfo._1 + 1,
-            comparison, new UnifyInfo(tycker.state), rhsInfo._2.sourcePos(), lhsInfo._2.sourcePos()));
+          new ClausesProblem.Confluence(pos, rhsInfo.component1() + 1, lhsInfo.component1() + 1,
+            comparison, new UnifyInfo(tycker.state), rhsInfo.component2().sourcePos(), lhsInfo.component2().sourcePos()));
       }
     });
   }

--- a/base/src/main/java/org/aya/tyck/pat/PatternTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatternTycker.java
@@ -75,7 +75,7 @@ public final class PatternTycker {
     return switch (pattern) {
       case Pattern.Absurd absurd -> {
         var selection = selectCtor(term, null, absurd);
-        if (selection != null) foundError(new PatternProblem.PossiblePat(absurd, selection._3));
+        if (selection != null) foundError(new PatternProblem.PossiblePat(absurd, selection.component3()));
         yield new Pat.Absurd();
       }
       case Pattern.Tuple tuple -> {
@@ -95,16 +95,16 @@ public final class PatternTycker {
         var var = ctor.resolved().data();
         var realCtor = selectCtor(term, var, ctor);
         if (realCtor == null) yield randomPat(term);
-        var ctorRef = realCtor._3.ref();
+        var ctorRef = realCtor.component3().ref();
         var dataIsProp = ctorRef.core.inProp();
         if (!resultIsProp && dataIsProp) foundError(new PatternProblem.IllegalPropPat(ctor));
         var ctorCore = ctorRef.core;
 
-        final var dataCall = realCtor._1;
-        var sig = new Def.Signature<>(Term.Param.subst(ctorCore.selfTele, realCtor._2, 0), dataCall);
+        final var dataCall = realCtor.component1();
+        var sig = new Def.Signature<>(Term.Param.subst(ctorCore.selfTele, realCtor.component2(), 0), dataCall);
         // It is possible that `ctor.params()` is empty.
         var patterns = tyckInner(sig, ctor.params().view(), ctor, resultIsProp).wellTyped.toImmutableSeq();
-        yield new Pat.Ctor(realCtor._3.ref(), patterns, dataCall);
+        yield new Pat.Ctor(realCtor.component3().ref(), patterns, dataCall);
       }
       case Pattern.Bind(var pos, var bind, var tyExpr, var tyRef) -> {
         exprTycker.localCtx.put(bind, term);

--- a/base/src/main/java/org/aya/tyck/tycker/MockedTycker.java
+++ b/base/src/main/java/org/aya/tyck/tycker/MockedTycker.java
@@ -50,7 +50,7 @@ public abstract sealed class MockedTycker extends ConcreteAwareTycker permits Un
     // TODO: maybe we should create a concrete hole and check it against the type
     //  in case we can synthesize this term via its type only
     var genName = param.ref().name().concat(Constants.GENERATED_POSTFIX);
-    return localCtx.freshHole(param.type(), genName, pos)._2;
+    return localCtx.freshHole(param.type(), genName, pos).component2();
   }
 
   protected final @NotNull Arg<Term> mockArg(Term.Param param, SourcePos pos) {
@@ -65,8 +65,8 @@ public abstract sealed class MockedTycker extends ConcreteAwareTycker permits Un
   private @NotNull Term generatePi(@NotNull SourcePos pos, @NotNull String name, boolean explicit) {
     var genName = name + Constants.GENERATED_POSTFIX;
     // [ice]: unsure if ZERO is good enough
-    var domain = localCtx.freshTyHole(genName + "ty", pos)._2;
-    var codomain = localCtx.freshTyHole(genName + "ret", pos)._2;
+    var domain = localCtx.freshTyHole(genName + "ty", pos).component2();
+    var codomain = localCtx.freshTyHole(genName + "ret", pos).component2();
     return new PiTerm(new Term.Param(new LocalVar(genName, pos), domain, explicit), codomain);
   }
 

--- a/base/src/main/java/org/aya/tyck/unify/TermComparator.java
+++ b/base/src/main/java/org/aya/tyck/unify/TermComparator.java
@@ -77,10 +77,10 @@ public sealed abstract class TermComparator extends StatedTycker permits Unifier
     var lSubst = new Subst();
     var rSubst = new Subst();
     for (var conv : l.view().zip3(r, tyVars)) {
-      lr.map.put(conv._3, new RefTerm(conv._2));
-      rl.map.put(conv._3, new RefTerm(conv._1));
-      lSubst.addDirectly(conv._1, new RefTerm(conv._3));
-      rSubst.addDirectly(conv._2, new RefTerm(conv._3));
+      lr.map.put(conv.component3(), new RefTerm(conv.component2()));
+      rl.map.put(conv.component3(), new RefTerm(conv.component1()));
+      lSubst.addDirectly(conv.component1(), new RefTerm(conv.component3()));
+      rSubst.addDirectly(conv.component2(), new RefTerm(conv.component3()));
     }
     var res = supplier.apply(lSubst, rSubst);
     lr.map.removeAll(tyVars);
@@ -254,7 +254,7 @@ public sealed abstract class TermComparator extends StatedTycker permits Unifier
   private @NotNull Term getType(@NotNull Callable lhs, @NotNull DefVar<? extends Def, ? extends Decl.Telescopic<?>> lhsRef) {
     var substMap = MutableMap.<AnyVar, Term>create();
     for (var pa : lhs.args().view().zip(Def.defTele(lhsRef))) {
-      substMap.set(pa._2.ref(), pa._1.term());
+      substMap.set(pa.component2().ref(), pa.component1().term());
     }
     return Def.defResult(lhsRef).subst(substMap);
   }
@@ -267,12 +267,12 @@ public sealed abstract class TermComparator extends StatedTycker permits Unifier
       case StructCall type1 -> {
         var fieldSigs = type1.ref().core.fields;
         var paramSubst = Def.defTele(type1.ref()).view().zip(type1.args().view()).map(x ->
-          Tuple.of(x._1.ref(), x._2.term())).<AnyVar, Term>toImmutableMap();
+          Tuple.of(x.component1().ref(), x.component2().term())).<AnyVar, Term>toImmutableMap();
         var fieldSubst = new Subst(MutableHashMap.create());
         for (var fieldSig : fieldSigs) {
           var dummyVars = fieldSig.selfTele.map(par -> par.ref().rename());
           var dummy = dummyVars.zip(fieldSig.selfTele).map(vpa ->
-            new Arg<Term>(new RefTerm(vpa._1), vpa._2.explicit()));
+            new Arg<Term>(new RefTerm(vpa.component1()), vpa.component2().explicit()));
           var l = new FieldTerm(lhs, fieldSig.ref(), type1.args(), dummy);
           var r = new FieldTerm(rhs, fieldSig.ref(), type1.args(), dummy);
           fieldSubst.add(fieldSig.ref(), l);

--- a/base/src/main/java/org/aya/tyck/unify/Unifier.java
+++ b/base/src/main/java/org/aya/tyck/unify/Unifier.java
@@ -65,13 +65,13 @@ public final class Unifier extends TermComparator {
   private @Nullable Seq<LocalVar> invertSpine(Subst subst, @NotNull MetaTerm lhs, @NotNull Meta meta) {
     var overlap = MutableArrayList.<LocalVar>create();
     for (var arg : lhs.args().zipView(meta.telescope)) {
-      if (uneta.uneta(arg._1.term()) instanceof RefTerm ref) {
+      if (uneta.uneta(arg.component1().term()) instanceof RefTerm ref) {
         if (overlap.contains(ref.var())) continue;
         if (subst.map().containsKey(ref.var())) {
           overlap.append(ref.var());
           subst.map().remove(ref.var());
         }
-        subst.add(ref.var(), arg._2.toTerm());
+        subst.add(ref.var(), arg.component2().toTerm());
       } else return null;
     }
     return overlap;
@@ -176,9 +176,9 @@ public final class Unifier extends TermComparator {
     for (var arg : lhs.args().zipView(rcall.args())) {
       if (!(holeTy instanceof PiTerm holePi))
         throw new InternalException("meta arg size larger than param size. this should not happen");
-      if (!compare(arg._1.term(), arg._2.term(), lr, rl, holePi.param().type()))
+      if (!compare(arg.component1().term(), arg.component2().term(), lr, rl, holePi.param().type()))
         return Option.some(null);
-      holeTy = holePi.substBody(arg._1.term());
+      holeTy = holePi.substBody(arg.component1().term());
     }
     return Option.some(holeTy);
   }

--- a/base/src/test/java/org/aya/core/NormalizeTest.java
+++ b/base/src/test/java/org/aya/core/NormalizeTest.java
@@ -31,8 +31,8 @@ public class NormalizeTest {
       def kiva : Nat => tracy (suc zero) zero
       def overlap1 (a : Nat) : Nat => tracy a zero
       def overlap2 (a : Nat) : Nat => tracy zero a""");
-    var defs = res._2;
-    var state = new TyckState(res._1);
+    var defs = res.component2();
+    var state = new TyckState(res.component1());
     IntFunction<Term> normalizer = i -> ((FnDef) defs.get(i)).body.getLeftValue().normalize(state, NormalizeMode.NF);
     assertTrue(normalizer.apply(2) instanceof ConCall conCall
       && Objects.equals(conCall.ref().name(), "suc"));
@@ -51,8 +51,8 @@ public class NormalizeTest {
       prim coe
       def xyr : Nat => (\\ i => Nat).coe zero freeze 1
       def kiva : Nat => (\\ i => Nat).coe (suc zero) freeze 1""");
-    var state = new TyckState(res._1);
-    var defs = res._2;
+    var state = new TyckState(res.component1());
+    var defs = res.component2();
     IntFunction<Term> normalizer = i -> ((FnDef) defs.get(i)).body.getLeftValue().normalize(state, NormalizeMode.NF);
     assertTrue(normalizer.apply(3) instanceof ConCall conCall
       && Objects.equals(conCall.ref().name(), "zero")
@@ -92,8 +92,8 @@ public class NormalizeTest {
       }
       def t2 => pure (zero + suc zero)
       """);
-    var state = new TyckState(res._1);
-    var defs = res._2;
+    var state = new TyckState(res.component1());
+    var defs = res.component2();
     IntFunction<Term> normalizer = i -> ((FnDef) defs.get(i)).body.getLeftValue().normalize(state, NormalizeMode.NF);
     assertEquals("suc zero :< nil", normalizer.apply(defs.size() - 2).toDoc(AyaPrettierOptions.debug()).debugRender());
     assertEquals("suc zero :< nil", normalizer.apply(defs.size() - 1).toDoc(AyaPrettierOptions.debug()).debugRender());

--- a/base/src/test/java/org/aya/core/PrettierTest.java
+++ b/base/src/test/java/org/aya/core/PrettierTest.java
@@ -91,7 +91,7 @@ public class PrettierTest {
 
       def infix ?= : Type -> Type -> Type => \\ (A B : Type) => A
       def use (A B : Type) => A ?= B
-      """)._2;
+      """).component2();
     var test1 = ((FnDef) decls.get(3)).body.getLeftValue();
     var test2 = ((FnDef) decls.get(4)).body.getLeftValue();
     var use = ((FnDef) decls.get(6)).body.getLeftValue();
@@ -109,7 +109,7 @@ public class PrettierTest {
 
       def g (h : Nat -> D) : Nat => zero
       def t (n : Nat) => g (n ·)
-      """)._2;
+      """).component2();
     var t = ((FnDef) decls.get(3)).body.getLeftValue();
     assertEquals("g (n ·)", t.toDoc(AyaPrettierOptions.informative()).debugRender());
   }
@@ -122,7 +122,7 @@ public class PrettierTest {
 
       def elim {A : Type} False : A | ()
       def NonEmpty (A : Type) => ¬ ¬ A
-      """)._2;
+      """).component2();
     var t = ((FnDef) decls.get(3)).body.getLeftValue();
     assertEquals("¬ (¬ A)", t.toDoc(AyaPrettierOptions.informative()).debugRender());
   }
@@ -136,7 +136,7 @@ public class PrettierTest {
       def infix = {A : Type} => Eq A
       open data Nat | zero | suc Nat
       def test => zero = zero
-      """)._2;
+      """).component2();
     var t = ((FnDef) decls.get(6)).body.getLeftValue();
     assertEquals("(=) {Nat} zero zero", t.toDoc(AyaPrettierOptions.informative()).debugRender());
     assertEquals("zero = zero", t.toDoc(AyaPrettierOptions.pretty()).debugRender());
@@ -155,7 +155,7 @@ public class PrettierTest {
       def infix = {A : Type} => Eq A
       def test1 {A : Type} {a : A} (p : a = a) (i j k : I) => p ((i ∨ j ∨ k) ∧ (k ∨ j ∨ i))
       def test2 {A : Type} {a : A} (p : a = a) (i j k : I) => p ((i ∧ j ∧ k) ∨ (k ∧ j ∧ i))
-      """)._2;
+      """).component2();
     var t1 = ((FnDef) decls.get(9)).body.getLeftValue();
     var t2 = ((FnDef) decls.get(10)).body.getLeftValue();
     assertEquals("p ((i ∨ j ∨ k) ∧ (k ∨ j ∨ i))", t1.toDoc(AyaPrettierOptions.informative()).commonRender());
@@ -178,7 +178,7 @@ public class PrettierTest {
       def infix = {A : Type} (a b : A) : Type => [| i |] A { ~ i := a | i := b }
       def idp {A : Type} {a : A} : a = a => \\i => a
       def test {A : Type} {a b : A} (p : a = b) : a = b => \\i => p i
-      """)._2;
+      """).component2();
     var t = ((FnDef) decls.get(5)).body.getLeftValue();
     assertEquals("\\ i => p i", t.toDoc(AyaPrettierOptions.informative()).debugRender());
   }
@@ -192,7 +192,7 @@ public class PrettierTest {
         | 0 => 1
         | 1 => 2
         | a => suc a
-      """)._2;
+      """).component2();
     var t1 = ((FnDef) decls.get(1)).body.getLeftValue();
     var t2 = ((FnDef) decls.get(2)).body.getLeftValue();
     var t3 = ((FnDef) decls.get(3));
@@ -228,10 +228,10 @@ public class PrettierTest {
   }
 
   private @NotNull Doc declDoc(@Language("Aya") String text) {
-    return Doc.vcat(TyckDeclTest.successTyckDecls(text)._2.map(d -> d.toDoc(AyaPrettierOptions.debug())));
+    return Doc.vcat(TyckDeclTest.successTyckDecls(text).component2().map(d -> d.toDoc(AyaPrettierOptions.debug())));
   }
 
   private @NotNull Doc declCDoc(@Language("Aya") String text) {
-    return Doc.vcat(TyckDeclTest.successDesugarDecls(text)._2.map(s -> s.toDoc(AyaPrettierOptions.debug())));
+    return Doc.vcat(TyckDeclTest.successDesugarDecls(text).component2().map(s -> s.toDoc(AyaPrettierOptions.debug())));
   }
 }

--- a/base/src/test/java/org/aya/core/SuedeTest.java
+++ b/base/src/test/java/org/aya/core/SuedeTest.java
@@ -72,9 +72,9 @@ public class SuedeTest {
 
   private void suedeAll(@Language("Aya") @NotNull String code) {
     var res = TyckDeclTest.successTyckDecls(code);
-    var state = new SerTerm.DeState(res._1);
+    var state = new SerTerm.DeState(res.component1());
     var serializer = new Serializer(new Serializer.State());
-    res._2.view()
+    res.component2().view()
       .map(serializer::serialize)
       .map(ser -> ser.de(state))
       .forEach(Assertions::assertNotNull);

--- a/base/src/test/java/org/aya/cubical/PartialTest.java
+++ b/base/src/test/java/org/aya/cubical/PartialTest.java
@@ -42,7 +42,7 @@ public class PartialTest {
       def t5 (A : Type) (i : I) (j : I) (a : A) (b : A) : Partial (~ i \\/ i /\\ ~ j) A =>
         {| ~ i := a | i := b |}
       """);
-    IntFunction<Doc> prettier = i -> res._2.get(i).toDoc(AyaPrettierOptions.debug());
+    IntFunction<Doc> prettier = i -> res.component2().get(i).toDoc(AyaPrettierOptions.debug());
     assertEquals("""
       def t (A : Type 0) (i : I) (a : A) : Partial A (~ i) => {| ~ i := a |}
       """.strip(), prettier.apply(8).debugRender());

--- a/base/src/test/java/org/aya/cubical/PathTest.java
+++ b/base/src/test/java/org/aya/cubical/PathTest.java
@@ -23,7 +23,7 @@ public class PathTest {
       def idp {A : Type} {a : A} : a = a =>
         \\i => a
       """);
-    IntFunction<Doc> prettier = i -> res._2.get(i).toDoc(AyaPrettierOptions.debug());
+    IntFunction<Doc> prettier = i -> res.component2().get(i).toDoc(AyaPrettierOptions.debug());
     assertEquals("def = {A : Type 0} (a b : A) : Type 0 => a = b",
       prettier.apply(3).debugRender());
     assertEquals("def idp {A : Type 0} {a : A} : (=) {A} a a => \\ i => a",

--- a/base/src/test/java/org/aya/experiments/NormalizeHugeChurch.java
+++ b/base/src/test/java/org/aya/experiments/NormalizeHugeChurch.java
@@ -29,8 +29,8 @@ public class NormalizeHugeChurch {
       def #16 : Num => mul #4 #4
       def #256 : Num => add #16 #16
       """);
-    var state = new TyckState(res._1);
-    var decls = res._2;
+    var state = new TyckState(res.component1());
+    var decls = res.component2();
     var last = ((FnDef) decls.last()).body.getLeftValue();
     println("Tyck: " + (System.currentTimeMillis() - startup));
     startup = System.currentTimeMillis();

--- a/base/src/test/java/org/aya/literate/HighlighterTester.java
+++ b/base/src/test/java/org/aya/literate/HighlighterTester.java
@@ -98,8 +98,8 @@ public class HighlighterTester {
   public void runTest(@NotNull Seq<HighlightInfo> actuals, @NotNull Seq<ExpectedHighlightInfo> expecteds) {
     assertEquals(actuals.size(), expecteds.size(), "size mismatch");
     for (var tup : actuals.zipView(expecteds)) {
-      var actual = tup._1;
-      var expected = tup._2;
+      var actual = tup.component1();
+      var expected = tup.component2();
 
       if (expected == null) {
         switch (actual.type()) {
@@ -191,7 +191,7 @@ public class HighlighterTester {
       assertTrue(existName.isDefined(), "Undefined name: " + expectedRef.name());
 
       var defData = existName.get();
-      assertEquals(defData._2.getOrNull(), actualRef.kind());
+      assertEquals(defData.component2().getOrNull(), actualRef.kind());
     }
 
     assertEquals(actualRef.kind(), expectedRef.kind());

--- a/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
+++ b/base/src/test/java/org/aya/repr/ShapeMatcherTest.java
@@ -89,19 +89,19 @@ public class ShapeMatcherTest {
   }
 
   public @Nullable ShapeRecognition match(boolean should, @NotNull AyaShape shape, @Language("Aya") @NonNls @NotNull String code) {
-    var def = TyckDeclTest.successTyckDecls(code)._2;
+    var def = TyckDeclTest.successTyckDecls(code).component2();
     return check(ImmutableSeq.fill(def.size(), should), shape, def).firstOrNull();
   }
 
   public void match(@NotNull ImmutableSeq<Boolean> should, @NotNull AyaShape shape, @Language("Aya") @NonNls @NotNull String code) {
-    var def = TyckDeclTest.successTyckDecls(code)._2;
+    var def = TyckDeclTest.successTyckDecls(code).component2();
     check(should, shape, def);
   }
 
   private static ImmutableSeq<ShapeRecognition> check(@NotNull ImmutableSeq<Boolean> should, @NotNull AyaShape shape, @NotNull ImmutableSeq<GenericDef> def) {
     return def.zipView(should).flatMap(tup -> {
-      var match = ShapeMatcher.match(shape, tup._1);
-      assertEquals(tup._2, match.isDefined());
+      var match = ShapeMatcher.match(shape, tup.component1());
+      assertEquals(tup.component2(), match.isDefined());
       return match;
     }).toImmutableSeq();
   }

--- a/base/src/test/java/org/aya/tyck/PatCCTest.java
+++ b/base/src/test/java/org/aya/tyck/PatCCTest.java
@@ -34,8 +34,8 @@ public class PatCCTest {
        | a, zero => a
        | suc a, b => suc (add a b)
        | a, suc b => suc (add a b)""");
-    var decls = res._2;
-    var classified = testClassify(res._1, (FnDef) decls.get(1));
+    var decls = res.component2();
+    var classified = testClassify(res.component1(), (FnDef) decls.get(1));
     assertEquals(4, classified.size());
     classified.forEach(cls ->
       assertEquals(2, cls.contents().size()));
@@ -48,8 +48,8 @@ public class PatCCTest {
        | zero, b => b
        | a, zero => a
        | suc a, suc b => suc (max a b)""");
-    var decls = res._2;
-    var classified = testClassify(res._1, (FnDef) decls.get(1));
+    var decls = res.component2();
+    var classified = testClassify(res.component1(), (FnDef) decls.get(1));
     assertEquals(4, classified.size());
     assertEquals(3, classified.filter(patClass -> patClass.contents().sizeEquals(1)).size());
     assertEquals(1, classified.filter(patClass -> patClass.contents().sizeEquals(2)).size());
@@ -63,8 +63,8 @@ public class PatCCTest {
        | (zero, b), unit x => b
        | (a, zero), y => a
        | (suc a, suc b), unit y => suc (max (a, b) (unit zero))""");
-    var decls = res._2;
-    var classified = testClassify(res._1, (FnDef) decls.get(2));
+    var decls = res.component2();
+    var classified = testClassify(res.component1(), (FnDef) decls.get(2));
     assertEquals(4, classified.size());
     assertEquals(3, classified.filter(patClass -> patClass.contents().sizeEquals(1)).size());
     assertEquals(1, classified.filter(patClass -> patClass.contents().sizeEquals(2)).size());

--- a/base/src/test/java/org/aya/tyck/TracingTest.java
+++ b/base/src/test/java/org/aya/tyck/TracingTest.java
@@ -33,11 +33,11 @@ public class TracingTest {
 
   @NotNull private Trace.Builder mkBuilder(@Language("Aya") String code) {
     var res = TyckDeclTest.successDesugarDecls(code);
-    var decls = res._2;
+    var decls = res.component2();
     var builder = new Trace.Builder();
     var shapes = new AyaShape.Factory();
     decls.forEach(decl -> {
-      if (decl instanceof TeleDecl<?> signatured) TyckDeclTest.tyck(res._1, signatured, builder, shapes);
+      if (decl instanceof TeleDecl<?> signatured) TyckDeclTest.tyck(res.component1(), signatured, builder, shapes);
     });
     return builder;
   }

--- a/base/src/test/java/org/aya/tyck/TyckDeclTest.java
+++ b/base/src/test/java/org/aya/tyck/TyckDeclTest.java
@@ -52,8 +52,8 @@ public class TyckDeclTest {
   public static @NotNull Tuple2<PrimDef.Factory, ImmutableSeq<GenericDef>> successTyckDecls(@Language("Aya") @NonNls @NotNull String text) {
     var res = successDesugarDecls(text);
     var shapes = new AyaShape.Factory();
-    return Tuple.of(res._1, res._2.view()
-      .map(i -> i instanceof TeleDecl<?> s ? tyck(res._1, s, null, shapes) : null)
+    return Tuple.of(res.component1(), res.component2().view()
+      .map(i -> i instanceof TeleDecl<?> s ? tyck(res.component1(), s, null, shapes) : null)
       .filter(Objects::nonNull).toImmutableSeq());
   }
 }

--- a/cli/src/main/java/org/aya/cli/literate/AyaMdParser.java
+++ b/cli/src/main/java/org/aya/cli/literate/AyaMdParser.java
@@ -34,7 +34,7 @@ public class AyaMdParser {
   public AyaMdParser(@NotNull SourceFile file, @NotNull Reporter reporter) {
     this.file = file;
     this.reporter = reporter;
-    this.linesIndex = StringUtil.indexedLines(file.sourceCode()).map(x -> x._1);
+    this.linesIndex = StringUtil.indexedLines(file.sourceCode()).map(x -> x.component1());
   }
 
   public @NotNull Literate parseLiterate() {

--- a/cli/src/main/java/org/aya/cli/literate/FaithfulPrettier.java
+++ b/cli/src/main/java/org/aya/cli/literate/FaithfulPrettier.java
@@ -62,10 +62,10 @@ public record FaithfulPrettier(@NotNull PrettierOptions options) {
 
     for (var current : highlights) {
       var parts = twoKnifeThreeParts(raw, base, current.sourcePos());
-      if (!parts._1.isEmpty()) docs.append(Doc.plain(parts._1.toString()));
-      var highlightPart = highlightOne(parts._2.toString(), current.type());
-      var remainPart = parts._3;
-      var newBase = parts._4;
+      if (!parts.component1().isEmpty()) docs.append(Doc.plain(parts.component1().toString()));
+      var highlightPart = highlightOne(parts.component2().toString(), current.type());
+      var remainPart = parts.component3();
+      var newBase = parts.component4();
 
       if (highlightPart != Doc.empty()) {
         // Hit if: SourcePos contains nothing

--- a/cli/src/main/java/org/aya/cli/plct/PLCTReport.java
+++ b/cli/src/main/java/org/aya/cli/plct/PLCTReport.java
@@ -67,7 +67,7 @@ public final class PLCTReport {
       markdown = generate("Your Awesome Repository", args.repoName, since);
     } else {
       markdown = Doc.vcat(REPO
-        .mapChecked(t -> generate(t._1, t._2, since))
+        .mapChecked(t -> generate(t.component1(), t.component2(), since))
         .view()
         .prepended(Doc.plain("## The Aya Theorem Prover")));
     }

--- a/cli/src/main/java/org/aya/cli/repl/jline/AyaCompleters.java
+++ b/cli/src/main/java/org/aya/cli/repl/jline/AyaCompleters.java
@@ -45,9 +45,9 @@ public interface AyaCompleters {
       var context = repl.replCompiler.getContext();
       context.modules.view().forEach((mod, contents) -> {
         var modName = mod.joinToString(Constants.SCOPE_SEPARATOR, "", Constants.SCOPE_SEPARATOR);
-        if (!modName.startsWith(fixed._1)) return;
+        if (!modName.startsWith(fixed.component1())) return;
         contents.keysView()
-          .map(name -> (fixed._2 ? Constants.SCOPE_SEPARATOR : modName) + name)
+          .map(name -> (fixed.component2() ? Constants.SCOPE_SEPARATOR : modName) + name)
           .map(Candidate::new)
           .forEach(candidates::add);
       });

--- a/cli/src/test/java/org/aya/cli/CodifierTest.java
+++ b/cli/src/test/java/org/aya/cli/CodifierTest.java
@@ -14,7 +14,7 @@ public class CodifierTest extends ReplTestBase {
       def inline infix ∨ => intervalMax
       def coePi (A : I -> Type) (B : Pi (i : I) -> A i -> Type) (f : Pi (a : A 0) -> B 0 a) : Pi (a : A 1) -> B 1 a => \\a => (\\i => B i ((\\j => A ((~ j) ∨ i)).coe a freeze i)).coe f ((\\i => A (~ i)).coe a)
       :codify coePi
-      """)._1.trim();
+      """).component1().trim();
     assertNotNull(out);
   }
 
@@ -23,7 +23,7 @@ public class CodifierTest extends ReplTestBase {
       prim I
       def pmap {A B : Type} (p : [| i |] A) (f : A -> B) : [| i |] B => \\i => f (p i)
       :codify pmap
-      """)._1.trim();
+      """).component1().trim();
     // It would be nice if we can generate a complete Java file
     //  and run the code to test the codifier
     assertNotNull(out);

--- a/cli/src/test/java/org/aya/cli/PlainReplTest.java
+++ b/cli/src/test/java/org/aya/cli/PlainReplTest.java
@@ -8,11 +8,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class PlainReplTest extends ReplTestBase {
   @Test public void exit() {
-    assertEquals("", repl("")._1.trim());
+    assertEquals("", repl("").component1().trim());
   }
 
   @Test public void help() {
-    var repl = repl(":help")._1;
+    var repl = repl(":help").component1();
     assertTrue(repl.contains("help"));
     assertTrue(repl.contains("REPL"));
   }
@@ -22,64 +22,64 @@ public class PlainReplTest extends ReplTestBase {
   }
 
   @Test public void redefinition() {
-    assertNotNull(repl("def test => Type\ndef test => Type")._1);
+    assertNotNull(repl("def test => Type\ndef test => Type").component1());
   }
 
   @Test public void illTyped() {
-    assertNotNull(repl("prim I\ndef test : I => Type")._2);
+    assertNotNull(repl("prim I\ndef test : I => Type").component2());
   }
 
   @Test public void load() {
-    assertNotNull(repl(":l ../base/src/test/resources/success/add-comm.aya")._1);
+    assertNotNull(repl(":l ../base/src/test/resources/success/add-comm.aya").component1());
   }
 
   @Test public void typeType() {
-    var s = repl(":type Type")._1.trim();
+    var s = repl(":type Type").component1().trim();
     assertTrue(s.startsWith("Type"));
   }
 
   @Test public void amb() {
-    var s = repl(":p")._2;
+    var s = repl(":p").component2();
     assertTrue(s.startsWith("Ambiguous command name"));
   }
 
   @Test public void notFound() {
-    assertTrue(repl(":cthulhu")._2.contains("not found"));
+    assertTrue(repl(":cthulhu").component2().contains("not found"));
   }
 
   @Test public void type() {
-    var s = repl("Type")._1.trim();
+    var s = repl("Type").component1().trim();
     assertTrue(s.startsWith("Type"));
   }
 
   @Test public void disableUnicode() {
-    assertTrue(repl(":unicode no")._1.contains("disable"));
-    assertTrue(repl(":unicode yes")._1.contains("enable"));
-    assertTrue(repl(":unicode false")._1.contains("disable"));
+    assertTrue(repl(":unicode no").component1().contains("disable"));
+    assertTrue(repl(":unicode yes").component1().contains("enable"));
+    assertTrue(repl(":unicode false").component1().contains("disable"));
   }
 
   @Test public void pwd() {
     // This is actually not very good (maybe people just
     //  clone this repo to some really weird places?) but anyways
-    assertTrue(repl(":pwd")._1.contains("aya"));
+    assertTrue(repl(":pwd").component1().contains("aya"));
   }
 
   @Test public void typeSuc() {
-    var repl = repl("data Nat : Type | suc Nat | zero\n:type Nat::suc")._1.trim();
+    var repl = repl("data Nat : Type | suc Nat | zero\n:type Nat::suc").component1().trim();
     assertEquals("Nat -> Nat", repl);
   }
 
   @Test public void color() {
-    assertTrue(repl(":color i")._1.contains("IntelliJ"));
-    assertTrue(repl(":color e")._1.contains("Emacs"));
-    assertTrue(repl(":color")._1.contains("Emacs"));
-    assertTrue(repl(":color Custom")._2.contains("give"));
-    assertTrue(repl(":color " + VscColorThemeTest.TEST_DATA)._1.contains(VscColorThemeTest.TEST_DATA.getFileName().toString()));
+    assertTrue(repl(":color i").component1().contains("IntelliJ"));
+    assertTrue(repl(":color e").component1().contains("Emacs"));
+    assertTrue(repl(":color").component1().contains("Emacs"));
+    assertTrue(repl(":color Custom").component2().contains("give"));
+    assertTrue(repl(":color " + VscColorThemeTest.TEST_DATA).component1().contains(VscColorThemeTest.TEST_DATA.getFileName().toString()));
   }
 
   @Test public void style() {
-    assertTrue(repl(":style d")._1.contains("Default"));
-    assertTrue(repl(":style")._1.contains("Default"));
-    assertTrue(repl(":style " + VscColorThemeTest.TEST_DATA)._2.contains("support"));
+    assertTrue(repl(":style d").component1().contains("Default"));
+    assertTrue(repl(":style").component1().contains("Default"));
+    assertTrue(repl(":style " + VscColorThemeTest.TEST_DATA).component2().contains("support"));
   }
 }

--- a/gradle/deps.properties
+++ b/gradle/deps.properties
@@ -7,7 +7,7 @@ version.project=0.27-SNAPSHOT
 
 # https://github.com/JetBrains/java-annotations
 version.annotations=23.1.0
-version.kala=0.60.1
+version.kala=0.61.0
 version.guest0x0=0.18.0
 version.aya-upstream=0.0.10
 # https://github.com/jflex-de/jflex

--- a/lsp/src/main/java/org/aya/lsp/server/AyaLanguageServer.java
+++ b/lsp/src/main/java/org/aya/lsp/server/AyaLanguageServer.java
@@ -222,8 +222,8 @@ public class AyaLanguageServer implements LanguageServer {
       .flatMap(p -> Stream.concat(Stream.of(p), p.inlineHints(options).stream().map(t -> new InlineHintProblem(p, t))))
       .flatMap(p -> p.sourcePos().file().underlying().stream().map(uri -> Tuple.of(uri, p)))
       .collect(Collectors.groupingBy(
-        t -> t._1,
-        Collectors.mapping(t -> t._2, ImmutableSeq.factory())
+        t -> t.component1(),
+        Collectors.mapping(t -> t.component2(), ImmutableSeq.factory())
       ));
     var from = ImmutableMap.from(diags);
     client.publishAyaProblems(from, options);
@@ -316,9 +316,9 @@ public class AyaLanguageServer implements LanguageServer {
       .view()
       .flatMap(t -> t.sourcePos().file().underlying().map(f -> Tuple.of(f.toUri(), t)))
       .collect(Collectors.groupingBy(
-        t -> t._1,
+        t -> t.component1(),
         Collectors.mapping(
-          t -> new TextEdit(LspRange.toRange(t._2.sourcePos()), t._2.newText()),
+          t -> new TextEdit(LspRange.toRange(t.component2().sourcePos()), t.component2().newText()),
           Collectors.toList()
         )
       ));

--- a/pretty/src/main/java/org/aya/pretty/backend/html/Html5Stylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/Html5Stylist.java
@@ -83,7 +83,7 @@ public class Html5Stylist extends ClosingStylist {
 
   public static @NotNull String colorsToCss(@NotNull ColorScheme colorScheme) {
     return colorScheme.definedColors().toImmutableSeq().view()
-      .map(t -> "%s: %s;".formatted(Html5Stylist.cssVar(t._1), Html5Stylist.cssColor(t._2)))
+      .map(t -> "%s: %s;".formatted(Html5Stylist.cssVar(t.component1()), Html5Stylist.cssColor(t.component2())))
       .joinToString("\n", "  %s"::formatted);
   }
 

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -532,12 +532,12 @@ public sealed interface Doc extends Docile {
   }
 
   static @NotNull Doc catBlockR(int minBeforeDelim, @NotNull SeqLike<Doc> left, @NotNull Doc delim, @NotNull SeqLike<Doc> right) {
-    var vs = left.zipView(right).map(p -> Doc.splitR(minBeforeDelim, p._1, delim, p._2));
+    var vs = left.zipView(right).map(p -> Doc.splitR(minBeforeDelim, p.component1(), delim, p.component2()));
     return Doc.vcat(vs);
   }
 
   static @NotNull Doc catBlockL(int minBeforeRight, @NotNull SeqLike<Doc> left, @NotNull Doc delim, @NotNull SeqLike<Doc> right) {
-    var vs = left.zipView(right).map(p -> Doc.splitL(minBeforeRight, p._1, delim, p._2));
+    var vs = left.zipView(right).map(p -> Doc.splitL(minBeforeRight, p.component1(), delim, p.component2()));
     return Doc.vcat(vs);
   }
 

--- a/tools/src/main/java/org/aya/util/binop/BinOpParser.java
+++ b/tools/src/main/java/org/aya/util/binop/BinOpParser.java
@@ -71,17 +71,17 @@ public abstract class BinOpParser<
         var currentOp = toSetElem(expr, opSet);
         while (opStack.isNotEmpty()) {
           var top = opStack.peek();
-          var cmp = opSet.compare(top._2, currentOp);
+          var cmp = opSet.compare(top.component2(), currentOp);
           if (cmp == BinOpSet.PredCmp.Tighter) {
             if (!foldLhsFor(expr))
               return createErrorExpr(sourcePos);
           } else if (cmp == BinOpSet.PredCmp.Equal) {
             // associativity should be specified to both left/right when their share
             // the same precedence. Or a parse error should be reported.
-            var topAssoc = top._2.assoc();
+            var topAssoc = top.component2().assoc();
             var currentAssoc = currentOp.assoc();
             if (Assoc.assocAmbiguous(topAssoc, currentAssoc)) {
-              reportFixityError(topAssoc, currentAssoc, top._2.name(), currentOp.name(), of(top._1));
+              reportFixityError(topAssoc, currentAssoc, top.component2().name(), currentOp.name(), of(top.component1()));
               return createErrorExpr(sourcePos);
             }
             if (topAssoc.leftAssoc()) {
@@ -90,7 +90,7 @@ public abstract class BinOpParser<
           } else if (cmp == BinOpSet.PredCmp.Looser) {
             break;
           } else {
-            reportAmbiguousPred(currentOp.name(), top._2.name(), of(top._1));
+            reportAmbiguousPred(currentOp.name(), top.component2().name(), of(top.component1()));
             return createErrorExpr(sourcePos);
           }
         }
@@ -100,7 +100,7 @@ public abstract class BinOpParser<
 
     while (opStack.isNotEmpty()) {
       foldTop();
-      if (opStack.isNotEmpty()) markAppliedOperand(opStack.peek()._1, AppliedSide.Rhs);
+      if (opStack.isNotEmpty()) markAppliedOperand(opStack.peek().component1(), AppliedSide.Rhs);
     }
 
     assert prefixes.sizeEquals(1);
@@ -140,13 +140,13 @@ public abstract class BinOpParser<
 
   private boolean foldTop() {
     var opDef = opStack.pop();
-    if (opDef._2.assoc().isBinary()) {
-      prefixes.append(foldTopBinary(opDef._1));
+    if (opDef.component2().assoc().isBinary()) {
+      prefixes.append(foldTopBinary(opDef.component1()));
     } else { // implies isUnary()
-      var op = opDef._1;
+      var op = opDef.component1();
       if (prefixes.isEmpty()) {
         // we don't support unary section -- just raise an error.
-        reportMissingOperand(opDef._2.name(), op.term().sourcePos());
+        reportMissingOperand(opDef.component2().name(), op.term().sourcePos());
         return false;
       }
       var operand = prefixes.dequeue();

--- a/tools/src/main/java/org/aya/util/terck/CallGraph.java
+++ b/tools/src/main/java/org/aya/util/terck/CallGraph.java
@@ -47,8 +47,8 @@ public record CallGraph<C, T, P>(
     while (true) {
       var comb = indirect(initial, step);
       var tup = merge(comb, step);
-      if (tup._1.isEmpty()) return step; // no better matrices are found, we are complete
-      step = tup._2; // got a partially completed call graph, try complete more
+      if (tup.component1().isEmpty()) return step; // no better matrices are found, we are complete
+      step = tup.component2(); // got a partially completed call graph, try complete more
     }
   }
 
@@ -87,9 +87,9 @@ public record CallGraph<C, T, P>(
         // check if there's still old ones better than new ones...
         // note: the idea of "better" is not the same as "decrease more", see comments on `Selector.select()`
         var cmp = Selector.select(n.view(), o.view());
-        cmp._1.forEach(newG::put); // filtered really better new ones,
-        cmp._1.forEach(oldG::put); // ... and accept them.
-        cmp._2.forEach(oldG::put); // filtered old ones that still better than new ones.
+        cmp.component1().forEach(newG::put); // filtered really better new ones,
+        cmp.component1().forEach(oldG::put); // ... and accept them.
+        cmp.component2().forEach(oldG::put); // filtered old ones that still better than new ones.
       });
     return Tuple.of(newG, oldG);
   }


### PR DESCRIPTION
* Make `kala.base` as multi-release jar;
* For Java 17+, use record to re implement Tuple, allowing use pattern matching for Tuples.
