### PR TITLE
Predicativity assumption for terck

### DIFF
--- a/base/src/main/java/org/aya/terck/CallResolver.java
+++ b/base/src/main/java/org/aya/terck/CallResolver.java
@@ -49,7 +49,7 @@ public record CallResolver(
 
   private void resolveCall(@NotNull Callable callable) {
     if (!(callable.ref() instanceof DefVar<?, ?> defVar)) return;
-    var callee = ((Def) defVar.core);
+    var callee = (Def) defVar.core;
     if (!targets.contains(callee)) return;
     var matrix = new CallMatrix<>(callable, caller, callee, caller.telescope, callee.telescope());
     fillMatrix(callable, callee, matrix);
@@ -65,7 +65,7 @@ public record CallResolver(
       // No matching, the caller is a simple function (not defined by pattern matching).
       // We should compare caller telescope with callee arguments.
       : caller.telescope.view().map(p -> Tuple.of(p.toPat(), p));
-    var codomThings = callable.args().zip(callee.telescope());
+    var codomThings = callable.args().zipView(callee.telescope());
     for (var domThing : domThings) {
       for (var codomThing : codomThings) {
         var relation = compare(codomThing.component1().term(), domThing.component1().term());

--- a/base/src/test/resources/success/common/src/Data/FiniteMultiSet/Core.aya
+++ b/base/src/test/resources/success/common/src/Data/FiniteMultiSet/Core.aya
@@ -10,10 +10,11 @@ open data FMSet (A : Type)
 
 variable A : Type
 
-// def infixr ++ : BinOp (FMSet A)
-// | nil, ys => ys
-// | x :< xs, ys => x :< xs ++ ys
-// | comm x y xs i, ys => comm x y (xs ++ ys) i
-// | trunc xs zs p q i j, ys =>
-//   trunc (xs ++ ys) (zs ++ ys) (pmap (++ ys) p) (pmap (++ ys) q) i j
-// tighter :< =
+def infixr ++ : BinOp (FMSet A)
+| nil, ys => ys
+| x :< xs, ys => x :< xs ++ ys
+| comm x y xs i, ys => comm x y (xs ++ ys) i
+| trunc xs zs p q i j, ys =>
+// trunc (xs ++ ys) (zs ++ ys) (pmap (++ ys) p) (pmap (++ ys) q) i j
+  trunc (xs ++ ys) (zs ++ ys) (λ k => p k ++ ys) (λ k => q k ++ ys) i j
+tighter :< =

--- a/base/src/test/resources/success/common/src/Logic/SetTrunc.aya
+++ b/base/src/test/resources/success/common/src/Logic/SetTrunc.aya
@@ -7,7 +7,8 @@ open data SetTrunc (A : Type)
 
 variable A B : Type
 
-// def rec (A -> B) (isSet B) (SetTrunc A) : B
-// | f, x, inj a => f a
-// | f, x, trunc a b p q i j =>
-//    x (rec f x a) (rec f x b) (λ k => rec f x (p k)) (λ k => rec f x (q k)) i j
+// TODO: improve the termination checker so that it unfolds unrecursive calls generate unfolded lambdas properly
+def rec (A -> B) (isSet B) (SetTrunc A) : B
+| f, x, inj a => f a
+| f, x, trunc a b p q i j =>
+    x (rec f x a) (rec f x b) (λ k => rec f x (p k)) (λ k => rec f x (q k)) i j


### PR DESCRIPTION
This partially addresses #907. There are two issues left:

+ Unfold some simple decls before tercking. This cannot be done because `TermConsumer` does not allow blocking a sub-tree traversal. /cc @wsx-ucb 
+ Predicativity assumption for `Type`