### PR TITLE
Partially address some problems in pretty printer

### DIFF
--- a/base/src/test/java/org/aya/literate/AyaMdParserTest.java
+++ b/base/src/test/java/org/aya/literate/AyaMdParserTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.literate;
 
@@ -116,7 +116,7 @@ public class AyaMdParserTest {
     loader.tyckModule(null, info, null);
     literate.tyckAdditional(info);
 
-    var doc = literate.docitfy(stmts, AyaPrettierOptions.pretty()).toDoc();
+    var doc = literate.toDoc(stmts, AyaPrettierOptions.pretty()).toDoc();
     var expectedMd = doc.renderToAyaMd();
     Files.writeString(oneCase.htmlFile(), doc.renderToHtml());
     Files.writeString(oneCase.outMdFile(), expectedMd);

--- a/base/src/test/java/org/aya/literate/HighlighterTest.java
+++ b/base/src/test/java/org/aya/literate/HighlighterTest.java
@@ -25,26 +25,22 @@ public class HighlighterTest {
       keyword(0, 3, "open"),
       whatever(),
       def(10, 12, "Nat", "nat", HighlightInfo.DefKind.Data),
-      whatever(), // eol
       whatever(), // |
       def(16, 16, "O", "zero", HighlightInfo.DefKind.Con),
       whatever(), // |
       def(20, 20, "S", "suc", HighlightInfo.DefKind.Con),
       ref(22, 24, "Nat", "nat", HighlightInfo.DefKind.Data),
-      whatever(), // eol
       whatever(),   // def
       def(31, 33, "add", HighlightInfo.DefKind.Fn),
       ref(35, 37, "Nat", "nat", HighlightInfo.DefKind.Data),
       ref(39, 41, "Nat", "nat", HighlightInfo.DefKind.Data),
       whatever(), // :
       ref(45, 47, "Nat", "nat", HighlightInfo.DefKind.Data),
-      whatever(), // eol
       whatever(), // |
       localDef(51, 51, "n", "n'"),
       litInt(54, 54, 0),
       whatever(), // =>
       localRef(59, 59, "n", "n'"),
-      whatever(), // eol
       whatever(), // |
       ref(63, 63, "S", "suc", HighlightInfo.DefKind.Con),
       // Note: n' is still available here, so use another name
@@ -67,10 +63,8 @@ public class HighlighterTest {
 
     highlightAndTest(code,
       keyword(3, 6, "open"),
-      whatever(), // eol
       keyword(8, 11, "data"),
       def(14, 16, "Nat", "nat", HighlightInfo.DefKind.Data),
-      whatever(), // eol
       whatever(),
       def(20, 20, "O", HighlightInfo.DefKind.Con),
       whatever(),
@@ -103,10 +97,8 @@ public class HighlighterTest {
     highlightAndTest(code,
       keyword(0, 5, "module"),
       def(7, 7, "X", "x", HighlightInfo.DefKind.Module),
-      whatever(), // eol
       keyword(12, 15, "open"),
       ref(17, 17, "X", "x", HighlightInfo.DefKind.Module),
-      whatever(), // eol
       keyword(19, 22, "open"),
       keyword(24, 27, "data"),
       def(29, 29, "Y", "y", HighlightInfo.DefKind.Data));
@@ -129,16 +121,13 @@ public class HighlighterTest {
       localDef(20, 20, "B", "LocalB"),
       whatever(), // :
       keyword(24, 27, "Type"),
-      whatever(), // eol
       whatever(), // |
       def(32, 35, "Left", HighlightInfo.DefKind.Con),
       localRef(37, 37, "A", "LocalA"),
-      whatever(), // eol
       whatever(), // |
       def(41, 45, "Right", HighlightInfo.DefKind.Con),
       localRef(47, 47, "B", "LocalB"),
 
-      whatever(), // eol
       keyword(50, 52, "def"),
       def(54, 59, "constA", HighlightInfo.DefKind.Fn),
       localDef(62, 62, "A", "LocalA'"),
@@ -166,7 +155,6 @@ public class HighlighterTest {
       def(9, 9, "A", "GA", HighlightInfo.DefKind.Generalized),
       whatever(), // :
       keyword(13, 16, "Type"),
-      whatever(), // eol
       keyword(19, 21, "def"),
       def(23, 24, "id", HighlightInfo.DefKind.Fn),
       localDef(27, 27, "a", "a"),

--- a/base/src/test/java/org/aya/literate/HighlighterTester.java
+++ b/base/src/test/java/org/aya/literate/HighlighterTester.java
@@ -213,9 +213,12 @@ public class HighlighterTester {
 
     Stmt.resolve(stmts, resolveInfo, EmptyModuleLoader.INSTANCE);
 
-    var result = SyntaxHighlight.highlight(Option.some(sourceFile), stmts);
+    var result = SyntaxHighlight.highlight(Option.some(sourceFile), stmts)
+      .filterNot(it -> it.type() instanceof HighlightInfo.SymLit(var kind)
+        && ignored.contains(kind));
     new HighlighterTester(code, result, expected).runTest();
   }
+  static Seq<HighlightInfo.LitKind> ignored = Seq.of(HighlightInfo.LitKind.Eol, HighlightInfo.LitKind.Whitespace);
 
   /// region Helper
 

--- a/cli-impl/src/main/java/org/aya/cli/literate/FaithfulPrettier.java
+++ b/cli-impl/src/main/java/org/aya/cli/literate/FaithfulPrettier.java
@@ -3,6 +3,7 @@
 package org.aya.cli.literate;
 
 import com.intellij.openapi.util.text.StringUtil;
+import kala.collection.Seq;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
 import kala.text.StringSlice;
@@ -106,12 +107,12 @@ public record FaithfulPrettier(@NotNull PrettierOptions options) {
 
   private @NotNull Doc highlightLit(@NotNull String raw, @NotNull HighlightInfo.LitKind litKind) {
     return switch (litKind) {
-      case Int -> Doc.plain(raw);
+      case Int, Whitespace -> Doc.plain(raw);
       case String -> Doc.plain(StringUtil.escapeStringCharacters(raw));
       case Keyword -> Doc.styled(BasePrettier.KEYWORD, Doc.symbol(raw));
       case Comment -> Doc.styled(BasePrettier.COMMENT, raw);
       case SpecialSymbol -> Doc.symbol(raw);
-      case Eol -> Doc.line();
+      case Eol -> Doc.cat(Seq.fill(raw.length(), Doc.line()));
     };
   }
 

--- a/cli-impl/src/main/java/org/aya/cli/literate/HighlightInfo.java
+++ b/cli-impl/src/main/java/org/aya/cli/literate/HighlightInfo.java
@@ -31,7 +31,7 @@ public record HighlightInfo(
   }
 
   public enum LitKind {
-    Int, String, Keyword, Comment, SpecialSymbol, Eol;
+    Int, String, Keyword, Comment, SpecialSymbol, Eol, Whitespace;
 
     public @NotNull HighlightInfo toLit(@NotNull SourcePos sourcePos) {
       return new HighlightInfo(sourcePos, new SymLit(this));

--- a/cli-impl/src/main/java/org/aya/cli/literate/SyntaxHighlight.java
+++ b/cli-impl/src/main/java/org/aya/cli/literate/SyntaxHighlight.java
@@ -62,9 +62,9 @@ public class SyntaxHighlight implements StmtFolder<MutableList<HighlightInfo>> {
           else if (AyaParserDefinitionBase.UNICODES.contains(tokenType)
             || AyaParserDefinitionBase.MARKERS.contains(tokenType))
             r = new SymLit(LitKind.SpecialSymbol);
-          if (tokenType == TokenType.WHITE_SPACE && token.range().getLength() <= 2) {
+          if (tokenType == TokenType.WHITE_SPACE) {
             var text = token.range().substring(file.sourceCode());
-            if (text.contains("\n")) r = new SymLit(LitKind.Eol);
+            r = new SymLit(text.contains("\n") ? LitKind.Eol : LitKind.Whitespace);
           }
           if (r == null) return null;
           return r.toInfo(AyaProducer.sourcePosOf(token, file));

--- a/cli-impl/src/main/java/org/aya/cli/single/SingleAyaFile.java
+++ b/cli-impl/src/main/java/org/aya/cli/single/SingleAyaFile.java
@@ -68,7 +68,7 @@ public sealed interface SingleAyaFile extends GenericAyaFile {
     var withStyleDef = !flags.prettyNoCodeStyle();
     if (currentStage == CliEnums.PrettyStage.literate) {
       var text = renderOptions.render(out,
-        docitfy((ImmutableSeq<Stmt>) doc, flags.prettierOptions()),
+        toDoc((ImmutableSeq<Stmt>) doc, flags.prettierOptions()),
         true,
         withStyleDef,
         !flags.ascii());
@@ -78,7 +78,7 @@ public sealed interface SingleAyaFile extends GenericAyaFile {
         (d, hdr) -> renderOptions.render(out, d, hdr, withStyleDef, !flags.ascii()));
     }
   }
-  @VisibleForTesting default @NotNull Doc docitfy(
+  @VisibleForTesting default @NotNull Doc toDoc(
     @NotNull ImmutableSeq<Stmt> program,
     @NotNull PrettierOptions options) throws IOException {
     var highlights = SyntaxHighlight.highlight(Option.some(codeFile()), program);

--- a/cli-impl/src/test/java/org/aya/cli/LexerPlayground.java
+++ b/cli-impl/src/test/java/org/aya/cli/LexerPlayground.java
@@ -1,0 +1,14 @@
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.cli;
+
+import org.aya.cli.repl.gk.GKReplLexer;
+import org.aya.parser._AyaPsiLexer;
+
+public class LexerPlayground {
+  public static void main(String[] args) {
+    var lexer = new GKReplLexer(new _AyaPsiLexer(false));
+    lexer.reset("a  \n\n  b", 0);
+    lexer.allTheWayDown().forEach(System.out::println);
+  }
+}

--- a/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
+++ b/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
@@ -23,7 +23,7 @@ public class RenderOptionsTest {
     var opt = new RenderOptions();
     opt.checkDeserialization();
     assertEquals("`hello'", opt.render(RenderOptions.OutputTarget.Terminal, doc, false, false, true));
-    assertEquals("\\noindent\\fbox{hello}", opt.render(RenderOptions.OutputTarget.LaTeX, doc, false, false, true));
+    assertEquals("\\noindent{}\\fbox{hello}", opt.render(RenderOptions.OutputTarget.LaTeX, doc, false, false, true));
     assertEquals("<code class=\"Aya\">hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, false, false, true));
     assertEquals("`hello`", opt.render(RenderOptions.OutputTarget.Plain, doc, false, false, true));
   }

--- a/parser/src/main/grammar/AyaPsiLexer.flex
+++ b/parser/src/main/grammar/AyaPsiLexer.flex
@@ -53,8 +53,6 @@ import static org.aya.parser.AyaPsiElementTypes.*;
 
 %unicode
 
-EOL = \R
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Identifier, adapted from AyaLexer.g4
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -101,7 +99,7 @@ RPATH = \|\] | \u27E7
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Comments, adapted from AyaLexer.g4
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-LINE_COMMENT        = "//" (.* | {EOL})
+LINE_COMMENT        = "//" (.* | \R)
 BLOCK_COMMENT_START = "/*"
 BLOCK_COMMENT_END   = "*/"
 
@@ -194,9 +192,9 @@ BLOCK_COMMENT_END   = "*/"
   {STRING}              { return STRING; }
 
   // whitespace tokens are treated separated for the convenience of LaTeX translation
-  {EOL}                 { return WHITE_SPACE; }
-  [ ]+                  { return WHITE_SPACE; }
-  [\t]+                 { return WHITE_SPACE; }
+  \R+  { return WHITE_SPACE; }
+  [ ]+ { return WHITE_SPACE; }
+  \t+  { return WHITE_SPACE; }
 }
 
 

--- a/parser/src/main/grammar/AyaPsiLexer.flex
+++ b/parser/src/main/grammar/AyaPsiLexer.flex
@@ -193,8 +193,10 @@ BLOCK_COMMENT_END   = "*/"
   {NUMBER}              { return NUMBER; }
   {STRING}              { return STRING; }
 
+  // whitespace tokens are treated separated for the convenience of LaTeX translation
   {EOL}                 { return WHITE_SPACE; }
-  [\s]+                 { return WHITE_SPACE; }
+  [ ]+                  { return WHITE_SPACE; }
+  [\t]+                 { return WHITE_SPACE; }
 }
 
 

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -23,7 +23,9 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
 
   @Override protected @NotNull String escapePlainText(@NotNull String content, EnumSet<Outer> outer) {
     // TODO: escape according to `outer`
-    return content.replace("\\", "").replace("_", "\\_");
+    return content.replace("\\", "")
+      .replace("_", "\\_")
+      .replace(" ", "~");
   }
 
   private static @NotNull Tuple2<String, String> id(@NotNull String name) {
@@ -79,7 +81,7 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
         return;
       }
     }
-    System.err.println("Warn: unknown symbol " + text);
+    if (!text.chars().allMatch(Character::isLetter)) System.err.println("Warn: unknown symbol " + text);
     renderPlainText(cursor, text, outer);
   }
 
@@ -92,7 +94,8 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
     cursor.lineBreakWith("\\\\\n");
   }
 
-  @Override protected void renderInlineCode(@NotNull Cursor cursor, Doc.@NotNull InlineCode code, EnumSet<Outer> outer) {
+  @Override
+  protected void renderInlineCode(@NotNull Cursor cursor, Doc.@NotNull InlineCode code, EnumSet<Outer> outer) {
     cursor.invisibleContent("\\fbox{");
     renderDoc(cursor, code.code(), outer);
     cursor.invisibleContent("}");

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -18,7 +18,7 @@ import java.util.EnumSet;
  */
 public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
   @Override protected void renderHeader(@NotNull Cursor cursor) {
-    cursor.invisibleContent("\\noindent");
+    cursor.invisibleContent("\\noindent{}");
   }
 
   @Override protected @NotNull String escapePlainText(@NotNull String content, EnumSet<Outer> outer) {

--- a/pretty/src/main/java/org/aya/pretty/style/AyaColorScheme.java
+++ b/pretty/src/main/java/org/aya/pretty/style/AyaColorScheme.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.style;
 
@@ -18,8 +18,7 @@ public record AyaColorScheme(@NotNull MutableMap<String, Integer> definedColors)
     Tuple.of(AyaStyleKey.Struct.key(), ColorScheme.colorOf(0.13f, 0.55f, 0.13f)),
     Tuple.of(AyaStyleKey.Con.key(), ColorScheme.colorOf(0.63f, 0.13f, 0.94f)),
     Tuple.of(AyaStyleKey.Field.key(), ColorScheme.colorOf(0, 0.55f, 0.55f)),
-    // I know this is exactly not 0x114514, but this color is better than that!
-    Tuple.of(AyaStyleKey.Comment.key(), ColorScheme.colorOf(0.11f, 0.45f, 0.14f))
+    Tuple.of(AyaStyleKey.Comment.key(), ColorScheme.colorOf(0.55f, 0.55f, 0.55f))
   ));
 
   /** The colors are from IntelliJ IDEA light theme. */
@@ -32,6 +31,6 @@ public record AyaColorScheme(@NotNull MutableMap<String, Integer> definedColors)
     Tuple.of(AyaStyleKey.Struct.key(), 0x000000),
     Tuple.of(AyaStyleKey.Con.key(), 0x067D17),
     Tuple.of(AyaStyleKey.Field.key(), 0x871094),
-    Tuple.of(AyaStyleKey.Comment.key(), 0x114514)
+    Tuple.of(AyaStyleKey.Comment.key(), 0x8C8C8C)
   ));
 }

--- a/pretty/src/test/java/org/aya/pretty/Reproduction.java
+++ b/pretty/src/test/java/org/aya/pretty/Reproduction.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty;
 
@@ -11,6 +11,6 @@ public class Reproduction {
   @Test public void mock() {
     var doc = Doc.nest(2, Doc.code(Doc.plain("hey")));
     assertEquals("  `hey'", doc.renderToTerminal());
-    assertEquals("\\noindent\\hspace*{1.0em}\\fbox{hey}", doc.renderToTeX());
+    assertEquals("\\noindent{}\\hspace*{1.0em}\\fbox{hey}", doc.renderToTeX());
   }
 }

--- a/tools-repl/src/main/java/org/aya/repl/ReplHighlighter.java
+++ b/tools-repl/src/main/java/org/aya/repl/ReplHighlighter.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.repl;
 
@@ -19,7 +19,7 @@ public abstract class ReplHighlighter<T> extends DefaultHighlighter {
   protected abstract @NotNull String renderToTerminal(@NotNull Doc doc);
 
   @Override public AttributedString highlight(LineReader reader, String buffer) {
-    lexer.reset(buffer, 0, buffer.length(), 0);
+    lexer.reset(buffer, 0);
     var tokens = lexer.allTheWayDown();
     var doc = Doc.cat(tokens.map(t -> highlight(lexer.tokenText(buffer, t), t)));
     return AttributedString.fromAnsi(renderToTerminal(doc));

--- a/tools-repl/src/main/java/org/aya/repl/ReplLexer.java
+++ b/tools-repl/src/main/java/org/aya/repl/ReplLexer.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.repl;
 
@@ -7,6 +7,10 @@ import org.jetbrains.annotations.NotNull;
 
 public interface ReplLexer<T> {
   void reset(@NotNull CharSequence buf, int start, int end, int initialState);
+
+  default void reset(@NotNull CharSequence buf, int initialState) {
+    reset(buf, 0, buf.length(), initialState);
+  }
 
   @NotNull ImmutableSeq<T> allTheWayDown();
 

--- a/tools-repl/src/main/java/org/aya/repl/ReplParser.java
+++ b/tools-repl/src/main/java/org/aya/repl/ReplParser.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.repl;
 
@@ -57,7 +57,7 @@ public record ReplParser<T>(
       if (shellAlike) return shellLike.parse(line, cursor, context);
     }
     // Drop whitespaces
-    lexer.reset(line, 0, line.length(), 0);
+    lexer.reset(line, 0);
     var tokens = lexer.allTheWayDown()
       .view()
       .filterNot(lexer::isWhitespace)


### PR DESCRIPTION
+ LaTeX backend now generates `~` instead of ` `
+ `\indent{}` instead of `\indent`
+ Improve comment style (hopefully)