### PR TITLE
Cleanup concrete decls: step 0

### DIFF
--- a/base/src/main/java/org/aya/concrete/stmt/ClassDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/ClassDecl.java
@@ -4,8 +4,6 @@ package org.aya.concrete.stmt;
 
 import org.aya.core.def.ClassDef;
 import org.aya.resolve.context.Context;
-import org.aya.util.binop.OpDecl;
-import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,10 +14,10 @@ import org.jetbrains.annotations.Nullable;
  * @see Decl
  */
 public non-sealed/*sealed*/ abstract class ClassDecl extends CommonDecl implements Decl.TopLevel {
-  private final @NotNull Decl.Personality personality;
+  private final @NotNull DeclInfo.Personality personality;
   public @Nullable Context ctx = null;
 
-  @Override public @NotNull Decl.Personality personality() {
+  @Override public @NotNull DeclInfo.Personality personality() {
     return personality;
   }
 
@@ -31,15 +29,8 @@ public non-sealed/*sealed*/ abstract class ClassDecl extends CommonDecl implemen
     this.ctx = ctx;
   }
 
-  protected ClassDecl(
-    @NotNull SourcePos sourcePos,
-    @NotNull SourcePos entireSourcePos,
-    @Nullable OpDecl.OpInfo opInfo,
-    @NotNull BindBlock bindBlock,
-    @NotNull Decl.Personality personality,
-    @NotNull Accessibility accessibility
-  ) {
-    super(sourcePos, entireSourcePos, accessibility, opInfo, bindBlock);
+  protected ClassDecl(@NotNull DeclInfo info, @NotNull DeclInfo.Personality personality) {
+    super(info);
     this.personality = personality;
   }
 }

--- a/base/src/main/java/org/aya/concrete/stmt/ClassDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/ClassDecl.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.stmt;
 
@@ -21,7 +21,7 @@ import java.util.function.UnaryOperator;
 public non-sealed/*sealed*/ abstract class ClassDecl extends CommonDecl implements Decl.Resulted, Decl.TopLevel {
   private final @NotNull Decl.Personality personality;
   public @Nullable Context ctx = null;
-  public @NotNull Expr result;
+  public @Nullable Expr result;
 
   @Override public @NotNull Decl.Personality personality() {
     return personality;
@@ -35,12 +35,12 @@ public non-sealed/*sealed*/ abstract class ClassDecl extends CommonDecl implemen
     this.ctx = ctx;
   }
 
-  @Override public @NotNull Expr result() {
+  @Override public @Nullable Expr result() {
     return result;
   }
 
   @Override public void modifyResult(@NotNull UnaryOperator<Expr> f) {
-    result = f.apply(result);
+    if (result != null) result = f.apply(result);
   }
 
   protected ClassDecl(
@@ -55,9 +55,5 @@ public non-sealed/*sealed*/ abstract class ClassDecl extends CommonDecl implemen
     super(sourcePos, entireSourcePos, accessibility, opInfo, bindBlock);
     this.result = result;
     this.personality = personality;
-  }
-
-  @Override public String toString() {
-    return getClass().getSimpleName() + "[" + ref().name() + "]";
   }
 }

--- a/base/src/main/java/org/aya/concrete/stmt/ClassDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/ClassDecl.java
@@ -2,7 +2,6 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.stmt;
 
-import org.aya.concrete.Expr;
 import org.aya.core.def.ClassDef;
 import org.aya.resolve.context.Context;
 import org.aya.util.binop.OpDecl;
@@ -10,18 +9,15 @@ import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.function.UnaryOperator;
-
 /**
  * Concrete classable definitions, corresponding to {@link ClassDef}.
  *
  * @author zaoqi
  * @see Decl
  */
-public non-sealed/*sealed*/ abstract class ClassDecl extends CommonDecl implements Decl.Resulted, Decl.TopLevel {
+public non-sealed/*sealed*/ abstract class ClassDecl extends CommonDecl implements Decl.TopLevel {
   private final @NotNull Decl.Personality personality;
   public @Nullable Context ctx = null;
-  public @Nullable Expr result;
 
   @Override public @NotNull Decl.Personality personality() {
     return personality;
@@ -35,25 +31,15 @@ public non-sealed/*sealed*/ abstract class ClassDecl extends CommonDecl implemen
     this.ctx = ctx;
   }
 
-  @Override public @Nullable Expr result() {
-    return result;
-  }
-
-  @Override public void modifyResult(@NotNull UnaryOperator<Expr> f) {
-    if (result != null) result = f.apply(result);
-  }
-
   protected ClassDecl(
     @NotNull SourcePos sourcePos,
     @NotNull SourcePos entireSourcePos,
     @Nullable OpDecl.OpInfo opInfo,
     @NotNull BindBlock bindBlock,
-    @NotNull Expr result,
     @NotNull Decl.Personality personality,
     @NotNull Accessibility accessibility
   ) {
     super(sourcePos, entireSourcePos, accessibility, opInfo, bindBlock);
-    this.result = result;
     this.personality = personality;
   }
 }

--- a/base/src/main/java/org/aya/concrete/stmt/CommonDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/CommonDecl.java
@@ -2,10 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.stmt;
 
-import org.aya.util.binop.OpDecl;
-import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Common parts of concrete definitions.
@@ -16,44 +13,14 @@ import org.jetbrains.annotations.Nullable;
  * @see Decl
  */
 public sealed abstract class CommonDecl implements Decl permits ClassDecl, TeleDecl {
-  public final @NotNull Accessibility accessibility;
-  public final @NotNull SourcePos sourcePos;
-  public final @NotNull SourcePos entireSourcePos;
-  public final @Nullable OpInfo opInfo;
-  public final @NotNull BindBlock bindBlock;
+  public final @NotNull DeclInfo info;
 
-  protected CommonDecl(
-    @NotNull SourcePos sourcePos,
-    @NotNull SourcePos entireSourcePos,
-    @NotNull Accessibility accessibility,
-    @Nullable OpDecl.OpInfo opInfo,
-    @NotNull BindBlock bindBlock
-  ) {
-    this.sourcePos = sourcePos;
-    this.entireSourcePos = entireSourcePos;
-    this.accessibility = accessibility;
-    this.opInfo = opInfo;
-    this.bindBlock = bindBlock;
+  protected CommonDecl(@NotNull DeclInfo info) {
+    this.info = info;
   }
 
-  @Override public @NotNull BindBlock bindBlock() {
-    return bindBlock;
-  }
-
-  @Override public @NotNull SourcePos sourcePos() {
-    return sourcePos;
-  }
-
-  @Override public @NotNull SourcePos entireSourcePos() {
-    return entireSourcePos;
-  }
-
-  @Override public @NotNull Accessibility accessibility() {
-    return accessibility;
-  }
-
-  @Override public @Nullable OpInfo opInfo() {
-    return opInfo;
+  @Override public @NotNull DeclInfo info() {
+    return info;
   }
 
   @Override public String toString() {

--- a/base/src/main/java/org/aya/concrete/stmt/CommonDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/CommonDecl.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Yinsen (Tesla) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.stmt;
 
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Common parts of concrete definitions.
+ * In particular, it does not assume the definition to have a telescope.
  *
  * @author ice1000
  * @apiNote This class should only be used in extends and permits clause. Use {@link Decl} elsewhere instead.

--- a/base/src/main/java/org/aya/concrete/stmt/CommonDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/CommonDecl.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
  * @apiNote This class should only be used in extends and permits clause. Use {@link Decl} elsewhere instead.
  * @see Decl
  */
-public sealed abstract class CommonDecl implements Decl permits ClassDecl, TeleDecl, TeleDecl.DataCtor, TeleDecl.StructField {
+public sealed abstract class CommonDecl implements Decl permits ClassDecl, TeleDecl {
   public final @NotNull Accessibility accessibility;
   public final @NotNull SourcePos sourcePos;
   public final @NotNull SourcePos entireSourcePos;

--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -24,7 +24,6 @@ import java.util.function.UnaryOperator;
  * <ul>
  *   <li>Whether it has a telescope, see {@link Telescopic}</li>
  *   <li>Whether it can be defined at top-level, see {@link TopLevel}</li>
- *   <li>Whether it has a result type, see {@link Resulted}</li>
  * </ul>
  * We say these are properties of a concrete definition and should be implemented selectively.
  *
@@ -66,10 +65,12 @@ public sealed interface Decl extends OpDecl, SourceNode, TyckUnit, Stmt permits 
    *
    * @author kiva
    */
-  sealed interface Telescopic<RetTy extends Term> extends Resulted permits TeleDecl, TeleDecl.DataCtor, TeleDecl.StructField {
+  sealed interface Telescopic<RetTy extends Term> permits TeleDecl, TeleDecl.DataCtor, TeleDecl.StructField {
     @NotNull ImmutableSeq<Expr.Param> telescope();
     void modifyTelescope(@NotNull UnaryOperator<ImmutableSeq<Expr.Param>> f);
     @Nullable Def.Signature<RetTy> signature();
+    @Nullable Expr result();
+    void modifyResult(@NotNull UnaryOperator<@NotNull Expr> f);
   }
 
   /**
@@ -81,15 +82,5 @@ public sealed interface Decl extends OpDecl, SourceNode, TyckUnit, Stmt permits 
     @NotNull Personality personality();
     @Nullable Context getCtx();
     void setCtx(@NotNull Context ctx);
-  }
-
-  /**
-   * Denotes that the definition has a result type
-   *
-   * @author kiva
-   */
-  sealed interface Resulted permits Telescopic {
-    @Nullable Expr result();
-    void modifyResult(@NotNull UnaryOperator<@NotNull Expr> f);
   }
 }

--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -65,7 +65,7 @@ public sealed interface Decl extends OpDecl, SourceNode, TyckUnit, Stmt permits 
    *
    * @author kiva
    */
-  sealed interface Telescopic<RetTy extends Term> permits TeleDecl, TeleDecl.DataCtor, TeleDecl.StructField {
+  sealed interface Telescopic<RetTy extends Term> permits TeleDecl {
     @NotNull ImmutableSeq<Expr.Param> telescope();
     void modifyTelescope(@NotNull UnaryOperator<ImmutableSeq<Expr.Param>> f);
     @Nullable Def.Signature<RetTy> signature();
@@ -78,7 +78,7 @@ public sealed interface Decl extends OpDecl, SourceNode, TyckUnit, Stmt permits 
    *
    * @author kiva
    */
-  sealed interface TopLevel permits ClassDecl, TeleDecl {
+  sealed interface TopLevel permits ClassDecl, TeleDecl.TopLevel {
     @NotNull Personality personality();
     @Nullable Context getCtx();
     void setCtx(@NotNull Context ctx);

--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -40,21 +40,27 @@ import java.util.function.UnaryOperator;
  * @see ClassDecl
  */
 public sealed interface Decl extends OpDecl, SourceNode, TyckUnit, Stmt permits CommonDecl {
-  /** @see org.aya.generic.Modifier */
-  enum Personality {
-    /** Denotes that the definition is a normal definition (default behavior) */
-    NORMAL,
-    /** Denotes that the definition is an example (same as normal, but in separated context) */
-    EXAMPLE,
-    /** Denotes that the definition is a counterexample (errors expected, in separated context) */
-    COUNTEREXAMPLE,
+  @Contract(pure = true) @NotNull DefVar<?, ?> ref();
+  @Contract(pure = true) @NotNull DeclInfo info();
+  default @NotNull BindBlock bindBlock() {
+    return info().bindBlock();
   }
 
-  @Override @NotNull Accessibility accessibility();
-  @Contract(pure = true) @NotNull DefVar<?, ?> ref();
-  @NotNull BindBlock bindBlock();
-  @Override @Nullable OpInfo opInfo();
-  @NotNull SourcePos entireSourcePos();
+  default @NotNull SourcePos entireSourcePos() {
+    return info().entireSourcePos();
+  }
+
+  @Override default @NotNull SourcePos sourcePos() {
+    return info().sourcePos();
+  }
+
+  @Override default @NotNull Accessibility accessibility() {
+    return info().accessibility();
+  }
+
+  @Override default @Nullable OpInfo opInfo() {
+    return info().opInfo();
+  }
 
   @Override default boolean needTyck(@NotNull ImmutableSeq<String> currentMod) {
     return ref().isInModule(currentMod) && ref().core == null;
@@ -79,7 +85,7 @@ public sealed interface Decl extends OpDecl, SourceNode, TyckUnit, Stmt permits 
    * @author kiva
    */
   sealed interface TopLevel permits ClassDecl, TeleDecl.TopLevel {
-    @NotNull Personality personality();
+    @NotNull DeclInfo.Personality personality();
     @Nullable Context getCtx();
     void setCtx(@NotNull Context ctx);
   }

--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.stmt;
 
@@ -90,6 +90,6 @@ public sealed interface Decl extends OpDecl, SourceNode, TyckUnit, Stmt permits 
    */
   sealed interface Resulted permits ClassDecl, Telescopic {
     @Nullable Expr result();
-    void modifyResult(@NotNull UnaryOperator<Expr> f);
+    void modifyResult(@NotNull UnaryOperator<@NotNull Expr> f);
   }
 }

--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -88,7 +88,7 @@ public sealed interface Decl extends OpDecl, SourceNode, TyckUnit, Stmt permits 
    *
    * @author kiva
    */
-  sealed interface Resulted permits ClassDecl, Telescopic {
+  sealed interface Resulted permits Telescopic {
     @Nullable Expr result();
     void modifyResult(@NotNull UnaryOperator<@NotNull Expr> f);
   }

--- a/base/src/main/java/org/aya/concrete/stmt/Decl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/Decl.java
@@ -3,9 +3,6 @@
 package org.aya.concrete.stmt;
 
 import kala.collection.immutable.ImmutableSeq;
-import org.aya.concrete.Expr;
-import org.aya.core.def.Def;
-import org.aya.core.term.Term;
 import org.aya.ref.DefVar;
 import org.aya.resolve.context.Context;
 import org.aya.tyck.order.TyckUnit;
@@ -16,13 +13,11 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.function.UnaryOperator;
-
 /**
  * Generic concrete definitions, corresponding to {@link org.aya.core.def.GenericDef}.
  * Concrete definitions can be varied in the following ways:
  * <ul>
- *   <li>Whether it has a telescope, see {@link Telescopic}</li>
+ *   <li>Whether it has a telescope, see {@link TeleDecl}</li>
  *   <li>Whether it can be defined at top-level, see {@link TopLevel}</li>
  * </ul>
  * We say these are properties of a concrete definition and should be implemented selectively.
@@ -64,19 +59,6 @@ public sealed interface Decl extends OpDecl, SourceNode, TyckUnit, Stmt permits 
 
   @Override default boolean needTyck(@NotNull ImmutableSeq<String> currentMod) {
     return ref().isInModule(currentMod) && ref().core == null;
-  }
-
-  /**
-   * Denotes that the definition is telescopic
-   *
-   * @author kiva
-   */
-  sealed interface Telescopic<RetTy extends Term> permits TeleDecl {
-    @NotNull ImmutableSeq<Expr.Param> telescope();
-    void modifyTelescope(@NotNull UnaryOperator<ImmutableSeq<Expr.Param>> f);
-    @Nullable Def.Signature<RetTy> signature();
-    @Nullable Expr result();
-    void modifyResult(@NotNull UnaryOperator<@NotNull Expr> f);
   }
 
   /**

--- a/base/src/main/java/org/aya/concrete/stmt/DeclInfo.java
+++ b/base/src/main/java/org/aya/concrete/stmt/DeclInfo.java
@@ -1,0 +1,26 @@
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.concrete.stmt;
+
+import org.aya.util.binop.OpDecl;
+import org.aya.util.error.SourcePos;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public record DeclInfo(
+  @NotNull Stmt.Accessibility accessibility,
+  @NotNull SourcePos sourcePos,
+  @NotNull SourcePos entireSourcePos,
+  @Nullable OpDecl.OpInfo opInfo,
+  @NotNull BindBlock bindBlock
+) {
+  /** @see org.aya.generic.Modifier */
+  public enum Personality {
+    /** Denotes that the definition is a normal definition (default behavior) */
+    NORMAL,
+    /** Denotes that the definition is an example (same as normal, but in separated context) */
+    EXAMPLE,
+    /** Denotes that the definition is a counterexample (errors expected, in separated context) */
+    COUNTEREXAMPLE,
+  }
+}

--- a/base/src/main/java/org/aya/concrete/stmt/TeleDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/TeleDecl.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.stmt;
 
@@ -32,24 +32,37 @@ import java.util.function.UnaryOperator;
  * @see Decl
  */
 public sealed abstract class TeleDecl<RetTy extends Term>
-  extends CommonDecl implements Decl.Telescopic<RetTy>, Decl.TopLevel {
-  private final @NotNull Decl.Personality personality;
-  public @Nullable Context ctx = null;
+  extends CommonDecl implements Decl.Telescopic<RetTy> {
   public @Nullable Expr result;
   // will change after resolve
   public @NotNull ImmutableSeq<Expr.Param> telescope;
   public @Nullable Def.Signature<RetTy> signature;
 
-  @Override public @NotNull Decl.Personality personality() {
-    return personality;
-  }
+  public sealed abstract static class TopLevel<RetTy extends Term> extends TeleDecl<RetTy> implements Decl.TopLevel {
+    private final @NotNull Decl.Personality personality;
+    public @Nullable Context ctx = null;
 
-  @Override public @Nullable Context getCtx() {
-    return ctx;
-  }
+    protected TopLevel(
+      @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
+      @NotNull Accessibility accessibility, @Nullable OpInfo opInfo,
+      @NotNull BindBlock bindBlock, @NotNull ImmutableSeq<Expr.Param> telescope,
+      @Nullable Expr result, @NotNull Personality personality
+    ) {
+      super(sourcePos, entireSourcePos, accessibility, opInfo, bindBlock, telescope, result);
+      this.personality = personality;
+    }
 
-  @Override public void setCtx(@NotNull Context ctx) {
-    this.ctx = ctx;
+    @Override public @NotNull Decl.Personality personality() {
+      return personality;
+    }
+
+    @Override public @Nullable Context getCtx() {
+      return ctx;
+    }
+
+    @Override public void setCtx(@NotNull Context ctx) {
+      this.ctx = ctx;
+    }
   }
 
   @Override public @Nullable Expr result() {
@@ -78,12 +91,10 @@ public sealed abstract class TeleDecl<RetTy extends Term>
     @Nullable OpInfo opInfo,
     @NotNull BindBlock bindBlock,
     @NotNull ImmutableSeq<Expr.Param> telescope,
-    @Nullable Expr result,
-    @NotNull Decl.Personality personality
+    @Nullable Expr result
   ) {
     super(sourcePos, entireSourcePos, accessibility, opInfo, bindBlock);
     this.result = result;
-    this.personality = personality;
     this.telescope = telescope;
   }
 
@@ -95,7 +106,7 @@ public sealed abstract class TeleDecl<RetTy extends Term>
    * which means it's unspecified in the concrete syntax.
    * @see PrimDef
    */
-  public static final class PrimDecl extends TeleDecl<Term> {
+  public static final class PrimDecl extends TopLevel<Term> {
     public final @NotNull DefVar<PrimDef, PrimDecl> ref;
 
     public PrimDecl(
@@ -117,16 +128,12 @@ public sealed abstract class TeleDecl<RetTy extends Term>
     }
   }
 
-  public static final class DataCtor extends CommonDecl implements Decl.Telescopic<DataCall> {
+  public static final class DataCtor extends TeleDecl<DataCall> {
     public final @NotNull DefVar<CtorDef, TeleDecl.DataCtor> ref;
     public DefVar<DataDef, DataDecl> dataRef;
     public @NotNull Expr.PartEl clauses;
     public @NotNull ImmutableSeq<Arg<Pattern>> patterns;
-    public @Nullable Expr result;
     public final boolean coerce;
-
-    // will change after resolve
-    public @NotNull ImmutableSeq<Expr.Param> telescope;
 
     public DataCtor(
       @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
@@ -135,10 +142,10 @@ public sealed abstract class TeleDecl<RetTy extends Term>
       @NotNull ImmutableSeq<Expr.Param> telescope,
       @NotNull Expr.PartEl clauses,
       @NotNull ImmutableSeq<Arg<Pattern>> patterns,
-      boolean coerce,
+      boolean coerce, @Nullable Expr result,
       @NotNull BindBlock bindBlock
     ) {
-      super(sourcePos, entireSourcePos, Accessibility.Public, opInfo, bindBlock);
+      super(sourcePos, entireSourcePos, Accessibility.Public, opInfo, bindBlock, telescope, result);
       this.clauses = clauses;
       this.coerce = coerce;
       this.patterns = patterns;
@@ -157,19 +164,6 @@ public sealed abstract class TeleDecl<RetTy extends Term>
     @Override public @NotNull DefVar<CtorDef, DataCtor> ref() {
       return ref;
     }
-
-    @Override public @NotNull ImmutableSeq<Expr.Param> telescope() {
-      return telescope;
-    }
-
-    @Override public void modifyTelescope(@NotNull UnaryOperator<ImmutableSeq<Expr.Param>> f) {
-      telescope = f.apply(telescope);
-    }
-
-    @Override public @Nullable Def.Signature<DataCall> signature() {
-      return null;
-    }
-
   }
 
   /**
@@ -178,7 +172,7 @@ public sealed abstract class TeleDecl<RetTy extends Term>
    * @author kiva
    * @see DataDef
    */
-  public static final class DataDecl extends TeleDecl<SortTerm> {
+  public static final class DataDecl extends TopLevel<SortTerm> {
     public final @NotNull DefVar<DataDef, DataDecl> ref;
     public final @NotNull ImmutableSeq<DataCtor> body;
     /** Yet type-checked constructors */
@@ -211,7 +205,7 @@ public sealed abstract class TeleDecl<RetTy extends Term>
    *
    * @author vont
    */
-  public static final class StructDecl extends TeleDecl<SortTerm> {
+  public static final class StructDecl extends TopLevel<SortTerm> {
     public final @NotNull DefVar<StructDef, StructDecl> ref;
     public final @NotNull ImmutableSeq<StructField> fields;
 
@@ -238,17 +232,11 @@ public sealed abstract class TeleDecl<RetTy extends Term>
     }
   }
 
-  public static final class StructField
-    extends CommonDecl implements Decl.Telescopic<Term> {
+  public static final class StructField extends TeleDecl<Term> {
     public final @NotNull DefVar<FieldDef, TeleDecl.StructField> ref;
     public DefVar<StructDef, StructDecl> structRef;
-    public @NotNull Expr result;
     public @NotNull Option<Expr> body;
     public final boolean coerce;
-
-    // will change after resolve
-    public @NotNull ImmutableSeq<Expr.Param> telescope;
-    public @Nullable Def.Signature<Term> signature;
 
     public StructField(
       @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
@@ -260,36 +248,14 @@ public sealed abstract class TeleDecl<RetTy extends Term>
       boolean coerce,
       @NotNull BindBlock bindBlock
     ) {
-      super(sourcePos, entireSourcePos, Accessibility.Public, opInfo, bindBlock);
+      super(sourcePos, entireSourcePos, Accessibility.Public, opInfo, bindBlock, telescope, result);
       this.coerce = coerce;
-      this.result = result;
       this.body = body;
       this.ref = DefVar.concrete(this, name);
-      this.telescope = telescope;
     }
 
     @Override public @NotNull DefVar<FieldDef, StructField> ref() {
       return ref;
-    }
-
-    @Override public @NotNull ImmutableSeq<Expr.Param> telescope() {
-      return telescope;
-    }
-
-    @Override public void modifyTelescope(@NotNull UnaryOperator<ImmutableSeq<Expr.Param>> f) {
-      telescope = f.apply(telescope);
-    }
-
-    @Override public Def.@Nullable Signature<Term> signature() {
-      return signature;
-    }
-
-    @Override public @NotNull Expr result() {
-      return result;
-    }
-
-    @Override public void modifyResult(@NotNull UnaryOperator<Expr> f) {
-      result = f.apply(result);
     }
   }
 
@@ -299,7 +265,7 @@ public sealed abstract class TeleDecl<RetTy extends Term>
    * @author re-xyr
    * @see FnDef
    */
-  public static final class FnDecl extends TeleDecl<Term> {
+  public static final class FnDecl extends TopLevel<Term> {
     public final @NotNull EnumSet<Modifier> modifiers;
     public final @NotNull DefVar<FnDef, FnDecl> ref;
     public @NotNull Either<Expr, ImmutableSeq<Pattern.Clause>> body;

--- a/base/src/main/java/org/aya/concrete/stmt/TeleDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/TeleDecl.java
@@ -30,8 +30,7 @@ import java.util.function.UnaryOperator;
  * @author re-xyr
  * @see Decl
  */
-public sealed abstract class TeleDecl<RetTy extends Term>
-  extends CommonDecl implements Decl.Telescopic<RetTy> {
+public sealed abstract class TeleDecl<RetTy extends Term> extends CommonDecl {
   public @Nullable Expr result;
   // will change after resolve
   public @NotNull ImmutableSeq<Expr.Param> telescope;
@@ -62,31 +61,15 @@ public sealed abstract class TeleDecl<RetTy extends Term>
     }
   }
 
-  @Override public @Nullable Expr result() {
-    return result;
-  }
-
-  @Override public void modifyResult(@NotNull UnaryOperator<Expr> f) {
+  public void modifyResult(@NotNull UnaryOperator<Expr> f) {
     if (result != null) result = f.apply(result);
   }
 
-  @Override public @NotNull ImmutableSeq<Expr.Param> telescope() {
-    return telescope;
-  }
-
-  @Override public void modifyTelescope(@NotNull UnaryOperator<ImmutableSeq<Expr.Param>> f) {
+  public void modifyTelescope(@NotNull UnaryOperator<ImmutableSeq<Expr.Param>> f) {
     telescope = f.apply(telescope);
   }
 
-  @Override public Def.@Nullable Signature<RetTy> signature() {
-    return signature;
-  }
-
-  protected TeleDecl(
-    @NotNull DeclInfo info,
-    @NotNull ImmutableSeq<Expr.Param> telescope,
-    @Nullable Expr result
-  ) {
+  protected TeleDecl(@NotNull DeclInfo info, @NotNull ImmutableSeq<Expr.Param> telescope, @Nullable Expr result) {
     super(info);
     this.result = result;
     this.telescope = telescope;
@@ -148,14 +131,6 @@ public sealed abstract class TeleDecl<RetTy extends Term>
       this.patterns = patterns;
       this.ref = DefVar.concrete(this, name);
       this.telescope = telescope;
-    }
-
-    @Override public @Nullable Expr result() {
-      return result;
-    }
-
-    @Override public void modifyResult(@NotNull UnaryOperator<Expr> f) {
-      if (result != null) result = f.apply(result);
     }
 
     @Override public @NotNull DefVar<CtorDef, DataCtor> ref() {

--- a/base/src/main/java/org/aya/concrete/stmt/TeleDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/TeleDecl.java
@@ -128,6 +128,9 @@ public sealed abstract class TeleDecl<RetTy extends Term>
     }
   }
 
+  /**
+   * @implNote {@link TeleDecl#signature} is always null.
+   */
   public static final class DataCtor extends TeleDecl<DataCall> {
     public final @NotNull DefVar<CtorDef, TeleDecl.DataCtor> ref;
     public DefVar<DataDef, DataDecl> dataRef;

--- a/base/src/main/java/org/aya/concrete/stmt/TeleDecl.java
+++ b/base/src/main/java/org/aya/concrete/stmt/TeleDecl.java
@@ -16,7 +16,6 @@ import org.aya.generic.Modifier;
 import org.aya.ref.DefVar;
 import org.aya.resolve.context.Context;
 import org.aya.util.Arg;
-import org.aya.util.binop.OpDecl;
 import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -39,20 +38,18 @@ public sealed abstract class TeleDecl<RetTy extends Term>
   public @Nullable Def.Signature<RetTy> signature;
 
   public sealed abstract static class TopLevel<RetTy extends Term> extends TeleDecl<RetTy> implements Decl.TopLevel {
-    private final @NotNull Decl.Personality personality;
+    private final @NotNull DeclInfo.Personality personality;
     public @Nullable Context ctx = null;
 
     protected TopLevel(
-      @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
-      @NotNull Accessibility accessibility, @Nullable OpInfo opInfo,
-      @NotNull BindBlock bindBlock, @NotNull ImmutableSeq<Expr.Param> telescope,
-      @Nullable Expr result, @NotNull Personality personality
+      @NotNull DeclInfo info, @NotNull ImmutableSeq<Expr.Param> telescope,
+      @Nullable Expr result, @NotNull DeclInfo.Personality personality
     ) {
-      super(sourcePos, entireSourcePos, accessibility, opInfo, bindBlock, telescope, result);
+      super(info, telescope, result);
       this.personality = personality;
     }
 
-    @Override public @NotNull Decl.Personality personality() {
+    @Override public @NotNull DeclInfo.Personality personality() {
       return personality;
     }
 
@@ -86,14 +83,11 @@ public sealed abstract class TeleDecl<RetTy extends Term>
   }
 
   protected TeleDecl(
-    @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
-    @NotNull Accessibility accessibility,
-    @Nullable OpInfo opInfo,
-    @NotNull BindBlock bindBlock,
+    @NotNull DeclInfo info,
     @NotNull ImmutableSeq<Expr.Param> telescope,
     @Nullable Expr result
   ) {
-    super(sourcePos, entireSourcePos, accessibility, opInfo, bindBlock);
+    super(info);
     this.result = result;
     this.telescope = telescope;
   }
@@ -115,7 +109,7 @@ public sealed abstract class TeleDecl<RetTy extends Term>
       @NotNull ImmutableSeq<Expr.Param> telescope,
       @Nullable Expr result
     ) {
-      super(sourcePos, entireSourcePos, Accessibility.Public, null, BindBlock.EMPTY, telescope, result, Personality.NORMAL);
+      super(new DeclInfo(Accessibility.Public, sourcePos, entireSourcePos, null, BindBlock.EMPTY), telescope, result, DeclInfo.Personality.NORMAL);
       this.ref = DefVar.concrete(this, name);
     }
 
@@ -148,7 +142,7 @@ public sealed abstract class TeleDecl<RetTy extends Term>
       boolean coerce, @Nullable Expr result,
       @NotNull BindBlock bindBlock
     ) {
-      super(sourcePos, entireSourcePos, Accessibility.Public, opInfo, bindBlock, telescope, result);
+      super(new DeclInfo(Accessibility.Public, sourcePos, entireSourcePos, opInfo, bindBlock), telescope, result);
       this.clauses = clauses;
       this.coerce = coerce;
       this.patterns = patterns;
@@ -182,17 +176,14 @@ public sealed abstract class TeleDecl<RetTy extends Term>
     public final @NotNull MutableList<@NotNull CtorDef> checkedBody = MutableList.create();
 
     public DataDecl(
-      @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
-      @NotNull Accessibility accessibility,
-      @Nullable OpInfo opInfo,
+      @NotNull DeclInfo info,
       @NotNull String name,
       @NotNull ImmutableSeq<Expr.Param> telescope,
       @Nullable Expr result,
       @NotNull ImmutableSeq<DataCtor> body,
-      @NotNull BindBlock bindBlock,
-      @NotNull Decl.Personality personality
+      @NotNull DeclInfo.Personality personality
     ) {
-      super(sourcePos, entireSourcePos, accessibility, opInfo, bindBlock, telescope, result, personality);
+      super(info, telescope, result, personality);
       this.body = body;
       this.ref = DefVar.concrete(this, name);
       body.forEach(ctors -> ctors.dataRef = ref);
@@ -213,18 +204,15 @@ public sealed abstract class TeleDecl<RetTy extends Term>
     public final @NotNull ImmutableSeq<StructField> fields;
 
     public StructDecl(
-      @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
-      @NotNull Accessibility accessibility,
-      @Nullable OpInfo opInfo,
+      @NotNull DeclInfo info,
       @NotNull String name,
       @NotNull ImmutableSeq<Expr.Param> telescope,
       @NotNull Expr result,
       // @NotNull ImmutableSeq<String> superClassNames,
       @NotNull ImmutableSeq<StructField> fields,
-      @NotNull BindBlock bindBlock,
-      @NotNull Decl.Personality personality
+      @NotNull DeclInfo.Personality personality
     ) {
-      super(sourcePos, entireSourcePos, accessibility, opInfo, bindBlock, telescope, result, personality);
+      super(info, telescope, result, personality);
       this.fields = fields;
       this.ref = DefVar.concrete(this, name);
       fields.forEach(field -> field.structRef = ref);
@@ -251,7 +239,7 @@ public sealed abstract class TeleDecl<RetTy extends Term>
       boolean coerce,
       @NotNull BindBlock bindBlock
     ) {
-      super(sourcePos, entireSourcePos, Accessibility.Public, opInfo, bindBlock, telescope, result);
+      super(new DeclInfo(Accessibility.Public, sourcePos, entireSourcePos, opInfo, bindBlock), telescope, result);
       this.coerce = coerce;
       this.body = body;
       this.ref = DefVar.concrete(this, name);
@@ -274,18 +262,15 @@ public sealed abstract class TeleDecl<RetTy extends Term>
     public @NotNull Either<Expr, ImmutableSeq<Pattern.Clause>> body;
 
     public FnDecl(
-      @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
-      @NotNull Accessibility accessibility,
+      @NotNull DeclInfo info,
       @NotNull EnumSet<Modifier> modifiers,
-      @Nullable OpDecl.OpInfo opInfo,
       @NotNull String name,
       @NotNull ImmutableSeq<Expr.Param> telescope,
       @Nullable Expr result,
       @NotNull Either<Expr, ImmutableSeq<Pattern.Clause>> body,
-      @NotNull BindBlock bindBlock,
-      @NotNull Decl.Personality personality
+      @NotNull DeclInfo.Personality personality
     ) {
-      super(sourcePos, entireSourcePos, accessibility, opInfo, bindBlock, telescope, result, personality);
+      super(info, telescope, result, personality);
       this.modifiers = modifiers;
       this.ref = DefVar.concrete(this, name);
       this.body = body;

--- a/base/src/main/java/org/aya/concrete/visitor/StmtConsumer.java
+++ b/base/src/main/java/org/aya/concrete/visitor/StmtConsumer.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.visitor;
 
@@ -11,9 +11,7 @@ public interface StmtConsumer extends Consumer<Stmt>, EndoExpr {
   default void accept(@NotNull Stmt stmt) {
     switch (stmt) {
       case Decl decl -> {
-        if (decl instanceof Decl.Telescopic<?> telescopic)
-          telescopic.modifyTelescope(t -> t.map(param -> param.descent(this)));
-        if (decl instanceof Decl.Resulted resulted) resulted.modifyResult(this);
+        if (decl instanceof Decl.Telescopic<?> telescopic) visitTelescopic(telescopic);
         switch (decl) {
           case TeleDecl.DataDecl data -> data.body.forEach(this);
           case TeleDecl.StructDecl struct -> struct.fields.forEach(this);
@@ -37,5 +35,10 @@ public interface StmtConsumer extends Consumer<Stmt>, EndoExpr {
       }
       case Generalize generalize -> generalize.type = apply(generalize.type);
     }
+  }
+
+  default void visitTelescopic(@NotNull Decl.Telescopic<?> telescopic) {
+    telescopic.modifyTelescope(t -> t.map(param -> param.descent(this)));
+    telescopic.modifyResult(this);
   }
 }

--- a/base/src/main/java/org/aya/concrete/visitor/StmtConsumer.java
+++ b/base/src/main/java/org/aya/concrete/visitor/StmtConsumer.java
@@ -11,7 +11,7 @@ public interface StmtConsumer extends Consumer<Stmt>, EndoExpr {
   default void accept(@NotNull Stmt stmt) {
     switch (stmt) {
       case Decl decl -> {
-        if (decl instanceof Decl.Telescopic<?> telescopic) visitTelescopic(telescopic);
+        if (decl instanceof TeleDecl<?> telescopic) visitTelescopic(telescopic);
         switch (decl) {
           case TeleDecl.DataDecl data -> data.body.forEach(this);
           case TeleDecl.StructDecl struct -> struct.fields.forEach(this);
@@ -37,7 +37,7 @@ public interface StmtConsumer extends Consumer<Stmt>, EndoExpr {
     }
   }
 
-  default void visitTelescopic(@NotNull Decl.Telescopic<?> telescopic) {
+  default void visitTelescopic(@NotNull TeleDecl<?> telescopic) {
     telescopic.modifyTelescope(t -> t.map(param -> param.descent(this)));
     telescopic.modifyResult(this);
   }

--- a/base/src/main/java/org/aya/concrete/visitor/StmtFolder.java
+++ b/base/src/main/java/org/aya/concrete/visitor/StmtFolder.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.concrete.visitor;
 
@@ -85,8 +85,8 @@ public interface StmtFolder<R> extends Function<Stmt, R>, ExprFolder<R> {
     if (decl.ref().core instanceof Def def) return Tuple.of(lazyType(decl.ref()),
       def.telescope().view().map(p -> Tuple.of(p.ref(), LazyValue.ofValue(p.type()))));
     // If it is telescopic, type is available when it is type-checked.
-    if (decl instanceof Decl.Telescopic<?> teleDecl) return Tuple.of(lazyType(decl.ref()),
-      teleDecl.telescope().view().map(p -> Tuple.of(p.ref(), withTermType(p))));
+    if (decl instanceof TeleDecl<?> teleDecl) return Tuple.of(lazyType(decl.ref()),
+      teleDecl.telescope.view().map(p -> Tuple.of(p.ref(), withTermType(p))));
     // Oops, no type available.
     return Tuple.of(noType(), SeqView.empty());
   }

--- a/base/src/main/java/org/aya/core/def/Def.java
+++ b/base/src/main/java/org/aya/core/def/Def.java
@@ -22,14 +22,14 @@ import java.util.Objects;
  * @author ice1000
  */
 public sealed interface Def extends AyaDocile, GenericDef permits SubLevelDef, TopLevelDef {
-  static @NotNull Term defType(@NotNull DefVar<? extends Def, ? extends Decl.Telescopic<?>> defVar) {
+  static @NotNull Term defType(@NotNull DefVar<? extends Def, ? extends TeleDecl<?>> defVar) {
     return PiTerm.make(defTele(defVar), defResult(defVar));
   }
 
-  static @NotNull ImmutableSeq<Term.Param> defTele(@NotNull DefVar<? extends Def, ? extends Decl.Telescopic<?>> defVar) {
+  static @NotNull ImmutableSeq<Term.Param> defTele(@NotNull DefVar<? extends Def, ? extends TeleDecl<?>> defVar) {
     if (defVar.core != null) return defVar.core.telescope();
       // guaranteed as this is already a core term
-    else return Objects.requireNonNull(defVar.concrete.signature()).param;
+    else return Objects.requireNonNull(defVar.concrete.signature).param;
   }
   static @NotNull Seq<CtorDef> dataBody(@NotNull DefVar<? extends DataDef, ? extends TeleDecl.DataDecl> defVar) {
     if (defVar.core != null) return defVar.core.body;

--- a/base/src/main/java/org/aya/core/def/Def.java
+++ b/base/src/main/java/org/aya/core/def/Def.java
@@ -38,10 +38,10 @@ public sealed interface Def extends AyaDocile, GenericDef permits SubLevelDef, T
   }
   @SuppressWarnings("unchecked") @Contract(pure = true)
   static <T extends Term> @NotNull T
-  defResult(@NotNull DefVar<? extends Def, ? extends Decl.Telescopic<? extends T>> defVar) {
+  defResult(@NotNull DefVar<? extends Def, ? extends TeleDecl<? extends T>> defVar) {
     if (defVar.core != null) return (T) defVar.core.result();
       // guaranteed as this is already a core term
-    else return Objects.requireNonNull(defVar.concrete.signature()).result;
+    else return Objects.requireNonNull(defVar.concrete.signature).result;
   }
 
   @Override @NotNull DefVar<? extends Def, ? extends Decl> ref();

--- a/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
+++ b/base/src/main/java/org/aya/core/repr/ShapeMatcher.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.repr;
 
@@ -7,7 +7,7 @@ import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableLinkedList;
 import kala.collection.mutable.MutableMap;
 import kala.control.Option;
-import org.aya.concrete.stmt.Decl;
+import org.aya.concrete.stmt.TeleDecl;
 import org.aya.core.def.CtorDef;
 import org.aya.core.def.DataDef;
 import org.aya.core.def.Def;
@@ -28,7 +28,7 @@ import java.util.function.Function;
  * @author kiva
  */
 public record ShapeMatcher(
-  @NotNull MutableLinkedList<DefVar<? extends Def, ? extends Decl.Telescopic<?>>> def,
+  @NotNull MutableLinkedList<DefVar<? extends Def, ? extends TeleDecl<?>>> def,
   @NotNull MutableMap<CodeShape.MomentId, DefVar<?, ?>> captures,
   @NotNull MutableMap<AnyVar, AnyVar> teleSubst
 ) {
@@ -117,7 +117,7 @@ public record ShapeMatcher(
       || (xlicit == CodeShape.ParamShape.Licit.Kind.Ex) == isExplicit;
   }
 
-  private boolean matchInside(@NotNull DefVar<? extends Def, ? extends Decl.Telescopic<?>> defVar, @NotNull BooleanSupplier matcher) {
+  private boolean matchInside(@NotNull DefVar<? extends Def, ? extends TeleDecl<?>> defVar, @NotNull BooleanSupplier matcher) {
     def.push(defVar);
     var result = matcher.getAsBoolean();
     def.pop();

--- a/base/src/main/java/org/aya/core/term/Callable.java
+++ b/base/src/main/java/org/aya/core/term/Callable.java
@@ -1,13 +1,14 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.core.term;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.concrete.stmt.Decl;
+import org.aya.concrete.stmt.TeleDecl;
 import org.aya.core.def.Def;
-import org.aya.util.Arg;
 import org.aya.ref.AnyVar;
 import org.aya.ref.DefVar;
+import org.aya.util.Arg;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -19,7 +20,7 @@ public sealed interface Callable extends Term permits Callable.DefCall, FieldTer
   @NotNull AnyVar ref();
   @NotNull ImmutableSeq<@NotNull Arg<Term>> args();
   sealed interface DefCall extends Callable permits ConCall, DataCall, FnCall, PrimCall, StructCall {
-    @Override @NotNull DefVar<? extends Def, ? extends Decl.Telescopic<?>> ref();
+    @Override @NotNull DefVar<? extends Def, ? extends TeleDecl<?>> ref();
     int ulift();
   }
 

--- a/base/src/main/java/org/aya/core/term/Term.java
+++ b/base/src/main/java/org/aya/core/term/Term.java
@@ -51,7 +51,7 @@ public sealed interface Term extends AyaDocile, Restr.TermLike<Term>
     return new EndoTerm.Substituter(subst).apply(this);
   }
 
-  default @NotNull Term subst(@NotNull Map<AnyVar, ? extends Term> subst) {
+  default @NotNull Term subst(@NotNull Map<? extends AnyVar, ? extends Term> subst) {
     return subst(new Subst(MutableMap.from(subst)));
   }
 

--- a/base/src/main/java/org/aya/prettier/ConcretePrettier.java
+++ b/base/src/main/java/org/aya/prettier/ConcretePrettier.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.prettier;
 
@@ -332,8 +332,8 @@ public class ConcretePrettier extends BasePrettier<Expr> {
     };
   }
 
-  private Stmt.Accessibility defaultAcc(@NotNull Decl.Personality personality) {
-    return personality == Decl.Personality.NORMAL ? Stmt.Accessibility.Public : Stmt.Accessibility.Private;
+  private Stmt.Accessibility defaultAcc(@NotNull DeclInfo.Personality personality) {
+    return personality == DeclInfo.Personality.NORMAL ? Stmt.Accessibility.Public : Stmt.Accessibility.Private;
   }
 
   public @NotNull Doc decl(@NotNull Decl predecl) {
@@ -422,7 +422,7 @@ public class ConcretePrettier extends BasePrettier<Expr> {
         term(Outer.Free, doBind.expr()));
   }
 
-  public @NotNull Doc visitPersonality(@NotNull Decl.Personality personality) {
+  public @NotNull Doc visitPersonality(@NotNull DeclInfo.Personality personality) {
     return switch (personality) {
       case NORMAL -> Doc.empty();
       case EXAMPLE -> Doc.styled(KEYWORD, "example");

--- a/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.resolve.visitor;
 
@@ -123,7 +123,7 @@ public interface StmtResolver {
   }
 
   private static @NotNull ExprResolver resolveDeclSignature(
-    @NotNull TeleDecl<?> decl,
+    @NotNull TeleDecl.TopLevel<?> decl,
     ExprResolver.@NotNull Options options,
     @NotNull ResolveInfo info
   ) {

--- a/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
@@ -103,7 +103,7 @@ public interface StmtResolver {
       case TeleDecl.StructField field -> {}
     }
   }
-  private static <T extends Decl.Telescopic<?> & TyckUnit>
+  private static <T extends TeleDecl<?> & TyckUnit>
   void resolveMemberSignature(T ctor, ExprResolver bodyResolver, MutableValue<@NotNull Context> mCtx) {
     ctor.modifyTelescope(t -> t.map(param -> bodyResolver.resolve(param, mCtx)));
     // If changed to method reference, `bodyResolver.enter(mCtx.get())` will be evaluated eagerly

--- a/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
@@ -187,15 +187,15 @@ public interface StmtResolver {
       case ClassDecl classDecl -> throw new UnsupportedOperationException("not implemented yet");
       case TeleDecl.DataDecl decl -> {
         decl.body.forEach(ctor -> resolveBind(ctor, info));
-        visitBind(decl.ref, decl.bindBlock, info);
+        visitBind(decl.ref, decl.bindBlock(), info);
       }
       case TeleDecl.StructDecl decl -> {
         decl.fields.forEach(field -> resolveBind(field, info));
-        visitBind(decl.ref, decl.bindBlock, info);
+        visitBind(decl.ref, decl.bindBlock(), info);
       }
-      case TeleDecl.DataCtor ctor -> visitBind(ctor.ref, ctor.bindBlock, info);
-      case TeleDecl.StructField field -> visitBind(field.ref, field.bindBlock, info);
-      case TeleDecl.FnDecl decl -> visitBind(decl.ref, decl.bindBlock, info);
+      case TeleDecl.DataCtor ctor -> visitBind(ctor.ref, ctor.bindBlock(), info);
+      case TeleDecl.StructField field -> visitBind(field.ref, field.bindBlock(), info);
+      case TeleDecl.FnDecl decl -> visitBind(decl.ref, decl.bindBlock(), info);
       case TeleDecl.PrimDecl decl -> {}
       case Command cmd -> {}
       case Generalize generalize -> {}

--- a/base/src/main/java/org/aya/resolve/visitor/StmtShallowResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtShallowResolver.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.resolve.visitor;
 
@@ -115,7 +115,7 @@ public record StmtShallowResolver(
       case TeleDecl.PrimDecl decl -> {
         var factory = resolveInfo.primFactory();
         var name = decl.ref.name();
-        var sourcePos = decl.sourcePos;
+        var sourcePos = decl.sourcePos();
         var primID = PrimDef.ID.find(name);
         if (primID == null) context.reportAndThrow(new PrimResolveError.UnknownPrim(sourcePos, name));
         var lack = factory.checkDependency(primID);
@@ -128,12 +128,12 @@ public record StmtShallowResolver(
       }
       case TeleDecl.DataCtor ctor -> {
         ctor.ref().module = context.moduleName();
-        context.addGlobalSimple(Stmt.Accessibility.Public, ctor.ref, ctor.sourcePos);
+        context.addGlobalSimple(Stmt.Accessibility.Public, ctor.ref, ctor.sourcePos());
         resolveOpInfo(ctor, context);
       }
       case TeleDecl.StructField field -> {
         field.ref().module = context.moduleName();
-        context.addGlobalSimple(Stmt.Accessibility.Public, field.ref, field.sourcePos);
+        context.addGlobalSimple(Stmt.Accessibility.Public, field.ref, field.sourcePos());
         resolveOpInfo(field, context);
       }
     }

--- a/base/src/main/java/org/aya/terck/CallResolver.java
+++ b/base/src/main/java/org/aya/terck/CallResolver.java
@@ -107,7 +107,7 @@ public record CallResolver(
       }
       case Pat.ShapedInt intPat -> switch (term) {
         case IntegerTerm intTerm -> {
-          // TODO: compareShape
+          // ice: by well-typedness, we don't need to compareShape
           if (intTerm.recognition().shape() != intPat.recognition().shape()) yield Relation.unk();
           yield Relation.fromCompare(Integer.compare(intTerm.repr(), intPat.repr()));
         }
@@ -141,9 +141,7 @@ public record CallResolver(
   }
 
   @Override public void pre(@NotNull Term term) {
-    if (term instanceof Callable call) {
-      resolveCall(call);
-    }
+    if (term instanceof Callable call) resolveCall(call);
     DefConsumer.super.pre(term);
   }
 }

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -81,7 +81,7 @@ public final class StmtTycker extends TracedTycker {
           }, clauses -> {
             var exprTycker = newTycker(tycker.state.primFactory(), tycker.shapeFactory);
             FnDef def;
-            var pos = decl.sourcePos;
+            var pos = decl.sourcePos();
             ClauseTycker.PatResult result;
             var orderIndependent = decl.modifiers.contains(Modifier.Overlap);
             if (orderIndependent) {
@@ -171,7 +171,7 @@ public final class StmtTycker extends TracedTycker {
       case TeleDecl.FnDecl fn -> {
         var resultTele = tele(tycker, fn.telescope, null);
         // It might contain unsolved holes, but that's acceptable.
-        if (fn.result == null) fn.result = new Expr.Hole(fn.sourcePos, false, null);
+        if (fn.result == null) fn.result = new Expr.Hole(fn.sourcePos(), false, null);
         var resultRes = tycker.ty(fn.result).freezeHoles(tycker.state);
         // We cannot solve metas in result type from clauses,
         //  because when we're in the clauses, the result type is substituted,
@@ -254,7 +254,7 @@ public final class StmtTycker extends TracedTycker {
     if (ctor.patterns.isNotEmpty()) {
       var sig = new Def.Signature<>(dataSig.param(), predataCall);
       var lhs = ClauseTycker.checkLhs(tycker,
-        new Pattern.Clause(ctor.sourcePos, ctor.patterns, Option.none()), sig, false, false);
+        new Pattern.Clause(ctor.sourcePos(), ctor.patterns, Option.none()), sig, false, false);
       pat = lhs.preclause().patterns();
       // Revert to the "after patterns" state
       tycker.ctx = lhs.gamma();

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -59,9 +59,8 @@ public final class StmtTycker extends TracedTycker {
   }
 
   private @NotNull GenericDef doTyck(@NotNull Decl predecl, @NotNull ExprTycker tycker) {
-    if (predecl instanceof Decl.Telescopic<?> decl) {
-      var signature = decl.signature();
-      if (signature != null) loadTele(tycker, signature);
+    if (predecl instanceof TeleDecl<?> decl) {
+      if (decl.signature != null) loadTele(tycker, decl.signature);
         // If core == null then not yet tycked. A constructor's signature is always null,
         // so we need this extra check
       else if (predecl.ref().core == null) tyckHeader(predecl, tycker);

--- a/base/src/main/java/org/aya/tyck/error/UnifyError.java
+++ b/base/src/main/java/org/aya/tyck/error/UnifyError.java
@@ -33,7 +33,7 @@ public sealed interface UnifyError extends TyckError {
     @NotNull UnifyInfo info
   ) implements UnifyError {
     @Override public @NotNull SourcePos sourcePos() {
-      return ctor.sourcePos;
+      return ctor.sourcePos();
     }
 
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {

--- a/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
@@ -8,6 +8,7 @@ import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableMap;
 import kala.collection.mutable.MutableSet;
 import org.aya.concrete.stmt.Decl;
+import org.aya.concrete.stmt.DeclInfo;
 import org.aya.concrete.stmt.TeleDecl;
 import org.aya.core.def.Def;
 import org.aya.core.def.FnDef;
@@ -199,7 +200,7 @@ public record AyaSccTycker(
 
   private @NotNull ExprTycker reuseTopLevel(@NotNull Decl.TopLevel decl) {
     // prevent counterexample errors from being reported to the user reporter
-    if (decl.personality() == Decl.Personality.COUNTEREXAMPLE) {
+    if (decl.personality() == DeclInfo.Personality.COUNTEREXAMPLE) {
       var reporter = sampleReporters.getOrPut(decl, BufferReporter::new);
       return new ExprTycker(resolveInfo.primFactory(), resolveInfo.shapeFactory(), reporter, tycker.traceBuilder);
     }

--- a/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
@@ -146,7 +146,7 @@ public record AyaSccTycker(
 
   private void checkSimpleFn(@NotNull TyckOrder order, @NotNull TeleDecl.FnDecl fn) {
     if (selfReferencing(resolveInfo.depGraph(), order)) {
-      reporter.report(new BadRecursion(fn.sourcePos, fn.ref, null));
+      reporter.report(new BadRecursion(fn.sourcePos(), fn.ref, null));
       throw new SCCTyckingFailed(ImmutableSeq.of(order));
     }
     decideTyckResult(fn, fn, tycker.simpleFn(reuseTopLevel(fn), fn));

--- a/base/src/main/java/org/aya/tyck/order/SigRefFinder.java
+++ b/base/src/main/java/org/aya/tyck/order/SigRefFinder.java
@@ -22,7 +22,7 @@ public record SigRefFinder(@NotNull MutableList<TyckUnit> references) implements
   public void accept(@NotNull TyckUnit sn) {
     switch (sn) {
       case Decl decl -> {
-        if (decl instanceof Decl.Telescopic<?> proof) telescopic(proof);
+        if (decl instanceof TeleDecl<?> proof) telescopic(proof);
         // for ctor: partial is a part of header
         if (decl instanceof TeleDecl.DataCtor ctor) accept(ctor.clauses);
       }
@@ -32,10 +32,9 @@ public record SigRefFinder(@NotNull MutableList<TyckUnit> references) implements
     }
   }
 
-  public void telescopic(Decl.Telescopic<?> proof) {
-    proof.telescope().mapNotNull(Expr.Param::type).forEach(this);
-    var result = proof.result();
-    if (result != null) accept(result);
+  public void telescopic(@NotNull TeleDecl<?> proof) {
+    proof.telescope.mapNotNull(Expr.Param::type).forEach(this);
+    if (proof.result != null) accept(proof.result);
   }
 
   @Override public void pre(@NotNull Expr expr) {

--- a/base/src/main/java/org/aya/tyck/order/SigRefFinder.java
+++ b/base/src/main/java/org/aya/tyck/order/SigRefFinder.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck.order;
 
@@ -22,21 +22,20 @@ public record SigRefFinder(@NotNull MutableList<TyckUnit> references) implements
   public void accept(@NotNull TyckUnit sn) {
     switch (sn) {
       case Decl decl -> {
-        if (decl instanceof Decl.Telescopic<?> proof)
-          proof.telescope().mapNotNull(Expr.Param::type).forEach(this);
-        if (decl instanceof Decl.Resulted proof) {
-          var result = proof.result();
-          if (result != null) accept(result);
-        }
+        if (decl instanceof Decl.Telescopic<?> proof) telescopic(proof);
         // for ctor: partial is a part of header
-        if (decl instanceof TeleDecl.DataDecl.DataCtor ctor) {
-          accept(ctor.clauses);
-        }
+        if (decl instanceof TeleDecl.DataCtor ctor) accept(ctor.clauses);
       }
       case Command.Module module -> module.contents().forEach(this::accept);
       case Command cmd -> {}
       case Generalize variables -> accept(variables.type);
     }
+  }
+
+  public void telescopic(Decl.Telescopic<?> proof) {
+    proof.telescope().mapNotNull(Expr.Param::type).forEach(this);
+    var result = proof.result();
+    if (result != null) accept(result);
   }
 
   @Override public void pre(@NotNull Expr expr) {

--- a/base/src/main/java/org/aya/tyck/tycker/StatedTycker.java
+++ b/base/src/main/java/org/aya/tyck/tycker/StatedTycker.java
@@ -2,7 +2,6 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck.tycker;
 
-import org.aya.concrete.stmt.Decl;
 import org.aya.concrete.stmt.TeleDecl;
 import org.aya.core.UntypedParam;
 import org.aya.core.def.*;
@@ -46,7 +45,7 @@ public abstract sealed class StatedTycker extends TracedTycker permits MockTycke
     return term.normalize(state, NormalizeMode.WHNF);
   }
 
-  protected final <D extends Def, S extends Decl & Decl.Telescopic<? extends Term>> @NotNull Result
+  protected final <D extends Def, S extends TeleDecl<? extends Term>> @NotNull Result
   defCall(DefVar<D, S> defVar, Callable.Factory<D, S> function) {
     var tele = Def.defTele(defVar);
     var teleRenamed = tele.map(LamTerm::paramRenamed);

--- a/base/src/main/java/org/aya/tyck/unify/TermComparator.java
+++ b/base/src/main/java/org/aya/tyck/unify/TermComparator.java
@@ -4,11 +4,11 @@ package org.aya.tyck.unify;
 
 import kala.collection.SeqLike;
 import kala.collection.SeqView;
+import kala.collection.immutable.ImmutableMap;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableHashMap;
 import kala.collection.mutable.MutableMap;
 import kala.tuple.Tuple;
-import org.aya.concrete.stmt.Decl;
 import org.aya.concrete.stmt.TeleDecl;
 import org.aya.core.def.CtorDef;
 import org.aya.core.def.Def;
@@ -237,7 +237,7 @@ public sealed abstract class TermComparator extends MockTycker permits Unifier {
 
   private @Nullable Term visitCall(
     @NotNull Callable lhs, @NotNull Callable rhs, Sub lr, Sub rl,
-    @NotNull DefVar<? extends Def, ? extends Decl.Telescopic<?>> lhsRef, int ulift
+    @NotNull DefVar<? extends Def, ? extends TeleDecl<?>> lhsRef, int ulift
   ) {
     var retType = synthesizer().press(lhs);
     if (synthesizer().tryPress(retType) instanceof SortTerm sort && sort.isProp()) return retType;
@@ -263,8 +263,8 @@ public sealed abstract class TermComparator extends MockTycker permits Unifier {
       default -> compareUntyped(lhs, rhs, lr, rl) != null;
       case StructCall type1 -> {
         var fieldSigs = type1.ref().core.fields;
-        var paramSubst = Def.defTele(type1.ref()).view().zip(type1.args().view()).map(x ->
-          Tuple.of(x.component1().ref(), x.component2().term())).<AnyVar, Term>toImmutableMap();
+        var paramSubst = ImmutableMap.from(Def.defTele(type1.ref()).zipView(type1.args()).map(x ->
+          Tuple.of(x.component1().ref(), x.component2().term())));
         var fieldSubst = new Subst(MutableHashMap.create());
         for (var fieldSig : fieldSigs) {
           var dummyVars = fieldSig.selfTele.map(par -> par.ref().rename());

--- a/cli/src/main/java/org/aya/cli/parse/AyaGKProducer.java
+++ b/cli/src/main/java/org/aya/cli/parse/AyaGKProducer.java
@@ -449,9 +449,9 @@ public record AyaGKProducer(
       partial(partial, partial != null ? sourcePosOf(partial) : namePos),
       patterns,
       node.peekChild(KW_COERCE) != null,
+      ty == null ? null : type(ty),
       bind == null ? BindBlock.EMPTY : bindBlock(bind)
     );
-    if (ty != null) ctor.result = type(ty);
     return ctor;
   }
 

--- a/cli/src/main/java/org/aya/cli/parse/ModifierParser.java
+++ b/cli/src/main/java/org/aya/cli/parse/ModifierParser.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.cli.parse;
 
@@ -7,7 +7,7 @@ import kala.collection.SeqLike;
 import org.aya.cli.parse.error.ContradictModifierError;
 import org.aya.cli.parse.error.DuplicatedModifierWarn;
 import org.aya.cli.parse.error.NotSuitableModifierWarn;
-import org.aya.concrete.stmt.Decl;
+import org.aya.concrete.stmt.DeclInfo;
 import org.aya.concrete.stmt.Stmt;
 import org.aya.generic.util.InternalException;
 import org.aya.util.error.SourcePos;
@@ -42,7 +42,7 @@ public class ModifierParser {
 
   public record ModifierSet(
     @NotNull WithPos<Stmt.Accessibility> accessibility,
-    @NotNull WithPos<Decl.Personality> personality,
+    @NotNull WithPos<DeclInfo.Personality> personality,
     @NotNull WithPos<Boolean> isReExport) {
   }
 
@@ -109,18 +109,18 @@ public class ModifierParser {
 
     // personality
     var persGroup = map.get(ModifierGroup.Personality);
-    WithPos<Decl.Personality> pers;
+    WithPos<DeclInfo.Personality> pers;
 
     if (persGroup != null && !persGroup.isEmpty()) {
       var entry = persGroup.entrySet().iterator().next();
-      Decl.Personality key = switch (entry.getKey()) {
-        case Example -> Decl.Personality.EXAMPLE;
-        case Counterexample -> Decl.Personality.COUNTEREXAMPLE;
+      DeclInfo.Personality key = switch (entry.getKey()) {
+        case Example -> DeclInfo.Personality.EXAMPLE;
+        case Counterexample -> DeclInfo.Personality.COUNTEREXAMPLE;
         default -> unreachable();
       };
 
       pers = new WithPos<>(entry.getValue(), key);
-    } else pers = new WithPos<>(SourcePos.NONE, Decl.Personality.NORMAL);
+    } else pers = new WithPos<>(SourcePos.NONE, DeclInfo.Personality.NORMAL);
 
     // others
     var noneGroup = map.get(ModifierGroup.None);

--- a/ide/src/main/java/org/aya/ide/action/ComputeSignature.java
+++ b/ide/src/main/java/org/aya/ide/action/ComputeSignature.java
@@ -1,17 +1,17 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.ide.action;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.cli.library.source.LibrarySource;
-import org.aya.concrete.stmt.Decl;
+import org.aya.concrete.stmt.TeleDecl;
 import org.aya.core.def.Def;
 import org.aya.core.term.PiTerm;
 import org.aya.core.term.Term;
-import org.aya.prettier.BasePrettier;
-import org.aya.prettier.CorePrettier;
 import org.aya.ide.Resolver;
 import org.aya.ide.util.XY;
+import org.aya.prettier.BasePrettier;
+import org.aya.prettier.CorePrettier;
 import org.aya.pretty.doc.Doc;
 import org.aya.ref.AnyVar;
 import org.aya.ref.DefVar;
@@ -35,9 +35,9 @@ public interface ComputeSignature {
       case LocalVar localVar -> BasePrettier.varDoc(localVar); // TODO: compute type of local vars
       case DefVar<?, ?> ref -> {
         // #299: hovering a mouse on a definition whose header is failed to tyck
-        if (!(ref.concrete instanceof Decl.Telescopic<?> concrete)
-          || (concrete.signature() == null && ref.core == null)) yield Doc.empty();
-        var defVar = (DefVar<? extends Def, ? extends Decl.Telescopic<?>>) ref;
+        if (!(ref.concrete instanceof TeleDecl<?> concrete)
+          || (concrete.signature == null && ref.core == null)) yield Doc.empty();
+        var defVar = (DefVar<? extends Def, ? extends TeleDecl<?>>) ref;
         yield computeSignature(options, Def.defTele(defVar), Def.defResult(defVar), withResult);
       }
       default -> Doc.empty();

--- a/tools/src/main/java/org/aya/util/terck/Relation.java
+++ b/tools/src/main/java/org/aya/util/terck/Relation.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.util.terck;
 
@@ -18,8 +18,10 @@ import org.jetbrains.annotations.NotNull;
 @Debug.Renderer(text = "toDoc().debugRender()")
 public sealed interface Relation extends Docile, Selector.Candidate<Relation> {
   /** increase or unrelated of callee argument wrt. caller parameter. */
-  record Unknown() implements Relation {
+  final class Unknown implements Relation {
     public static final @NotNull Unknown INSTANCE = new Unknown();
+
+    private Unknown() {}
   }
 
   /**


### PR DESCRIPTION
This PR:

+ Removes `Decl.Resulted` and `Decl.Telescopic`
+ Make code use `TeleDecl`
+ Introduce `DeclInfo` for good code reuse.