### PR TITLE
Fix some potential bugs

### DIFF
--- a/base/src/main/java/org/aya/resolve/ResolveInfo.java
+++ b/base/src/main/java/org/aya/resolve/ResolveInfo.java
@@ -46,8 +46,8 @@ public record ResolveInfo(
   @NotNull AyaShape.Factory shapeFactory,
   @NotNull AyaBinOpSet opSet,
   @NotNull MutableMap<DefVar<?, ?>, Tuple3<RenamedOpDecl, BindBlock, Boolean>> opRename,
-  @NotNull MutableMap<ModulePath, Tuple2<ResolveInfo, Boolean>> imports,
-  @NotNull MutableMap<ModulePath, UseHide> reExports,
+  @NotNull MutableMap<ModulePath.Qualified, Tuple2<ResolveInfo, Boolean>> imports,
+  @NotNull MutableMap<ModulePath.Qualified, UseHide> reExports,
   @NotNull MutableGraph<TyckOrder> depGraph
 ) {
   public ResolveInfo(

--- a/base/src/main/java/org/aya/resolve/context/Context.java
+++ b/base/src/main/java/org/aya/resolve/context/Context.java
@@ -70,7 +70,7 @@ public interface Context {
    */
   default @NotNull AnyVar get(@NotNull QualifiedID name) {
     return switch (name.component()) {
-      case ModulePath.This aThis -> getUnqualified(name.name(), name.sourcePos());
+      case ModulePath.ThisRef aThis -> getUnqualified(name.name(), name.sourcePos());
       case ModulePath.Qualified qualified -> getQualified(qualified, name.name(), name.sourcePos());
     };
   }
@@ -80,7 +80,7 @@ public interface Context {
    */
   default @Nullable AnyVar getMaybe(@NotNull QualifiedID name) {
     return switch (name.component()) {
-      case ModulePath.This aThis -> getUnqualifiedMaybe(name.name(), name.sourcePos());
+      case ModulePath.ThisRef aThis -> getUnqualifiedMaybe(name.name(), name.sourcePos());
       case ModulePath.Qualified qualified -> getQualifiedMaybe(qualified, name.name(), name.sourcePos());
     };
   }

--- a/base/src/main/java/org/aya/resolve/context/ModulePath.java
+++ b/base/src/main/java/org/aya/resolve/context/ModulePath.java
@@ -9,11 +9,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.Serializable;
 
-public sealed interface ModulePath {
+public sealed interface ModulePath extends Serializable {
   int size();
-  final class This implements ModulePath {
-    private This() {
-    }
+  enum ThisRef implements ModulePath {
+    Obj;
 
     @Override public int size() {
       return 0;
@@ -36,7 +35,7 @@ public sealed interface ModulePath {
     }
   }
 
-  record Qualified(@NotNull ImmutableSeq<String> ids) implements ModulePath, Serializable {
+  record Qualified(@NotNull ImmutableSeq<String> ids) implements ModulePath {
     public Qualified(String @NotNull ... ids) {
       this(ImmutableSeq.of(ids));
     }
@@ -69,7 +68,7 @@ public sealed interface ModulePath {
 
   /// region static
 
-  @NotNull This This = new This();
+  @NotNull ModulePath.ThisRef This = ThisRef.Obj;
 
   static @NotNull ModulePath from(@NotNull ImmutableSeq<String> ids) {
     if (ids.isEmpty()) return This;

--- a/base/src/main/java/org/aya/resolve/context/ModulePath.java
+++ b/base/src/main/java/org/aya/resolve/context/ModulePath.java
@@ -7,6 +7,8 @@ import org.aya.generic.Constants;
 import org.aya.generic.util.InternalException;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.Serializable;
+
 public sealed interface ModulePath {
   int size();
   final class This implements ModulePath {
@@ -34,7 +36,7 @@ public sealed interface ModulePath {
     }
   }
 
-  record Qualified(@NotNull ImmutableSeq<String> ids) implements ModulePath {
+  record Qualified(@NotNull ImmutableSeq<String> ids) implements ModulePath, Serializable {
     public Qualified(String @NotNull ... ids) {
       this(ImmutableSeq.of(ids));
     }

--- a/base/src/main/java/org/aya/resolve/context/ModuleSymbol.java
+++ b/base/src/main/java/org/aya/resolve/context/ModuleSymbol.java
@@ -81,7 +81,7 @@ public record ModuleSymbol<T>(
   public @NotNull Result<T, Error> getMaybe(@NotNull ModulePath component, @NotNull String unqualifiedName) {
     return switch (component) {
       case ModulePath.Qualified qualified -> getQualifiedMaybe(component, unqualifiedName).toResult(Error.NotFound);
-      case ModulePath.This aThis -> getUnqualifiedMaybe(unqualifiedName);
+      case ModulePath.ThisRef aThis -> getUnqualifiedMaybe(unqualifiedName);
     };
   }
 
@@ -141,7 +141,7 @@ public record ModuleSymbol<T>(
           yield Result.ok(result.get());
         }
       }
-      case ModulePath.This aThis -> removeDefinitely(unqualifiedName);
+      case ModulePath.ThisRef aThis -> removeDefinitely(unqualifiedName);
     };
   }
 


### PR DESCRIPTION
- The keys of `ResolveInfo#imports` and `ResolveInfo#reExports` are now `ModulePath.Qualified` as they should.
- Supports module renaming in `CompiledAya` to fix a TODO.