### PR TITLE
Use snapshot jacoco

### DIFF
--- a/gradle/deps.properties
+++ b/gradle/deps.properties
@@ -16,7 +16,7 @@ version.hamcrest=2.2
 # https://junit.org/junit5/
 version.junit=5.9.2
 # https://github.com/jacoco/jacoco
-version.jacoco=0.8.8
+version.jacoco=0.8.9-SNAPSHOT
 # https://picocli.info/
 version.picocli=4.7.0
 version.jimgui=v0.21.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,8 @@ rootProject.name = "aya-prover"
 dependencyResolutionManagement {
   @Suppress("UnstableApiUsage") repositories {
     mavenCentral()
+    // For jacoco snapshot. Delete once jacoco 0.8.9 is released.
+    maven("https://oss.sonatype.org/content/repositories/snapshots")
   }
 }
 


### PR DESCRIPTION
We need to switch to the release version immediately once 0.8.9 is released and delete the extra maven repository. I conjecture that this can improve the test coverage drastically.