### PR TITLE
Keyword: `Pi` -> `Fn`, `λ` -> `fn`

### DIFF
--- a/base/src/main/java/org/aya/prettier/ConcretePrettier.java
+++ b/base/src/main/java/org/aya/prettier/ConcretePrettier.java
@@ -73,7 +73,7 @@ public class ConcretePrettier extends BasePrettier<Expr> {
         if (!data[0] && !data[1]) {
           doc = Doc.sep(justType(expr.param(), Outer.Domain), Doc.symbol("->"), last);
         } else {
-          doc = Doc.sep(Doc.styled(KEYWORD, Doc.symbol("Pi")), expr.param().toDoc(options), Doc.symbol("->"), last);
+          doc = Doc.sep(Doc.styled(KEYWORD, Doc.symbol("Fn")), expr.param().toDoc(options), Doc.symbol("->"), last);
         }
         // When outsider is neither a codomain nor non-expression, we need to add parentheses.
         yield checkParen(outer, doc, Outer.Domain);

--- a/base/src/main/java/org/aya/prettier/CorePrettier.java
+++ b/base/src/main/java/org/aya/prettier/CorePrettier.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.prettier;
 
@@ -177,7 +177,7 @@ public class CorePrettier extends BasePrettier<Term> {
         var params = MutableList.of(params0);
         var body = PiTerm.unpi(body0, UnaryOperator.identity(), params);
         var doc = Doc.sep(
-          Doc.styled(KEYWORD, Doc.symbol("Pi")),
+          Doc.styled(KEYWORD, Doc.symbol("Fn")),
           visitTele(params, body, Term::findUsages),
           Doc.symbol("->"),
           term(Outer.Codomain, body)

--- a/base/src/test/java/org/aya/concrete/ParseTest.java
+++ b/base/src/test/java/org/aya/concrete/ParseTest.java
@@ -82,11 +82,11 @@ public class ParseTest {
   @Test public void successDecl() {
     parseFn("def a => 1");
     parseFn("def a (b : X) => b");
-    parseFn("def a (f : Pi a b c d -> a) => b");
+    parseFn("def a (f : Fn a b c d -> a) => b");
     parseFn("def a (t : Sig a b ** s) => b");
     parseFn("""
       def uncurry (A : Type) (B : Type) (C : Type)
-                   (f : Pi A B -> C)
+                   (f : Fn A B -> C)
                    (p : Sig A ** B) : C
         => f (p.1) (p.2)""");
     parseData("data Unit");
@@ -129,17 +129,17 @@ public class ParseTest {
       && app.seq().get(1).term() instanceof Expr.Proj);
     assertTrue(parseExpr("(f a).1") instanceof Expr.Proj proj
       && proj.tup() instanceof Expr.BinOpSeq);
-    assertTrue(parseExpr("λ a => a") instanceof Expr.Lambda);
+    assertTrue(parseExpr("fn a => a") instanceof Expr.Lambda);
     assertTrue(parseExpr("\\ a => a") instanceof Expr.Lambda);
     assertTrue(parseExpr("\\ a b => a") instanceof Expr.Lambda);
-    assertTrue(parseExpr("Π a -> a") instanceof Expr.Pi dt);
-    assertTrue(parseExpr("Pi a -> a") instanceof Expr.Pi dt);
-    assertTrue(parseExpr("Pi a b -> a") instanceof Expr.Pi dt
+    assertTrue(parseExpr("∀ a -> a") instanceof Expr.Pi dt);
+    assertTrue(parseExpr("Fn a -> a") instanceof Expr.Pi dt);
+    assertTrue(parseExpr("Fn a b -> a") instanceof Expr.Pi dt
       && dt.last() instanceof Expr.Pi);
     assertTrue(parseExpr("Σ a ** b") instanceof Expr.Sigma dt);
     assertTrue(parseExpr("Sig a ** b") instanceof Expr.Sigma dt);
     assertTrue(parseExpr("Sig a b ** c") instanceof Expr.Sigma dt);
-    assertTrue(parseExpr("Pi (x : Sig a ** b) -> c") instanceof Expr.Pi dt && dt.param().type() instanceof Expr.Sigma);
+    assertTrue(parseExpr("Fn (x : Sig a ** b) -> c") instanceof Expr.Pi dt && dt.param().type() instanceof Expr.Sigma);
     parseTo("(f a) . 1", new Expr.Proj(
       SourcePos.NONE,
       new Expr.BinOpSeq(

--- a/base/src/test/java/org/aya/core/PrettierTest.java
+++ b/base/src/test/java/org/aya/core/PrettierTest.java
@@ -24,11 +24,11 @@ public class PrettierTest {
     var doc2 = declDoc("def id {A : Type} (a : A) => a");
     var doc3 = declDoc("""
       def curry3 (A  B  C  D : Type)
-                  (f : Pi (x : Sig A B ** C) -> D)
+                  (f : Fn (x : Sig A B ** C) -> D)
                   (a : A) (b : B) (c : C) : D
         => f (a, b, c)
       def uncurry3 (A : Type) (B : Type) (C : Type) (D : Type)
-                    (f : Pi A B C -> D)
+                    (f : Fn A B C -> D)
                     (p : Sig A B ** C) : D
         => f (p.1) (p.2) (p.3)""");
     assertFalse(Doc.cat(doc1, doc2, doc3).renderToHtml().isEmpty());
@@ -86,8 +86,8 @@ public class PrettierTest {
       def infix = (A B : Type) => A
       def infix == (A B : Type) => A looser =
       def infix <= (A B : Type) => A tighter =
-      def test1 (X : Type) => Pi (A : Type) -> A ulift = X
-      def test2 (X : Type) => (Pi (A : Type) -> A) ulift = X
+      def test1 (X : Type) => Fn (A : Type) -> A ulift = X
+      def test2 (X : Type) => (Fn (A : Type) -> A) ulift = X
 
       def infix ?= : Type -> Type -> Type => \\ (A B : Type) => A
       def use (A B : Type) => A ?= B
@@ -97,8 +97,8 @@ public class PrettierTest {
     var use = ((FnDef) decls.get(6)).body.getLeftValue();
     assertNotNull(decls.get(1).ref().concrete.toDoc(AyaPrettierOptions.informative()));
     assertNotNull(decls.get(2).ref().concrete.toDoc(AyaPrettierOptions.informative()));
-    assertEquals("Pi (A : Type 0) -> A = X", test1.toDoc(AyaPrettierOptions.informative()).debugRender());
-    assertEquals("(Pi (A : Type 0) -> A) = X", test2.toDoc(AyaPrettierOptions.informative()).debugRender());
+    assertEquals("Fn (A : Type 0) -> A = X", test1.toDoc(AyaPrettierOptions.informative()).debugRender());
+    assertEquals("(Fn (A : Type 0) -> A) = X", test2.toDoc(AyaPrettierOptions.informative()).debugRender());
     assertEquals("A ?= B", use.toDoc(AyaPrettierOptions.informative()).debugRender());
   }
 

--- a/base/src/test/java/org/aya/core/SuedeTest.java
+++ b/base/src/test/java/org/aya/core/SuedeTest.java
@@ -21,7 +21,7 @@ public class SuedeTest {
   }
 
   @Test public void piSig() {
-    suedeAll("def test (y : Type 0) : Type 3 => Pi (x : Type 0 -> Type 2) -> Sig (x y) ** x y");
+    suedeAll("def test (y : Type 0) : Type 3 => Fn (x : Type 0 -> Type 2) -> Sig (x y) ** x y");
   }
 
   @Test public void adjunction() {
@@ -31,7 +31,7 @@ public class SuedeTest {
                  (a : A) (b : B) : C
         => f (a, b)
       def uncurry (A : Type) (B : Type) (C : Type)
-                   (f : Pi A B -> C)
+                   (f : Fn A B -> C)
                    (p : Sig A ** B) : C
         => f (p.1) (p.2)
       def fst {A B : Type} (t : Sig A ** B) : A

--- a/base/src/test/java/org/aya/cubical/PathTest.java
+++ b/base/src/test/java/org/aya/cubical/PathTest.java
@@ -67,7 +67,7 @@ public class PathTest {
       def funExt
         {A B : Type}
         (f g : A -> B)
-        (p : Pi (a : A) -> f a = g a)
+        (p : Fn (a : A) -> f a = g a)
         : f = g
         => \\i a => p a i
       """);

--- a/base/src/test/java/org/aya/experiments/NormalizeHugeChurch.java
+++ b/base/src/test/java/org/aya/experiments/NormalizeHugeChurch.java
@@ -1,10 +1,10 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.experiments;
 
 import org.aya.core.def.FnDef;
-import org.aya.prettier.AyaPrettierOptions;
 import org.aya.generic.util.NormalizeMode;
+import org.aya.prettier.AyaPrettierOptions;
 import org.aya.tyck.TyckDeclTest;
 import org.aya.tyck.tycker.TyckState;
 import org.jetbrains.annotations.NotNull;
@@ -19,7 +19,7 @@ public class NormalizeHugeChurch {
   @Test @Timeout(value = 5000) public void ppBench() {
     var startup = System.currentTimeMillis();
     var res = TyckDeclTest.successTyckDecls("""
-      def Num => Pi (x : Type 0) -> (x -> x) -> (x -> x)
+      def Num => Fn (x : Type 0) -> (x -> x) -> (x -> x)
       def zero : Num => \\ A f x => x
       def suc (a : Num) : Num => \\ A f x => a A f (f x)
       def add (a b : Num) : Num => \\A f x => a A f (b A f x)

--- a/base/src/test/resources/failure/cubical/transport-non-constant.aya.txt
+++ b/base/src/test/resources/failure/cubical/transport-non-constant.aya.txt
@@ -8,8 +8,8 @@ In file $FILE:17:6 ->
 Error: Under the cofibration:
          i
        The type in the body still depends on the interval parameter:
-         λ j ⇒ A (i ∧ j)
-         (Normalized under cofibration: λ j ⇒ A j)
+         \ j ⇒ A (i ∧ j)
+         (Normalized under cofibration: \ j ⇒ A j)
        which is not allowed in coercion
 
 In file $FILE:21:6 ->
@@ -22,7 +22,7 @@ In file $FILE:21:6 ->
 Error: Under the cofibration:
          i
        The type in the body still depends on the interval parameter:
-         λ j ⇒ A j
+         \ j ⇒ A j
        which is not allowed in coercion
 
 In file $FILE:25:5 ->
@@ -63,7 +63,7 @@ In file $FILE:29:6 ->
 Error: Under the cofibration:
          <a>
        The type in the body still depends on the interval parameter:
-         λ j ⇒ A (i ∧ j)
+         \ j ⇒ A (i ∧ j)
        which is not allowed in coercion
 
 5 error(s), 0 warning(s).

--- a/base/src/test/resources/failure/holes/ulf-hole-illtype.aya
+++ b/base/src/test/resources/failure/holes/ulf-hole-illtype.aya
@@ -3,4 +3,4 @@ data Empty
 def Neg (T : Type) => T -> Empty
 def test
  (F : Type -> Type)
- (g : Pi (X : F _) -> F (Neg X)) : Nat => g zero
+ (g : ∀ (X : F _) -> F (Neg X)) : Nat => g zero

--- a/base/src/test/resources/failure/holes/ulf-hole-illtype.aya.txt
+++ b/base/src/test/resources/failure/holes/ulf-hole-illtype.aya.txt
@@ -1,9 +1,9 @@
-In file $FILE:6:29 ->
+In file $FILE:6:28 ->
 
   4 │   def test
   5 │    (F : Type -> Type)
-  6 │    (g : Pi (X : F _) -> F (Neg X)) : Nat => g zero
-    │                                ╰╯
+  6 │    (g : ∀ (X : F _) -> F (Neg X)) : Nat => g zero
+    │                               ╰╯
 
 Error: Cannot check the expression
          X
@@ -12,12 +12,12 @@ Error: Cannot check the expression
        against the type
          Type 0
 
-In file $FILE:6:16 ->
+In file $FILE:6:15 ->
 
   4 │   def test
   5 │    (F : Type -> Type)
-  6 │    (g : Pi (X : F _) -> F (Neg X)) : Nat => g zero
-    │                   ╰╯
+  6 │    (g : ∀ (X : F _) -> F (Neg X)) : Nat => g zero
+    │                  ╰╯
 
 Error: Unsolved meta _
        in `F _`

--- a/base/src/test/resources/failure/implicit/implicit2.aya
+++ b/base/src/test/resources/failure/implicit/implicit2.aya
@@ -1,5 +1,5 @@
 open data Unit : Type | unit
 
-def y : Pi {a : Unit} -> Unit => \{a} => a
-def x : Pi {a : Unit} -> Unit => y
-def z : Pi {a : Unit} -> Unit => x
+def y : ∀ {a : Unit} -> Unit => \{a} => a
+def x : ∀ {a : Unit} -> Unit => y
+def z : ∀ {a : Unit} -> Unit => x

--- a/base/src/test/resources/failure/implicit/implicit2.aya.txt
+++ b/base/src/test/resources/failure/implicit/implicit2.aya.txt
@@ -1,9 +1,9 @@
-In file $FILE:4:33 ->
+In file $FILE:4:32 ->
 
   2 │   
-  3 │   def y : Pi {a : Unit} -> Unit => \{a} => a
-  4 │   def x : Pi {a : Unit} -> Unit => y
-    │                                    ╰╯
+  3 │   def y : ∀ {a : Unit} -> Unit => \{a} => a
+  4 │   def x : ∀ {a : Unit} -> Unit => y
+    │                                   ╰╯
 
 Error: Unsolved meta a'
        in `y {a'}`

--- a/base/src/test/resources/failure/implicit/implicit2.aya.txt
+++ b/base/src/test/resources/failure/implicit/implicit2.aya.txt
@@ -7,7 +7,7 @@ In file $FILE:4:32 ->
 
 Error: Unsolved meta a'
        in `y {a'}`
-       in `λ {_} ⇒ y {a'}`
+       in `\ {_} ⇒ y {a'}`
 
 1 error(s), 0 warning(s).
 What are you doing?

--- a/base/src/test/resources/failure/patterns/selection-failure.aya
+++ b/base/src/test/resources/failure/patterns/selection-failure.aya
@@ -4,6 +4,6 @@ open data Nat : Type
 open data Vect (A : Type) (n : Nat) : Type
  | A, zero => vnil
  | A, suc m => vcons A (Vect A m)
-def mapImpl {A B : Type} {n : Nat} (f : Pi A -> B) (xs : Vect A n) : Vect B n
+def mapImpl {A B : Type} {n : Nat} (f : A -> B) (xs : Vect A n) : Vect B n
  | {A}, {B}, {n}, f, vnil => vnil
  | {A}, {B}, {n}, f, vcons x xs => _

--- a/base/src/test/resources/failure/patterns/selection-failure.aya.txt
+++ b/base/src/test/resources/failure/patterns/selection-failure.aya.txt
@@ -1,7 +1,7 @@
 In file $FILE:8:21 ->
 
   6 │    | A, suc m => vcons A (Vect A m)
-  7 │   def mapImpl {A B : Type} {n : Nat} (f : Pi A -> B) (xs : Vect A n) : Vect B n
+  7 │   def mapImpl {A B : Type} {n : Nat} (f : A -> B) (xs : Vect A n) : Vect B n
   8 │    | {A}, {B}, {n}, f, vnil => vnil
     │                        ╰──╯
 
@@ -12,7 +12,7 @@ Error: I'm not sure if there should be a case for
 
 In file $FILE:9:21 ->
 
-  7 │   def mapImpl {A B : Type} {n : Nat} (f : Pi A -> B) (xs : Vect A n) : Vect B n
+  7 │   def mapImpl {A B : Type} {n : Nat} (f : A -> B) (xs : Vect A n) : Vect B n
   8 │    | {A}, {B}, {n}, f, vnil => vnil
   9 │    | {A}, {B}, {n}, f, vcons x xs => _
     │                        ╰────────╯

--- a/base/src/test/resources/failure/struct/arg-num-mismatch.aya
+++ b/base/src/test/resources/failure/struct/arg-num-mismatch.aya
@@ -2,5 +2,5 @@ prim I
 open struct PseudoPath (A : I -> Type) (a : A 0) (b : A 1) : Type
  | at (i : I) : A i
 
-def path {A : I -> Type} (p : Pi (i : I) -> A i)
+def path {A : I -> Type} (p : ∀ (i : I) -> A i)
   => new PseudoPath A (p 0) (p 1) { | at i j => p i }

--- a/base/src/test/resources/failure/struct/arg-num-mismatch.aya.txt
+++ b/base/src/test/resources/failure/struct/arg-num-mismatch.aya.txt
@@ -1,7 +1,7 @@
 In file $FILE:6:5 ->
 
   4 │   
-  5 │   def path {A : I -> Type} (p : Pi (i : I) -> A i)
+  5 │   def path {A : I -> Type} (p : ∀ (i : I) -> A i)
   6 │     => new PseudoPath A (p 0) (p 1) { | at i j => p i }
     │        ╰──────────────────────────────────────────────╯
 

--- a/base/src/test/resources/failure/syntax/issue164.aya
+++ b/base/src/test/resources/failure/syntax/issue164.aya
@@ -1,9 +1,9 @@
 def uncurry (A : Type) (B : Type) (C : Type)
-             (f : Pi A B -> C)
+             (f : Fn A B -> C)
              (p : Sig A  B) : C
   => f (p.1) (p.2)
 
 def uncurry3 (A : Type) (B : Type) (C : Type) (D : Type)
-              (f : Pi A B C -> D)
+              (f : Fn A B C -> D)
               (p : Sig A B  C) : D
   => f (p.1) (p.2) (p.3)

--- a/base/src/test/resources/failure/syntax/issue164.aya.txt
+++ b/base/src/test/resources/failure/syntax/issue164.aya.txt
@@ -1,7 +1,7 @@
 In file $FILE:3:26 ->
 
   1 │   def uncurry (A : Type) (B : Type) (C : Type)
-  2 │                (f : Pi A B -> C)
+  2 │                (f : Fn A B -> C)
   3 │                (p : Sig A  B) : C
     │                             ╰╯
 
@@ -10,7 +10,7 @@ Error: Cannot parse
 In file $FILE:8:29 ->
 
   6 │   def uncurry3 (A : Type) (B : Type) (C : Type) (D : Type)
-  7 │                 (f : Pi A B C -> D)
+  7 │                 (f : Fn A B C -> D)
   8 │                 (p : Sig A B  C) : D
     │                                ╰╯
 
@@ -20,7 +20,7 @@ In file $FILE:1:4 ->
 
   1 │   def uncurry (A : Type) (B : Type) (C : Type)
     │       ╰─────╯
-  2 │                (f : Pi A B -> C)
+  2 │                (f : Fn A B -> C)
   3 │                (p : Sig A  B) : C
 
 Error: Unsolved meta _

--- a/base/src/test/resources/failure/tyck/issues/issue659-01.aya.txt
+++ b/base/src/test/resources/failure/tyck/issues/issue659-01.aya.txt
@@ -4,7 +4,7 @@ In file $FILE:1:31 ->
     │                                  ╰────────╯
 
 Error: Cannot check
-         λ {x} ⇒ x
+         \ {x} ⇒ x
        against the Pi type
          A → A
        because explicitness do not match

--- a/base/src/test/resources/failure/tyck/unexpected-end.aya
+++ b/base/src/test/resources/failure/tyck/unexpected-end.aya
@@ -1,2 +1,2 @@
 prim I
-def path {A : I -> Type} (p : Pi (i : I) -> A i) => p 3
+def path {A : I -> Type} (p : ∀ (i : I) -> A i) => p 3

--- a/base/src/test/resources/failure/tyck/unexpected-end.aya.txt
+++ b/base/src/test/resources/failure/tyck/unexpected-end.aya.txt
@@ -1,8 +1,8 @@
-In file $FILE:2:54 ->
+In file $FILE:2:53 ->
 
   1 │   prim I
-  2 │   def path {A : I -> Type} (p : Pi (i : I) -> A i) => p 3
-    │                                                         ╰╯
+  2 │   def path {A : I -> Type} (p : ∀ (i : I) -> A i) => p 3
+    │                                                        ╰╯
 
 Error: The point `3` does not live in interval
 note: Did you mean:  `0` or `1`

--- a/base/src/test/resources/failure/tyck/want-but-no.aya.txt
+++ b/base/src/test/resources/failure/tyck/want-but-no.aya.txt
@@ -6,7 +6,7 @@ In file $FILE:1:19 ->
 Error: The expected type is
          Type 0
        but the given expression
-         λ x ⇒ x
+         \ x ⇒ x
        does not try to construct something into this type
 
 1 error(s), 0 warning(s).

--- a/base/src/test/resources/literate/syntax.aya.md
+++ b/base/src/test/resources/literate/syntax.aya.md
@@ -9,7 +9,7 @@ def dependent (x : Nat) : Type
 | x as x' => Nat
 
 // yes, just id
-def justId : Pi (a b : Nat) -> Sig (e : dependent a) ** (dependent e) => 
+def justId : Fn (a b : Nat) -> Sig (e : dependent a) ** (dependent e) => 
   \ a b => let
     | c := a
     | d := b

--- a/base/src/test/resources/success/common/src/Algebra/Formula.aya
+++ b/base/src/test/resources/success/common/src/Algebra/Formula.aya
@@ -1,5 +1,5 @@
 open import Paths
 
 def BinOp (A : Type) : Type => A → A → A
-def Commutative {A : Type} (op : BinOp A) => Pi (a b : A) -> op a b = op b a
-def Associative {A : Type} (op : BinOp A) => Pi (a b c : A) -> op (op a b) c = op a (op b c)
+def Commutative {A : Type} (op : BinOp A) => ∀ (a b : A) -> op a b = op b a
+def Associative {A : Type} (op : BinOp A) => ∀ (a b c : A) -> op (op a b) c = op a (op b c)

--- a/base/src/test/resources/success/common/src/Arith/Nat/Encoding.aya
+++ b/base/src/test/resources/success/common/src/Arith/Nat/Encoding.aya
@@ -1,5 +1,5 @@
 // Warning: the feature used in this file is deprecated and will be removed soon
-def Natλ => Pi (P : Prop) (P -> P) P -> P
+def Natλ => Fn (P : Prop) (P -> P) P -> P
 
 def zero : Natλ => \P s z => z
 def suc (x : Natλ) : Natλ => \P s z => s (x P s z)

--- a/base/src/test/resources/success/common/src/Arith/Ordinal.aya
+++ b/base/src/test/resources/success/common/src/Arith/Ordinal.aya
@@ -25,12 +25,12 @@ open data infix ≤ Ord Ord
 def ≤f⇒≤l (f : _) (n : Nat) (α ≤ f n) : α ≤ lim f
 | _, _, z≤ => z≤
 | _, _, s≤ _ ≤∸ => s≤ (exist {f} _ _) ≤∸
-| f, n, l≤ f≤ => l≤ (λ m => ≤f⇒≤l f n (f≤ m))
+| f, n, l≤ f≤ => l≤ (\ m => ≤f⇒≤l f n (f≤ m))
 
 def ≤∸⇒≤ {d : Depth β} (α ≤ pred d) : α ≤ β
 | z≤ => z≤
 | s≤ _ ≤∸ => s≤ d (≤∸⇒≤ ≤∸)
-| l≤ f≤ => l≤ (λ n => ≤∸⇒≤ (f≤ n))
+| l≤ f≤ => l≤ (\ n => ≤∸⇒≤ (f≤ n))
 
 def ≤⇒∸≤ (d : Depth α) (α ≤ β) : pred d ≤ β
 | empty, s≤ _ ≤∸ => ≤∸⇒≤ ≤∸
@@ -38,33 +38,33 @@ def ≤⇒∸≤ (d : Depth α) (α ≤ β) : pred d ≤ β
 | exist n d, l≤ f≤ => ≤⇒∸≤ d (f≤ n)
 
 def l≤l {f g : Nat → Ord} (f≤g : ∀ n → f n ≤ g n) : lim f ≤ lim g =>
-  // l≤ (λ n => ≤f⇒≤l _ _ (f≤g n))
+  // l≤ (\ n => ≤f⇒≤l _ _ (f≤g n))
   // seems to cause Aya to loop
-  l≤ (λ n => ≤f⇒≤l g n (f≤g n))
+  l≤ (\ n => ≤f⇒≤l g n (f≤g n))
 
 def s≤s (p : α ≤ β) : suc α ≤ suc β => s≤ empty p
 
 def ≤-refl : Reflexive (≤)
 | {zero} => z≤
 | {suc α} => s≤s ≤-refl
-| {lim f} => l≤ (λ n => ≤f⇒≤l f n ≤-refl)
+| {lim f} => l≤ (\ n => ≤f⇒≤l f n ≤-refl)
 
 def ≤-trans : Transitive (≤)
 | z≤, _ => z≤
 | s≤ empty α≤β, s≤ _ β≤γ => s≤ _ (≤-trans α≤β β≤γ)
 | s≤ (next d) α≤β, s≤ _ β≤γ => s≤ _ (≤-trans α≤β (≤⇒∸≤ d β≤γ))
 | s≤ (exist n d) α≤β, l≤ f≤γ => ≤-trans (s≤ d α≤β) (f≤γ n)
-| l≤ f≤β, β≤γ => l≤ (λ n => ≤-trans (f≤β n) β≤γ)
+| l≤ f≤β, β≤γ => l≤ (\ n => ≤-trans (f≤β n) β≤γ)
 
 def s∸≤ (d : Depth α) : suc (pred d) ≤ α
 | empty => ≤-refl
 | next d => s≤s (≤⇒∸≤ d ≤-refl)
 | exist n _ as dd => s≤ dd ≤-refl
 
-def infix ≈ : Rel Ord => λ α β => Sig (α ≤ β) ** β ≤ α
+def infix ≈ : Rel Ord => \ α β => Sig (α ≤ β) ** β ≤ α
 
 // This implicit lambda is supposed to be omitted.
-def ≈-refl : Reflexive (≈) => λ {x} => (≤-refl , ≤-refl)
+def ≈-refl : Reflexive (≈) => \ {x} => (≤-refl , ≤-refl)
 
 def ≈-sym : Symmetric (≈)
 | (p , q) => (q , p)
@@ -75,4 +75,4 @@ def ≤z⇒≈z' (α ≤ zero) : α ≈ zero
 | {lim _}, ≤ => (≤ , z≤)
 
 def l≈l {f g : Nat → Ord} (f≈g : ∀ n → f n ≈ g n) : lim f ≈ lim g =>
-  (l≤l (λ n => (f≈g n) .1), l≤l (λ n => (f≈g n).2))
+  (l≤l (\ n => (f≈g n) .1), l≤l (\ n => (f≈g n).2))

--- a/base/src/test/resources/success/common/src/Data/Tree/RedBlack/Base.aya
+++ b/base/src/test/resources/success/common/src/Data/Tree/RedBlack/Base.aya
@@ -1,4 +1,4 @@
 public open import Arith::Bool
 
 open data Color | red | black
-def Decider (A : Type) => Pi (x y : A) -> Bool
+def Decider (A : Type) => Fn (x y : A) -> Bool

--- a/base/src/test/resources/success/common/src/Data/Vec.aya
+++ b/base/src/test/resources/success/common/src/Data/Vec.aya
@@ -33,7 +33,7 @@ def infix !! (l : Vec A n) (i : Fin n) : A
 | a :> l, fzero => a
 | a :> l, fsuc i => l !! i
 
-def fold (f : Pi B A -> B) (init : B) (xs : Vec A n) : B
+def fold (f : Fn B A -> B) (init : B) (xs : Vec A n) : B
 | f, init, vnil => init
 | f, acc, x :> xs => fold f (f acc x) xs
 

--- a/base/src/test/resources/success/common/src/Logic/SetTrunc.aya
+++ b/base/src/test/resources/success/common/src/Logic/SetTrunc.aya
@@ -11,4 +11,4 @@ variable A B : Type
 def rec (A -> B) (isSet B) (SetTrunc A) : B
 | f, x, inj a => f a
 | f, x, trunc a b p q i j =>
-    x (rec f x a) (rec f x b) (λ k => rec f x (p k)) (λ k => rec f x (q k)) i j
+    x (rec f x a) (rec f x b) (\ k => rec f x (p k)) (\ k => rec f x (q k)) i j

--- a/base/src/test/resources/success/common/src/Relation/Formula.aya
+++ b/base/src/test/resources/success/common/src/Relation/Formula.aya
@@ -2,7 +2,7 @@ def Rel' (A : Type) (B : Type) => A → B → Type
 def Rel (A : Type) => Rel' A A
 
 variable A B C : Type
-def Reflexive (r : Rel A) => Pi {x : A} -> r x x
+def Reflexive (r : Rel A) => ∀ {x : A} -> r x x
 
 //  Generalised transitivity.
 def Trans (P : Rel' A B) (Q : Rel' B C) (R : Rel' A C) => ∀ {x} {y} {z} -> P x y -> Q y z -> R x z

--- a/base/src/test/resources/success/src/Binop.aya
+++ b/base/src/test/resources/success/src/Binop.aya
@@ -1,12 +1,12 @@
 open import Arith::Nat
 
 example def test1 : Nat => (+ 0) 0
-example def test2 : Pi Nat -> Nat => + 0
+example def test2 : Nat -> Nat => + 0
 example def test3 : Nat => (0 +) 0
-example def test4 : Pi Nat -> Nat => 0 +
+example def test4 : Nat -> Nat => 0 +
 
-def f1 (a : Pi Nat -> Nat -> Nat) : Nat => 0
-def f2 {a : Pi Nat -> Nat -> Nat} : Nat => 0
+def f1 (a : Nat -> Nat -> Nat) : Nat => 0
+def f2 {a : Nat -> Nat -> Nat} : Nat => 0
 
 example def add => +
 example def test5 : Nat => f1 (add)

--- a/base/src/test/resources/success/src/CubicalBasics.aya
+++ b/base/src/test/resources/success/src/CubicalBasics.aya
@@ -33,54 +33,54 @@ example def coeFillRight (A : I -> Type) (u : A 0) : (A.coeFill u) 1 = transp A 
 def id {A : Type} (a: A) : A => a
 def transportID {A : Type} (a: A) : A => (transp (\ i => A -> A) id) a
 
-def coePi (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
-    (f : Pi (a : A 0) -> B 0 a) : Pi (a : A 1) -> B 1 a
+def coePi (A : I -> Type) (B : ∀ (i : I) -> A i -> Type)
+    (f : ∀ (a : A 0) -> B 0 a) : ∀ (a : A 1) -> B 1 a
     => \a => (\i => B i ((\j => A ((~ j) ∨ i)).coe a freeze i)).coe f
       ((\i => A (~ i)).coe a)
 
-example def coePiEq (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
-    (f : Pi (a : A 0) -> B 0 a)
-    : coePi A B f = (\i => Pi (x : A i) -> B i x).coe f
+example def coePiEq (A : I -> Type) (B : ∀ (i : I) -> A i -> Type)
+    (f : ∀ (a : A 0) -> B 0 a)
+    : coePi A B f = (\i => ∀ (x : A i) -> B i x).coe f
     => idp
 
-example def coeSigma (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
+example def coeSigma (A : I -> Type) (B : Fn (i : I) -> A i -> Type)
     (t : Sig (x : A 0) ** B 0 x) : Sig (x : A 1) ** B 1 x =>
   (A.coe t.1,
      (\i => B i ((A.coeFill t.1) i)).coe t.2)
-example def coeSigmaEq (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
+example def coeSigmaEq (A : I -> Type) (B : Fn (i : I) -> A i -> Type)
     (t : Sig (x : A 0) ** B 0 x)
     : coeSigma A B t = (\i => Sig (x : A i) ** B i x).coe t
     => idp
 
-example def coeSigma3 (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
-    (C : Pi (i : I) (a : A i) -> B i a -> Type)
+example def coeSigma3 (A : I -> Type) (B : Fn (i : I) -> A i -> Type)
+    (C : Fn (i : I) (a : A i) -> B i a -> Type)
     (t : Sig (a : A 0) (b : B 0 a) ** C 0 a b) : Sig (a : A 1) (b : B 1 a) ** C 1 a b =>
   (A.coe t.1
   , (\i => B i ((A.coeFill t.1) i)).coe t.2
   , (\i => C i ((A.coeFill t.1) i) (((\j => B j ((A.coeFill t.1) j)).coeFill t.2) i)).coe t.3)
-example def coeSigma3Eq (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
-    (C : Pi (i : I) (a : A i) -> B i a -> Type)
+example def coeSigma3Eq (A : I -> Type) (B : Fn (i : I) -> A i -> Type)
+    (C : Fn (i : I) (a : A i) -> B i a -> Type)
     (t : Sig (a : A 0) (b : B 0 a) ** C 0 a b) : coeSigma3 A B C t = (\i => Sig (a : A i) (b : B i a) ** C i a b).coe t => idp
 
-example def coeSigma4 (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
-    (C : Pi (i : I) (a : A i) -> B i a -> Type)
-    (D : Pi (i : I) (a : A i) (b : B i a) -> C i a b -> Type)
+example def coeSigma4 (A : I -> Type) (B : Fn (i : I) -> A i -> Type)
+    (C : Fn (i : I) (a : A i) -> B i a -> Type)
+    (D : Fn (i : I) (a : A i) (b : B i a) -> C i a b -> Type)
     (t : Sig (a : A 0) (b : B 0 a) (c : C 0 a b) ** D 0 a b c) : Sig (a : A 1) (b : B 1 a) (c : C 1 a b) ** D 1 a b c =>
   (A.coe t.1
   , (\i => B i ((A.coeFill t.1) i)).coe t.2
   , (\i => C i ((A.coeFill t.1) i) (((\j => B j ((A.coeFill t.1) j)).coeFill t.2) i)).coe t.3
   , (\i => D i ((A.coeFill t.1) i) (((\j => B j ((A.coeFill t.1) j)).coeFill t.2) i)
       (((\j => C j ((A.coeFill t.1) j) (((\k => B k ((A.coeFill t.1) k)).coeFill t.2) j)).coeFill t.3) i)).coe t.4)
-example def coeSigma4Eq (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
-    (C : Pi (i : I) (a : A i) -> B i a -> Type)
-    (D : Pi (i : I) (a : A i) (b : B i a) -> C i a b -> Type)
+example def coeSigma4Eq (A : I -> Type) (B : Fn (i : I) -> A i -> Type)
+    (C : Fn (i : I) (a : A i) -> B i a -> Type)
+    (D : Fn (i : I) (a : A i) (b : B i a) -> C i a b -> Type)
     (t : Sig (a : A 0) (b : B 0 a) (c : C 0 a b) ** D 0 a b c)
      : coeSigma4 A B C D t = (\i => Sig (a : A i) (b : B i a) (c : C i a b) ** D i a b c).coe t => idp
 
-example def coeSigma5 (A : I -> Type) (B : Pi (i : I) -> A i -> Type)
-    (C : Pi (i : I) (a : A i) -> B i a -> Type)
-    (D : Pi (i : I) (a : A i) (b : B i a) -> C i a b -> Type)
-    (E : Pi (i : I) (a : A i) (b : B i a) (c : C i a b) -> D i a b c -> Type)
+example def coeSigma5 (A : I -> Type) (B : Fn (i : I) -> A i -> Type)
+    (C : Fn (i : I) (a : A i) -> B i a -> Type)
+    (D : Fn (i : I) (a : A i) (b : B i a) -> C i a b -> Type)
+    (E : Fn (i : I) (a : A i) (b : B i a) (c : C i a b) -> D i a b c -> Type)
     (t : Sig (a : A 0) (b : B 0 a) (c : C 0 a b) (d : D 0 a b c) ** E 0 a b c d)
      : Sig (a : A 1) (b : B 1 a) (c : C 1 a b) (d : D 1 a b c) ** E 1 a b c d =>
   (A.coe t.1
@@ -105,6 +105,6 @@ example def coeFillAlt=coeFillPrim (A : I -> Type) (u : A 0)
   : coeFillAlt A u = A.coeFill u
   => idp
 
-example def piFromPath (A : Type) (a b : A) (p : a = b) : Pi (i : I) -> A => p
+example def piFromPath (A : Type) (a b : A) (p : a = b) : ∀ (i : I) -> A => p
 example def piFromPathH (A : I -> Type) (a : A 0) (b : A 1)
-  (p : Path A a b) : Pi (i : I) -> A i => p
+  (p : Path A a b) : ∀ (i : I) -> A i => p

--- a/base/src/test/resources/success/src/CubicalMoveFromLib.aya
+++ b/base/src/test/resources/success/src/CubicalMoveFromLib.aya
@@ -8,7 +8,7 @@ open import Paths
 // |              |
 // |              |
 // a ---- ab ---- b
-def HeteroSquare {A : Pi (i j : I) -> Type}
+def HeteroSquare {A : ∀ (i j : I) -> Type}
   {a : A 0 0} {b : A 0 1}
   {c : A 1 0} {d : A 1 1}
   (ab : Path (A 0) a b)
@@ -23,7 +23,7 @@ def HeteroSquare {A : Pi (i j : I) -> Type}
   }
 
 // TODO: eta
-def heteroSquare {A : Pi (i j : I) -> Type} (p : Pi (i j : I) -> A i j)
+def heteroSquare {A : ∀ (i j : I) -> Type} (p : ∀ (i j : I) -> A i j)
   : HeteroSquare {A} (\i => p 0 i) (\i => p 1 i)
     (\x => p x 0)
     (\x => p x 1) => \i j => p i j

--- a/base/src/test/resources/success/src/GlueProto.aya
+++ b/base/src/test/resources/success/src/GlueProto.aya
@@ -16,4 +16,4 @@ def isHAEquiv (f : A -> B) => Sig
 def idFun (a : A) => a
 
 def idHA : isHAEquiv (idFun {A}) =>
-  (idFun, λ a => idp, λ b => idp, λ a i => idp)
+  (idFun, \ a => idp, \ b => idp, \ a i => idp)

--- a/base/src/test/resources/success/src/Invol.aya
+++ b/base/src/test/resources/success/src/Invol.aya
@@ -1,4 +1,4 @@
 open import Paths
 
-def path' {A : I -> Type} (p : Pi (i : I) -> A i)
+def path' {A : I -> Type} (p : ∀ (i : I) -> A i)
   : Path A (p 0) (p 1) => \x => p x

--- a/base/src/test/resources/success/src/Issues/523.aya
+++ b/base/src/test/resources/success/src/Issues/523.aya
@@ -3,9 +3,9 @@ open import Paths
 open struct PseudoPath (A : I -> Type) (a : A 0) (b : A 1) : Type
  | at (i : I) : A i
 
-def path {A : I -> Type} (p : Pi (i : I) -> A i)
+def path {A : I -> Type} (p : Fn (i : I) -> A i)
   => new PseudoPath A (p 0) (p 1) { | at i => p i }
 
 variable A : Type
-def idp-old (a : A) => path {λ i => A} (λ i => a)
+def idp-old (a : A) => path {\ i => A} (\ i => a)
 def idp-proj (a : A) => (idp-old a) .at 0

--- a/base/src/test/resources/success/src/Issues/564.aya
+++ b/base/src/test/resources/success/src/Issues/564.aya
@@ -1,11 +1,11 @@
 open import Paths
 open import Arith::Nat
 
-def +-assoc-redo : Pi (n m p : Nat) → n + (m + p) = (n + m) + p
+def +-assoc-redo : ∀ (n m p : Nat) → n + (m + p) = (n + m) + p
 | zero, m, p => idp
 | suc n, m, p => pmap suc (+-assoc-redo n m p)
 
-def +-assoc-redo2 (n : Nat) : Pi (m p : Nat) → n + (m + p) = (n + m) + p
+def +-assoc-redo2 (n : Nat) : ∀ (m p : Nat) → n + (m + p) = (n + m) + p
 | zero, m, p => idp
 | suc n, m, p => pmap suc (+-assoc-redo2 n m p)
 

--- a/base/src/test/resources/success/src/Issues/595.aya
+++ b/base/src/test/resources/success/src/Issues/595.aya
@@ -13,7 +13,7 @@ open data ImCtor (A : Type)
 def elimIt {A : Type} (x : ImCtor A) : A
 | imCtor {a} => a
 
-def matchIt {A : Type} (x : ImCtor A) : Pi A -> A
+def matchIt {A : Type} (x : ImCtor A) : Fn A -> A
 | {A} as A', imCtor {a as a'} => \ (x' : A') => a'
 
 def proofIt (A : Type) (x : ImCtor A) (a : A) : matchIt x a = elimIt x

--- a/base/src/test/resources/success/src/Issues/625.aya
+++ b/base/src/test/resources/success/src/Issues/625.aya
@@ -1,5 +1,5 @@
 example def bua (A : Type)
   (B : A -> Type)
-  (C : Pi (a : A) -> B a -> Type)
+  (C : Fn (a : A) -> B a -> Type)
   (t : Sig (a : A) (b : B a) ** C a b)
   : C t.1 t.2 => t.3

--- a/base/src/test/resources/success/src/Issues/861.aya
+++ b/base/src/test/resources/success/src/Issues/861.aya
@@ -1,7 +1,7 @@
 open import Paths
 variable A : Type
 
-def partialGivesContr (c : Pi (φ : I) (u : Partial φ A) -> Sub A φ u) : isContr A =>
+def partialGivesContr (c : Fn (φ : I) (u : Partial φ A) -> Sub A φ u) : isContr A =>
    ( outS (c 0 {| |})
    , \y i => outS (c (i ∨ (~ i)) {| i := y | ~ i := outS (c 0 {| |}) |})
    )

--- a/base/src/test/resources/success/src/Issues/924.aya
+++ b/base/src/test/resources/success/src/Issues/924.aya
@@ -3,4 +3,4 @@ open import Arith::Bool
 
 def id (x : Bool) => x
 
-def Goal => (λ x => not (not x)) = id
+def Goal => (\ x => not (not x)) = id

--- a/base/src/test/resources/success/src/Mutual.aya
+++ b/base/src/test/resources/success/src/Mutual.aya
@@ -11,7 +11,7 @@ def even Nat : Bool
 
 def say (i : Universe) : Type
   | nat => Nat
-  | pi a b => Pi (x : say a) -> say (b x)
+  | pi a b => Fn (x : say a) -> say (b x)
   | sig a b => Sig (x : say a) ** say (b x)
 
 open data Universe : Type

--- a/base/src/test/resources/success/src/ProtoIssues/659.aya
+++ b/base/src/test/resources/success/src/ProtoIssues/659.aya
@@ -1,10 +1,10 @@
-def imConst {A : Type} (a : A) : Pi {ignoreMe ignoreThis : A} -> A => a
-def imId {A : Type} : Pi {ignoreMe : A} -> A -> Pi {ignoreThis : A} -> A => \ a => a
+def imConst {A : Type} (a : A) : Fn {ignoreMe ignoreThis : A} -> A => a
+def imId {A : Type} : Fn {ignoreMe : A} -> A -> Fn {ignoreThis : A} -> A => \ a => a
 
 def id {A : Type} (x : A) : A => x
-def idId {A : Type} : Pi (x : A) -> A => (id id)
+def idId {A : Type} : Fn (x : A) -> A => (id id)
 
 def idS {A : Type} (x : Sig A ** A) : Sig A ** A => x
-def idIdS {A : Type} : Pi (x : Sig A ** A) -> Sig A ** A => (id id)
+def idIdS {A : Type} : Fn (x : Sig A ** A) -> Sig A ** A => (id id)
 
 // https://github.com/aya-prover/aya-prover-proto/issues/659

--- a/base/src/test/resources/success/src/ProtoIssues/726.aya
+++ b/base/src/test/resources/success/src/ProtoIssues/726.aya
@@ -22,8 +22,8 @@ def refl { A : Type } => new Isomorphism { A } { A } {
 struct Isomorphism' { A B : Type } : Type
   | to : A -> B
   | from : B -> A
-  | from∘to : Pi (a : A) -> from (to a) = a
-  | to∘from : Pi (b : B) -> to (from b) = b
+  | from∘to : Fn (a : A) -> from (to a) = a
+  | to∘from : Fn (b : B) -> to (from b) = b
 
 def refl' { A : Type } => new Isomorphism' { A } { A } {
   | to => ident

--- a/base/src/test/resources/success/src/ProtoIssues/736.aya
+++ b/base/src/test/resources/success/src/ProtoIssues/736.aya
@@ -3,6 +3,6 @@ open struct PointedMagma {A : Type} : Type
   | op : A -> A -> A
 
 open data Unit | unit
-def test : Pi {x : Type} -> Type => \{x} => PointedMagma {x}
+def test : Fn {x : Type} -> Type => \{x} => PointedMagma {x}
 
 def unitMagma : PointedMagma {Unit} => new test { | point => unit | op => \ x y => unit }

--- a/base/src/test/resources/success/src/Refparo/Model.aya
+++ b/base/src/test/resources/success/src/Refparo/Model.aya
@@ -7,7 +7,7 @@ def coe {A B : Type} (eq : A ↑ = B) (x : A) : B
   => (\y => eq y).primCoe x
 
 def coeFill {A : Type} {x : A} : x = coe (↑ idp) x
-  => λ i => (λ j => A).primCoe x freeze (~ i)
+  => \ i => (\ j => A).primCoe x freeze (~ i)
 
 // *** Types
 
@@ -17,7 +17,7 @@ open struct EventT : Type 1
 def GetterT => EventT -> Type
 def SetterT => Type -> EventT -> EventT
 def Invariant (GetT : GetterT) (SetT : SetterT)
-  => Pi (T : EventT) (E : Type) -> E ↑ = GetT (SetT E T)
+  => Fn (T : EventT) (E : Type) -> E ↑ = GetT (SetT E T)
 
 // wish these getter/setters could be generated automatically
 def GetAgentT (T : EventT) => T.AgentT
@@ -29,7 +29,7 @@ def AgentT-inv : Invariant GetAgentT SetAgentT
 open struct Event (T : EventT) : Type
   | agent : T.AgentT
 
-def Getter (GetT : GetterT) => Pi {T : EventT} (Event T) -> GetT T
+def Getter (GetT : GetterT) => Fn {T : EventT} (Event T) -> GetT T
 
 def getAgent {T : EventT} (e : Event T) : T.AgentT => e.agent
 
@@ -53,11 +53,11 @@ def VP (T : EventT) => Verb T
 def BDP (E : Type) => Quantifier E
 
 def DP (SetT : SetterT) (E : Type)
-  => Pi {T : EventT} -> VP (SetT E T) -> VP (SetT E T)
+  => Fn {T : EventT} -> VP (SetT E T) -> VP (SetT E T)
 
 // thetas transform a BDP into a DP with that thematic role
 def Theta (SetT : SetterT) : Type 1
-  => Pi {E : Type} -> BDP E -> DP SetT E
+  => Fn {E : Type} -> BDP E -> DP SetT E
 
 def mkTheta (GetT : GetterT)
   (get : Getter GetT)

--- a/base/src/test/resources/success/src/Sorts.aya
+++ b/base/src/test/resources/success/src/Sorts.aya
@@ -25,4 +25,4 @@ def Leibniz (x y : A) : Prop
 
 def refl (a : A) : Leibniz a a => \p x => x
 def symm {x y : A} (p : Leibniz x y)
-  : Leibniz y x => p (λ y' => Leibniz y' x) (refl _)
+  : Leibniz y x => p (\ y' => Leibniz y' x) (refl _)

--- a/base/src/test/resources/success/src/Sorts.aya
+++ b/base/src/test/resources/success/src/Sorts.aya
@@ -21,7 +21,7 @@ variable A : Type
 
 // Leibniz equality using impredicative universe of propositions
 def Leibniz (x y : A) : Prop
-  => Pi (P : A → Prop) → P x → P y
+  => Fn (P : A → Prop) → P x → P y
 
 def refl (a : A) : Leibniz a a => \p x => x
 def symm {x y : A} (p : Leibniz x y)

--- a/base/src/test/resources/success/src/TypeSafeNorm.aya
+++ b/base/src/test/resources/success/src/TypeSafeNorm.aya
@@ -18,4 +18,4 @@ def normalize {t : TermTy} (x : Term t) : termTy t
  | inv b => not (normalize b)
  | case b x y => ifElse (normalize b) (normalize x) (normalize y)
 
-def Normalize => Pi {t : TermTy} (x : Term t) -> termTy t
+def Normalize => Fn {t : TermTy} (x : Term t) -> termTy t

--- a/base/src/test/resources/success/src/UnivIR.aya
+++ b/base/src/test/resources/success/src/UnivIR.aya
@@ -10,7 +10,7 @@ def El U : Type
 | Nat' => Nat
 | a ×' b => Sig (El a) ** El b
 | a →' b => El a -> El b
-| Π' dom cod => Pi (d : El dom) -> El (cod d)
+| Π' dom cod => ∀ (d : El dom) -> El (cod d)
 | Σ' dom cod => Sig (d : El dom) ** El (cod d)
 
 def tyExample : U => Nat' →' Nat' ×' (Nat' ×' Nat') ×' Nat'

--- a/base/src/test/resources/success/src/UnivIR.aya
+++ b/base/src/test/resources/success/src/UnivIR.aya
@@ -14,4 +14,4 @@ def El U : Type
 | Σ' dom cod => Sig (d : El dom) ** El (cod d)
 
 def tyExample : U => Nat' →' Nat' ×' (Nat' ×' Nat') ×' Nat'
-def valExample : El tyExample => λ x => (x, ((2, 3), 4))
+def valExample : El tyExample => \ x => (x, ((2, 3), 4))

--- a/cli-impl/src/test/java/org/aya/cli/CodifierTest.java
+++ b/cli-impl/src/test/java/org/aya/cli/CodifierTest.java
@@ -12,7 +12,7 @@ public class CodifierTest extends ReplTestBase {
       prim I prim coe prim intervalInv prim intervalMax
       inline def ~ => intervalInv
       inline def infix ∨ => intervalMax
-      def coePi (A : I -> Type) (B : Pi (i : I) -> A i -> Type) (f : Pi (a : A 0) -> B 0 a) : Pi (a : A 1) -> B 1 a => \\a => (\\i => B i ((\\j => A ((~ j) ∨ i)).coe a freeze i)).coe f ((\\i => A (~ i)).coe a)
+      def coePi (A : I -> Type) (B : Fn (i : I) -> A i -> Type) (f : Pi (a : A 0) -> B 0 a) : Pi (a : A 1) -> B 1 a => \\a => (\\i => B i ((\\j => A ((~ j) ∨ i)).coe a freeze i)).coe f ((\\i => A (~ i)).coe a)
       :codify coePi
       """).component1().trim();
     assertNotNull(out);

--- a/cli-impl/src/test/java/org/aya/cli/CodifierTest.java
+++ b/cli-impl/src/test/java/org/aya/cli/CodifierTest.java
@@ -12,7 +12,7 @@ public class CodifierTest extends ReplTestBase {
       prim I prim coe prim intervalInv prim intervalMax
       inline def ~ => intervalInv
       inline def infix ∨ => intervalMax
-      def coePi (A : I -> Type) (B : Fn (i : I) -> A i -> Type) (f : Pi (a : A 0) -> B 0 a) : Pi (a : A 1) -> B 1 a => \\a => (\\i => B i ((\\j => A ((~ j) ∨ i)).coe a freeze i)).coe f ((\\i => A (~ i)).coe a)
+      def coePi (A : I -> Type) (B : Fn (i : I) -> A i -> Type) (f : Fn (a : A 0) -> B 0 a) : Fn (a : A 1) -> B 1 a => \\a => (\\i => B i ((\\j => A ((~ j) ∨ i)).coe a freeze i)).coe f ((\\i => A (~ i)).coe a)
       :codify coePi
       """).component1().trim();
     assertNotNull(out);

--- a/cli-impl/src/test/java/org/aya/cli/ReplTestBase.java
+++ b/cli-impl/src/test/java/org/aya/cli/ReplTestBase.java
@@ -25,7 +25,7 @@ public class ReplTestBase {
     config.prompt = "";
   }
 
-  @NotNull protected Tuple2<String, String> repl(@Language("TEXT") @NotNull String input) {
+  @NotNull protected Tuple2<String, String> repl(@Language("Aya") @NotNull String input) {
     var out = new StringWriter();
     var err = new StringWriter();
     var reader = new StringReader(input + "\n:exit");

--- a/parser/src/main/gen/org/aya/parser/AyaPsiElementTypes.java
+++ b/parser/src/main/gen/org/aya/parser/AyaPsiElementTypes.java
@@ -147,7 +147,7 @@ public interface AyaPsiElementTypes {
   IElementType KW_INFIXR = new AyaPsiTokenType("infixr");
   IElementType KW_INLINE = new AyaPsiTokenType("inline");
   IElementType KW_ISET = new AyaPsiTokenType("ISet");
-  IElementType KW_LAMBDA = new AyaPsiTokenType("\\");
+  IElementType KW_LAMBDA = new AyaPsiTokenType("fn");
   IElementType KW_LET = new AyaPsiTokenType("let");
   IElementType KW_LOOSER = new AyaPsiTokenType("looser");
   IElementType KW_MATCH = new AyaPsiTokenType("match");
@@ -157,7 +157,7 @@ public interface AyaPsiElementTypes {
   IElementType KW_OPEN = new AyaPsiTokenType("open");
   IElementType KW_OVERLAP = new AyaPsiTokenType("overlap");
   IElementType KW_OVERRIDE = new AyaPsiTokenType("override");
-  IElementType KW_PI = new AyaPsiTokenType("Pi");
+  IElementType KW_PI = new AyaPsiTokenType("Fn");
   IElementType KW_PRIM = new AyaPsiTokenType("prim");
   IElementType KW_PRIVATE = new AyaPsiTokenType("private");
   IElementType KW_PROP = new AyaPsiTokenType("Prop");

--- a/parser/src/main/grammar/AyaPsiLexer.flex
+++ b/parser/src/main/grammar/AyaPsiLexer.flex
@@ -83,8 +83,10 @@ OCT_DIGIT = [0-8]
 
 ULIFT = ulift | \u2191+
 SIGMA = Sig | \u03a3
+// TODO: replace with fn -- lambda as a keyword is too likely to
+//  be used as a variable name for mathematicians and type theorists
 LAMBDA = \\ | \u03bb
-PI = Pi | \u03a0
+PI = Fn
 FORALL = forall | \u2200
 TO = -> | \u2192
 LARROW = <- | \u2190
@@ -150,6 +152,7 @@ BLOCK_COMMENT_END   = "*/"
   "let"                 { return KW_LET; }
   "in"                  { return KW_IN; }
   "completed"           { return KW_COMPLETED; }
+  "Fn"                  { return KW_PI; }
   ":="                  { return DEFINE_AS; }
   "**"                  { return SUCHTHAT; }
   "."                   { return DOT; }
@@ -171,7 +174,6 @@ BLOCK_COMMENT_END   = "*/"
   {ULIFT}               { return KW_ULIFT; }
   {SIGMA}               { return KW_SIGMA; }
   {LAMBDA}              { return KW_LAMBDA; }
-  {PI}                  { return KW_PI; }
   {FORALL}              { return KW_FORALL; }
   {TO}                  { return TO; }
   {LARROW}              { return LARROW; }

--- a/parser/src/main/grammar/AyaPsiLexer.flex
+++ b/parser/src/main/grammar/AyaPsiLexer.flex
@@ -150,7 +150,6 @@ BLOCK_COMMENT_END   = "*/"
   "let"                 { return KW_LET; }
   "in"                  { return KW_IN; }
   "completed"           { return KW_COMPLETED; }
-  "Fn"                  { return KW_PI; }
   ":="                  { return DEFINE_AS; }
   "**"                  { return SUCHTHAT; }
   "."                   { return DOT; }
@@ -172,6 +171,7 @@ BLOCK_COMMENT_END   = "*/"
   {ULIFT}               { return KW_ULIFT; }
   {SIGMA}               { return KW_SIGMA; }
   {LAMBDA}              { return KW_LAMBDA; }
+  {PI}                  { return KW_PI; }
   {FORALL}              { return KW_FORALL; }
   {TO}                  { return TO; }
   {LARROW}              { return LARROW; }

--- a/parser/src/main/grammar/AyaPsiLexer.flex
+++ b/parser/src/main/grammar/AyaPsiLexer.flex
@@ -83,9 +83,7 @@ OCT_DIGIT = [0-8]
 
 ULIFT = ulift | \u2191+
 SIGMA = Sig | \u03a3
-// TODO: replace with fn -- lambda as a keyword is too likely to
-//  be used as a variable name for mathematicians and type theorists
-LAMBDA = \\ | \u03bb
+LAMBDA = \\ | fn
 PI = Fn
 FORALL = forall | \u2200
 TO = -> | \u2192

--- a/parser/src/main/grammar/AyaPsiParser.bnf
+++ b/parser/src/main/grammar/AyaPsiParser.bnf
@@ -87,8 +87,7 @@
     // symbols
     // KW_SIGMA =  'regexp:Sig|\u03a3'
     KW_SIGMA =  'Sig'
-    // KW_LAMBDA = 'fn'
-    KW_LAMBDA = '\'
+    KW_LAMBDA = 'fn'
     KW_PI = 'Fn'
     // KW_FORALL = 'regexp:forall|\u2200'
     KW_FORALL = 'forall'

--- a/parser/src/main/grammar/AyaPsiParser.bnf
+++ b/parser/src/main/grammar/AyaPsiParser.bnf
@@ -87,10 +87,9 @@
     // symbols
     // KW_SIGMA =  'regexp:Sig|\u03a3'
     KW_SIGMA =  'Sig'
-    // KW_LAMBDA = 'regexp:[\\\u03bb]'
+    // KW_LAMBDA = 'fn'
     KW_LAMBDA = '\'
-    // KW_PI = 'regexp:Pi|\u03a0'
-    KW_PI = 'Pi'
+    KW_PI = 'Fn'
     // KW_FORALL = 'regexp:forall|\u2200'
     KW_FORALL = 'forall'
 

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -37,7 +37,6 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
   /** similar to StringPrinter, but with mappings from source code unicode to LaTeX unicode. */
   private static final @NotNull Map<String, String> commandMapping = Map.ofEntries(
     Tuple.of("Sig", "\\Sigma"),
-    Tuple.of("\\", "\\lambda"),
     Tuple.of("\\/", "\\lor"),
     Tuple.of("/\\", "\\land"),
     Tuple.of("|", "\\mid"),
@@ -46,7 +45,6 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
     Tuple.of("_|_", "\\bot"),
     Tuple.of("forall", "\\forall"),
     Tuple.of("\u03A3", "\\Sigma"),
-    Tuple.of("\u03BB", "\\lambda"),
     Tuple.of("\u2228", "\\lor"),
     Tuple.of("\u2227", "\\land"),
     Tuple.of("\u21D2", "\\Rightarrow"),

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -36,7 +36,6 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
 
   /** similar to StringPrinter, but with mappings from source code unicode to LaTeX unicode. */
   private static final @NotNull Map<String, String> commandMapping = Map.ofEntries(
-    Tuple.of("Pi", "\\Pi"),
     Tuple.of("Sig", "\\Sigma"),
     Tuple.of("\\", "\\lambda"),
     Tuple.of("\\/", "\\lor"),
@@ -46,7 +45,6 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
     Tuple.of("->", "\\to"),
     Tuple.of("_|_", "\\bot"),
     Tuple.of("forall", "\\forall"),
-    Tuple.of("\u03A0", "\\Pi"),
     Tuple.of("\u03A3", "\\Sigma"),
     Tuple.of("\u03BB", "\\lambda"),
     Tuple.of("\u2228", "\\lor"),

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinter.java
@@ -109,7 +109,6 @@ public class StringPrinter<Config extends StringPrinterConfig<?>> implements Pri
 
   private static final @NotNull Map<String, String> unicodeMapping = Map.ofEntries(
     Tuple.of("Sig", "\u03A3"),
-    Tuple.of("\\", "\u03BB"),
     Tuple.of("/\\", "\u2227"),
     Tuple.of("\\/", "\u2228"),
     Tuple.of("=>", "\u21D2"),

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinter.java
@@ -108,7 +108,6 @@ public class StringPrinter<Config extends StringPrinterConfig<?>> implements Pri
   }
 
   private static final @NotNull Map<String, String> unicodeMapping = Map.ofEntries(
-    Tuple.of("Pi", "\u03A0"),
     Tuple.of("Sig", "\u03A3"),
     Tuple.of("\\", "\u03BB"),
     Tuple.of("/\\", "\u2227"),


### PR DESCRIPTION
These symbols are too likely to be used as a variable name for mathematicians and type theorists.
Note: one can still use `\` for lambda abstraction.