### PR TITLE
Literate: KaTeX, ServerSideRendering, and options to inline highlight styles

### DIFF
--- a/base/src/test/java/org/aya/literate/AyaMdParserTest.java
+++ b/base/src/test/java/org/aya/literate/AyaMdParserTest.java
@@ -134,9 +134,12 @@ public class AyaMdParserTest {
     // save some coverage
     var actualTexInlinedStyle = doc.renderToTeX();
     var actualTexWithHeader = new RenderOptions().render(RenderOptions.OutputTarget.LaTeX,
-      doc, new RenderOptions.Opts(true, true, true, true, -1));
+      doc, new RenderOptions.Opts(true, true, true, true, -1, false));
+    var actualTexButKa = new RenderOptions().render(RenderOptions.OutputTarget.KaTeX,
+      doc, new RenderOptions.Opts(true, true, true, true, -1, false));
     assertFalse(actualTexInlinedStyle.isEmpty());
     assertFalse(actualTexWithHeader.isEmpty());
+    assertFalse(actualTexButKa.isEmpty());
   }
 
   private @NotNull String trim(@NotNull String input) {

--- a/base/src/test/java/org/aya/literate/AyaMdParserTest.java
+++ b/base/src/test/java/org/aya/literate/AyaMdParserTest.java
@@ -25,8 +25,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AyaMdParserTest {
   public final static @NotNull Path TEST_DIR = Path.of("src", "test", "resources", "literate");
@@ -130,12 +129,12 @@ public class AyaMdParserTest {
       oneCase.outMdFile()
     ), null);
     var actualMd = Files.readString(oneCase.outMdFile());
-    assertLinesMatch(trim(expectedMd).lines(), trim(actualMd).lines());
+    assertEquals(trim(expectedMd), trim(actualMd));
 
     // save some coverage
     var actualTexInlinedStyle = doc.renderToTeX();
     var actualTexWithHeader = new RenderOptions().render(RenderOptions.OutputTarget.LaTeX,
-      doc, true, true, true);
+      doc, new RenderOptions.Opts(true, true, true, true, -1));
     assertFalse(actualTexInlinedStyle.isEmpty());
     assertFalse(actualTexWithHeader.isEmpty());
   }

--- a/cli-console/src/main/java/org/aya/cli/console/Main.java
+++ b/cli-console/src/main/java/org/aya/cli/console/Main.java
@@ -59,11 +59,13 @@ public class Main extends MainArgs implements Callable<Integer> {
     }
     replConfig.close();
     var pretty = prettyStage == null
-      ? (outputPath != null ? CompilerFlags.prettyInfoFromOutput(outputPath, renderOptions, prettyNoCodeStyle, prettyInlineCodeStyle) : null)
+      ? (outputPath != null ? CompilerFlags.prettyInfoFromOutput(
+      outputPath, renderOptions, prettyNoCodeStyle, prettyInlineCodeStyle, prettySSR) : null)
       : new CompilerFlags.PrettyInfo(
         asciiOnly,
         prettyNoCodeStyle,
         prettyInlineCodeStyle,
+        prettySSR,
         prettyStage,
         prettyFormat,
         prettierOptions,

--- a/cli-console/src/main/java/org/aya/cli/console/Main.java
+++ b/cli-console/src/main/java/org/aya/cli/console/Main.java
@@ -59,10 +59,11 @@ public class Main extends MainArgs implements Callable<Integer> {
     }
     replConfig.close();
     var pretty = prettyStage == null
-      ? (outputPath != null ? CompilerFlags.prettyInfoFromOutput(outputPath, renderOptions, prettyNoCodeStyle) : null)
+      ? (outputPath != null ? CompilerFlags.prettyInfoFromOutput(outputPath, renderOptions, prettyNoCodeStyle, prettyInlineCodeStyle) : null)
       : new CompilerFlags.PrettyInfo(
         asciiOnly,
         prettyNoCodeStyle,
+        prettyInlineCodeStyle,
         prettyStage,
         prettyFormat,
         prettierOptions,

--- a/cli-console/src/main/java/org/aya/cli/console/MainArgs.java
+++ b/cli-console/src/main/java/org/aya/cli/console/MainArgs.java
@@ -91,6 +91,8 @@ public class MainArgs {
   public boolean prettyNoCodeStyle;
   @Option(names = {"--pretty-inline-code-style"}, description = "Use inlined highlight styles.")
   public boolean prettyInlineCodeStyle;
+  @Option(names = {"--pretty-ssr"}, description = "Generate Server-Side-Rendering code for literate output.")
+  public boolean prettySSR;
   @Option(names = {"--trace"}, description = "Enable tracing.")
   public boolean enableTrace;
   @Option(names = {"--ascii-only"}, description = "Do not show unicode in success/fail message.")

--- a/cli-console/src/main/java/org/aya/cli/console/MainArgs.java
+++ b/cli-console/src/main/java/org/aya/cli/console/MainArgs.java
@@ -87,8 +87,10 @@ public class MainArgs {
   public String prettyDir;
   @Option(names = {"--pretty-color"}, description = "The color theme of pretty printing." + CANDIDATES, defaultValue = "emacs")
   public PredefinedStyle prettyColor;
-  @Option(names = {"--pretty-no-code-style"}, description = "Do not render styled code.")
+  @Option(names = {"--pretty-no-code-style"}, description = "Do not include default highlight styles.")
   public boolean prettyNoCodeStyle;
+  @Option(names = {"--pretty-inline-code-style"}, description = "Use inlined highlight styles.")
+  public boolean prettyInlineCodeStyle;
   @Option(names = {"--trace"}, description = "Enable tracing.")
   public boolean enableTrace;
   @Option(names = {"--ascii-only"}, description = "Do not show unicode in success/fail message.")

--- a/cli-console/src/main/java/org/aya/cli/repl/ReplCommands.java
+++ b/cli-console/src/main/java/org/aya/cli/repl/ReplCommands.java
@@ -159,7 +159,7 @@ public interface ReplCommands {
       var fallbackPath = options.path;
       try {
         options.updateColorScheme(colorParam.value);
-        options.stylist(RenderOptions.OutputTarget.Terminal); // if there's error, report now.
+        options.stylist(RenderOptions.OutputTarget.Unix); // if there's error, report now.
         return Result.ok(options.prettyColorScheme(), true);
       } catch (IllegalArgumentException | IOException e) {
         options.colorScheme = fallback;
@@ -176,7 +176,7 @@ public interface ReplCommands {
       var fallback = options.styleFamily;
       try {
         options.updateStyleFamily(styleParam.value);
-        options.stylist(RenderOptions.OutputTarget.Terminal); // if there's error, report now.
+        options.stylist(RenderOptions.OutputTarget.Unix); // if there's error, report now.
         return Result.ok(repl.config.renderOptions.prettyStyleFamily(), true);
       } catch (IllegalArgumentException | IOException e) {
         options.styleFamily = fallback;

--- a/cli-console/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
+++ b/cli-console/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
@@ -88,8 +88,8 @@ public final class JlineRepl extends AyaRepl {
   }
 
   private @NotNull String renderDoc(@NotNull Doc doc, int pageWidth) {
-    return config.renderOptions.render(RenderOptions.OutputTarget.Terminal, doc,
-      false, false, config.enableUnicode, pageWidth);
+    return config.renderOptions.render(RenderOptions.OutputTarget.Unix, doc,
+      new RenderOptions.Opts(false, false, false, config.enableUnicode, pageWidth));
   }
 
   @Override public void println(@NotNull String x) {

--- a/cli-console/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
+++ b/cli-console/src/main/java/org/aya/cli/repl/jline/JlineRepl.java
@@ -89,7 +89,7 @@ public final class JlineRepl extends AyaRepl {
 
   private @NotNull String renderDoc(@NotNull Doc doc, int pageWidth) {
     return config.renderOptions.render(RenderOptions.OutputTarget.Unix, doc,
-      new RenderOptions.Opts(false, false, false, config.enableUnicode, pageWidth));
+      new RenderOptions.Opts(false, false, false, config.enableUnicode, pageWidth, false));
   }
 
   @Override public void println(@NotNull String x) {

--- a/cli-impl/src/main/java/org/aya/cli/interactive/ReplConfig.java
+++ b/cli-impl/src/main/java/org/aya/cli/interactive/ReplConfig.java
@@ -41,7 +41,7 @@ public class ReplConfig implements AutoCloseable {
     if (renderOptions == null) renderOptions = new RenderOptions();
     renderOptions.checkDeserialization();
     try {
-      renderOptions.stylist(RenderOptions.OutputTarget.Terminal);
+      renderOptions.stylist(RenderOptions.OutputTarget.Unix);
     } catch (IOException | JsonParseException e) {
       System.err.println("Failed to load stylist from config file, using default stylist instead.");
     }

--- a/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
+++ b/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
@@ -152,7 +152,7 @@ public class RenderOptions {
       config.set(StringPrinterConfig.TextOptions.Unicode, unicode);
       config.set(StringPrinterConfig.StyleOptions.HeaderCode, headerCode);
       config.set(StringPrinterConfig.StyleOptions.StyleCode, styleCode);
-      config.set(StringPrinterConfig.StyleOptions.SeparateStyle, styleCode);
+      config.set(StringPrinterConfig.StyleOptions.SeparateStyle, separateStyle);
       config.set(StringPrinterConfig.StyleOptions.AyaFlavored, true);
       return config;
     }

--- a/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
+++ b/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
@@ -151,18 +151,18 @@ public class RenderOptions {
 
   public @NotNull String render(
     @NotNull OutputTarget output, @NotNull Doc doc,
-    boolean witHeader, boolean withStyleDef, boolean unicode,
+    boolean headerCode, boolean styleCode, boolean unicode,
     int pageWidth
   ) {
     var stylist = stylistOrDefault(output);
     return switch (output) {
-      case Plain -> doc.renderToString(new StringPrinterConfig<>(stylist, pageWidth, unicode));
+      case Plain -> doc.renderToString(new StringPrinterConfig<>(stylist, pageWidth, unicode, headerCode, styleCode));
       case LaTeX -> doc.render(new DocTeXPrinter(), new DocTeXPrinter.Config(
-        (TeXStylist) stylist, witHeader, withStyleDef));
+        (TeXStylist) stylist, headerCode, styleCode));
       case HTML -> doc.render(new DocHtmlPrinter<>(), new DocHtmlPrinter.Config(
-        (Html5Stylist) stylist, witHeader, withStyleDef));
+        (Html5Stylist) stylist, headerCode, styleCode));
       case AyaMd -> doc.render(new DocMdPrinter(), new DocMdPrinter.Config(
-        (MdStylist) stylist, witHeader, withStyleDef, true));
+        (MdStylist) stylist, headerCode, styleCode, true));
       case Terminal -> doc.render(new DocTermPrinter(), new DocTermPrinter.Config(
         (UnixTermStylist) stylist, pageWidth, unicode));
     };

--- a/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
+++ b/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
@@ -149,7 +149,7 @@ public class RenderOptions {
     }
   }
 
-  public record Opts(boolean headerCode, boolean styleCode, boolean separateStyle, boolean unicode, int pageWidth) {
+  public record Opts(boolean headerCode, boolean styleCode, boolean separateStyle, boolean unicode, int pageWidth, boolean SSR) {
     public <T extends PrinterConfig.Basic<?>> @NotNull T setup(@NotNull T config) {
       config.set(PrinterConfig.PageOptions.PageWidth, pageWidth);
       config.set(StringPrinterConfig.TextOptions.Unicode, unicode);
@@ -157,6 +157,7 @@ public class RenderOptions {
       config.set(StringPrinterConfig.StyleOptions.StyleCode, styleCode);
       config.set(StringPrinterConfig.StyleOptions.SeparateStyle, separateStyle);
       config.set(StringPrinterConfig.StyleOptions.AyaFlavored, true);
+      config.set(StringPrinterConfig.StyleOptions.ServerSideRendering, SSR);
       return config;
     }
   }

--- a/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
+++ b/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
@@ -19,6 +19,7 @@ import org.aya.pretty.backend.terminal.DocTermPrinter;
 import org.aya.pretty.backend.terminal.UnixTermStylist;
 import org.aya.pretty.doc.Doc;
 import org.aya.pretty.printer.ColorScheme;
+import org.aya.pretty.printer.PrinterConfig;
 import org.aya.pretty.printer.StyleFamily;
 import org.aya.pretty.style.AyaColorScheme;
 import org.aya.pretty.style.AyaStyleFamily;
@@ -34,7 +35,7 @@ import java.util.Objects;
 /** Multi-target {@link org.aya.pretty.printer.Stylist}, usually created from json files. */
 public class RenderOptions {
   public enum OutputTarget {
-    Terminal(".txt"),
+    Unix(".txt"),
     LaTeX(".tex"),
     AyaMd(".md"),
     HTML(".html"),
@@ -115,7 +116,7 @@ public class RenderOptions {
 
   public static @NotNull StringStylist defaultStylist(@NotNull OutputTarget output) {
     return switch (output) {
-      case Terminal -> AdaptiveCliStylist.INSTANCE;
+      case Unix -> AdaptiveCliStylist.INSTANCE;
       case LaTeX -> TeXStylist.DEFAULT;
       case AyaMd -> MdStylist.DEFAULT;
       case HTML -> Html5Stylist.DEFAULT;
@@ -128,7 +129,7 @@ public class RenderOptions {
     final var c = buildColorScheme();
     final var s = buildStyleFamily();
     return switch (output) {
-      case Terminal -> new UnixTermStylist(c, s);
+      case Unix -> new UnixTermStylist(c, s);
       case LaTeX -> new TeXStylist(c, s);
       case AyaMd -> new MdStylist(c, s);
       case HTML -> new Html5Stylist(c, s);
@@ -145,26 +146,26 @@ public class RenderOptions {
     }
   }
 
-  public @NotNull String render(@NotNull OutputTarget output, @NotNull Doc doc, boolean witHeader, boolean withStyleDef, boolean unicode) {
-    return render(output, doc, witHeader, withStyleDef, unicode, StringPrinterConfig.INFINITE_SIZE);
+  public record Opts(boolean headerCode, boolean styleCode, boolean separateStyle, boolean unicode, int pageWidth) {
+    public <T extends PrinterConfig.Basic<?>> @NotNull T setup(@NotNull T config) {
+      config.set(PrinterConfig.PageOptions.PageWidth, pageWidth);
+      config.set(StringPrinterConfig.TextOptions.Unicode, unicode);
+      config.set(StringPrinterConfig.StyleOptions.HeaderCode, headerCode);
+      config.set(StringPrinterConfig.StyleOptions.StyleCode, styleCode);
+      config.set(StringPrinterConfig.StyleOptions.SeparateStyle, styleCode);
+      config.set(StringPrinterConfig.StyleOptions.AyaFlavored, true);
+      return config;
+    }
   }
 
-  public @NotNull String render(
-    @NotNull OutputTarget output, @NotNull Doc doc,
-    boolean headerCode, boolean styleCode, boolean unicode,
-    int pageWidth
-  ) {
+  public @NotNull String render(@NotNull OutputTarget output, @NotNull Doc doc, @NotNull Opts opts) {
     var stylist = stylistOrDefault(output);
     return switch (output) {
-      case Plain -> doc.renderToString(new StringPrinterConfig<>(stylist, pageWidth, unicode, headerCode, styleCode));
-      case LaTeX -> doc.render(new DocTeXPrinter(), new DocTeXPrinter.Config(
-        (TeXStylist) stylist, headerCode, styleCode));
-      case HTML -> doc.render(new DocHtmlPrinter<>(), new DocHtmlPrinter.Config(
-        (Html5Stylist) stylist, headerCode, styleCode));
-      case AyaMd -> doc.render(new DocMdPrinter(), new DocMdPrinter.Config(
-        (MdStylist) stylist, headerCode, styleCode, true));
-      case Terminal -> doc.render(new DocTermPrinter(), new DocTermPrinter.Config(
-        (UnixTermStylist) stylist, pageWidth, unicode));
+      case Plain -> doc.renderToString(opts.setup(new StringPrinterConfig<>(stylist)));
+      case LaTeX -> doc.render(new DocTeXPrinter(), opts.setup(new DocTeXPrinter.Config((TeXStylist) stylist)));
+      case HTML -> doc.render(new DocHtmlPrinter<>(), opts.setup(new DocHtmlPrinter.Config((Html5Stylist) stylist)));
+      case AyaMd -> doc.render(new DocMdPrinter(), opts.setup(new DocMdPrinter.Config((MdStylist) stylist)));
+      case Unix -> doc.render(new DocTermPrinter(), opts.setup(new DocTermPrinter.Config((UnixTermStylist) stylist)));
     };
   }
 

--- a/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
+++ b/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
@@ -37,6 +37,7 @@ public class RenderOptions {
   public enum OutputTarget {
     Unix(".txt"),
     LaTeX(".tex"),
+    KaTeX(".katex"),
     AyaMd(".md"),
     HTML(".html"),
     Plain(".txt");
@@ -118,6 +119,7 @@ public class RenderOptions {
     return switch (output) {
       case Unix -> AdaptiveCliStylist.INSTANCE;
       case LaTeX -> TeXStylist.DEFAULT;
+      case KaTeX -> TeXStylist.DEFAULT_KATEX;
       case AyaMd -> MdStylist.DEFAULT;
       case HTML -> Html5Stylist.DEFAULT;
       case Plain -> DebugStylist.DEFAULT;
@@ -130,7 +132,8 @@ public class RenderOptions {
     final var s = buildStyleFamily();
     return switch (output) {
       case Unix -> new UnixTermStylist(c, s);
-      case LaTeX -> new TeXStylist(c, s);
+      case LaTeX -> new TeXStylist(c, s, false);
+      case KaTeX -> new TeXStylist(c, s, true);
       case AyaMd -> new MdStylist(c, s);
       case HTML -> new Html5Stylist(c, s);
       case Plain -> new DebugStylist(c, s);
@@ -162,7 +165,7 @@ public class RenderOptions {
     var stylist = stylistOrDefault(output);
     return switch (output) {
       case Plain -> doc.renderToString(opts.setup(new StringPrinterConfig<>(stylist)));
-      case LaTeX -> doc.render(new DocTeXPrinter(), opts.setup(new DocTeXPrinter.Config((TeXStylist) stylist)));
+      case KaTeX, LaTeX -> doc.render(new DocTeXPrinter(), opts.setup(new DocTeXPrinter.Config((TeXStylist) stylist)));
       case HTML -> doc.render(new DocHtmlPrinter<>(), opts.setup(new DocHtmlPrinter.Config((Html5Stylist) stylist)));
       case AyaMd -> doc.render(new DocMdPrinter(), opts.setup(new DocMdPrinter.Config((MdStylist) stylist)));
       case Unix -> doc.render(new DocTermPrinter(), opts.setup(new DocTermPrinter.Config((UnixTermStylist) stylist)));

--- a/cli-impl/src/main/java/org/aya/cli/single/CompilerFlags.java
+++ b/cli-impl/src/main/java/org/aya/cli/single/CompilerFlags.java
@@ -6,6 +6,7 @@ import kala.collection.SeqLike;
 import org.aya.cli.render.RenderOptions;
 import org.aya.cli.utils.CliEnums;
 import org.aya.prettier.AyaPrettierOptions;
+import org.aya.pretty.backend.string.StringPrinterConfig;
 import org.aya.util.prettier.PrettierOptions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,6 +46,10 @@ public record CompilerFlags(
     @NotNull RenderOptions renderOptions,
     @Nullable String prettyDir
   ) {
+    public @NotNull RenderOptions.Opts renderOpts(boolean headerCode) {
+      return new RenderOptions.Opts(headerCode, !prettyNoCodeStyle,
+        !prettyNoCodeStyle, !ascii, StringPrinterConfig.INFINITE_SIZE);
+    }
   }
 
   public record Message(

--- a/cli-impl/src/main/java/org/aya/cli/single/CompilerFlags.java
+++ b/cli-impl/src/main/java/org/aya/cli/single/CompilerFlags.java
@@ -22,13 +22,12 @@ public record CompilerFlags(
   @Nullable Path outputFile
 ) {
   public static @Nullable CompilerFlags.PrettyInfo prettyInfoFromOutput(
-    @Nullable Path outputFile,
-    @NotNull RenderOptions renderOptions,
-    boolean noCodeStyle, boolean inlineCodeStyle
+    @Nullable Path outputFile, @NotNull RenderOptions renderOptions,
+    boolean noCodeStyle, boolean inlineCodeStyle, boolean SSR
   ) {
     if (outputFile != null) return new PrettyInfo(
       false,
-      noCodeStyle, inlineCodeStyle,
+      noCodeStyle, inlineCodeStyle, SSR,
       CliEnums.PrettyStage.literate,
       CliEnums.detectFormat(outputFile),
       AyaPrettierOptions.pretty(),
@@ -41,6 +40,7 @@ public record CompilerFlags(
     boolean ascii,
     boolean prettyNoCodeStyle,
     boolean prettyInlineCodeStyle,
+    boolean prettySSR,
     @NotNull CliEnums.PrettyStage prettyStage,
     @NotNull CliEnums.PrettyFormat prettyFormat,
     @NotNull PrettierOptions prettierOptions,
@@ -48,8 +48,8 @@ public record CompilerFlags(
     @Nullable String prettyDir
   ) {
     public @NotNull RenderOptions.Opts renderOpts(boolean headerCode) {
-      return new RenderOptions.Opts(headerCode, !prettyNoCodeStyle,
-        !prettyInlineCodeStyle, !ascii, StringPrinterConfig.INFINITE_SIZE);
+      return new RenderOptions.Opts(headerCode, !prettyNoCodeStyle, !prettyInlineCodeStyle,
+        !ascii, StringPrinterConfig.INFINITE_SIZE, prettySSR);
     }
   }
 

--- a/cli-impl/src/main/java/org/aya/cli/single/CompilerFlags.java
+++ b/cli-impl/src/main/java/org/aya/cli/single/CompilerFlags.java
@@ -24,11 +24,11 @@ public record CompilerFlags(
   public static @Nullable CompilerFlags.PrettyInfo prettyInfoFromOutput(
     @Nullable Path outputFile,
     @NotNull RenderOptions renderOptions,
-    boolean noCodeStyle
+    boolean noCodeStyle, boolean inlineCodeStyle
   ) {
     if (outputFile != null) return new PrettyInfo(
       false,
-      noCodeStyle,
+      noCodeStyle, inlineCodeStyle,
       CliEnums.PrettyStage.literate,
       CliEnums.detectFormat(outputFile),
       AyaPrettierOptions.pretty(),
@@ -40,6 +40,7 @@ public record CompilerFlags(
   public record PrettyInfo(
     boolean ascii,
     boolean prettyNoCodeStyle,
+    boolean prettyInlineCodeStyle,
     @NotNull CliEnums.PrettyStage prettyStage,
     @NotNull CliEnums.PrettyFormat prettyFormat,
     @NotNull PrettierOptions prettierOptions,
@@ -48,7 +49,7 @@ public record CompilerFlags(
   ) {
     public @NotNull RenderOptions.Opts renderOpts(boolean headerCode) {
       return new RenderOptions.Opts(headerCode, !prettyNoCodeStyle,
-        !prettyNoCodeStyle, !ascii, StringPrinterConfig.INFINITE_SIZE);
+        !prettyInlineCodeStyle, !ascii, StringPrinterConfig.INFINITE_SIZE);
     }
   }
 

--- a/cli-impl/src/main/java/org/aya/cli/single/SingleAyaFile.java
+++ b/cli-impl/src/main/java/org/aya/cli/single/SingleAyaFile.java
@@ -65,17 +65,13 @@ public sealed interface SingleAyaFile extends GenericAyaFile {
     }
 
     var renderOptions = flags.renderOptions();
-    var withStyleDef = !flags.prettyNoCodeStyle();
     if (currentStage == CliEnums.PrettyStage.literate) {
-      var text = renderOptions.render(out,
-        toDoc((ImmutableSeq<Stmt>) doc, flags.prettierOptions()),
-        true,
-        withStyleDef,
-        !flags.ascii());
+      var d = toDoc((ImmutableSeq<Stmt>) doc, flags.prettierOptions());
+      var text = renderOptions.render(out, d, flags.renderOpts(true));
       FileUtil.writeString(prettyDir.resolve(fileName), text);
     } else {
       doWrite(doc, prettyDir, flags.prettierOptions(), fileName, out.fileExt,
-        (d, hdr) -> renderOptions.render(out, d, hdr, withStyleDef, !flags.ascii()));
+        (d, hdr) -> renderOptions.render(out, d, flags.renderOpts(hdr)));
     }
   }
   @VisibleForTesting default @NotNull Doc toDoc(

--- a/cli-impl/src/main/java/org/aya/cli/single/SingleAyaFile.java
+++ b/cli-impl/src/main/java/org/aya/cli/single/SingleAyaFile.java
@@ -41,7 +41,7 @@ import java.util.function.BiFunction;
 public sealed interface SingleAyaFile extends GenericAyaFile {
   private static @Nullable CompilerFlags.PrettyInfo parsePrettyInfo(@NotNull CompilerFlags flags) {
     if (flags.prettyInfo() != null) return flags.prettyInfo();
-    return CompilerFlags.prettyInfoFromOutput(flags.outputFile(), new RenderOptions(), false);
+    return CompilerFlags.prettyInfoFromOutput(flags.outputFile(), new RenderOptions(), false, false);
   }
 
   @SuppressWarnings("unchecked") default void pretty(

--- a/cli-impl/src/main/java/org/aya/cli/single/SingleAyaFile.java
+++ b/cli-impl/src/main/java/org/aya/cli/single/SingleAyaFile.java
@@ -41,7 +41,7 @@ import java.util.function.BiFunction;
 public sealed interface SingleAyaFile extends GenericAyaFile {
   private static @Nullable CompilerFlags.PrettyInfo parsePrettyInfo(@NotNull CompilerFlags flags) {
     if (flags.prettyInfo() != null) return flags.prettyInfo();
-    return CompilerFlags.prettyInfoFromOutput(flags.outputFile(), new RenderOptions(), false, false);
+    return CompilerFlags.prettyInfoFromOutput(flags.outputFile(), new RenderOptions(), false, false, false);
   }
 
   @SuppressWarnings("unchecked") default void pretty(

--- a/cli-impl/src/main/java/org/aya/cli/utils/CliEnums.java
+++ b/cli-impl/src/main/java/org/aya/cli/utils/CliEnums.java
@@ -12,6 +12,7 @@ public interface CliEnums {
     var name = outputFile.getFileName().toString();
     if (name.endsWith(".md")) return PrettyFormat.markdown;
     if (name.endsWith(".tex")) return PrettyFormat.latex;
+    if (name.endsWith(".katex")) return PrettyFormat.katex;
     if (name.endsWith(".html")) return PrettyFormat.html;
     return PrettyFormat.plain;
   }
@@ -26,6 +27,7 @@ public interface CliEnums {
     html(RenderOptions.OutputTarget.HTML),
     plain(RenderOptions.OutputTarget.Plain),
     latex(RenderOptions.OutputTarget.LaTeX),
+    katex(RenderOptions.OutputTarget.KaTeX),
     markdown(RenderOptions.OutputTarget.AyaMd),
     unix(RenderOptions.OutputTarget.Unix);
 

--- a/cli-impl/src/main/java/org/aya/cli/utils/CliEnums.java
+++ b/cli-impl/src/main/java/org/aya/cli/utils/CliEnums.java
@@ -27,7 +27,7 @@ public interface CliEnums {
     plain(RenderOptions.OutputTarget.Plain),
     latex(RenderOptions.OutputTarget.LaTeX),
     markdown(RenderOptions.OutputTarget.AyaMd),
-    unix(RenderOptions.OutputTarget.Terminal);
+    unix(RenderOptions.OutputTarget.Unix);
 
     public final @NotNull RenderOptions.OutputTarget target;
 

--- a/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
+++ b/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
@@ -22,9 +22,10 @@ public class RenderOptionsTest {
     var doc = Doc.code("hello");
     var opt = new RenderOptions();
     opt.checkDeserialization();
-    assertEquals("`hello'", opt.render(RenderOptions.OutputTarget.Terminal, doc, false, false, true));
-    assertEquals("\\fbox{hello}", opt.render(RenderOptions.OutputTarget.LaTeX, doc, false, false, true));
-    assertEquals("<code class=\"Aya\">hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, false, false, true));
-    assertEquals("`hello`", opt.render(RenderOptions.OutputTarget.Plain, doc, false, false, true));
+    var opts = new RenderOptions.Opts(false, false, false, true, -1);
+    assertEquals("`hello'", opt.render(RenderOptions.OutputTarget.Unix, doc, opts));
+    assertEquals("\\fbox{hello}", opt.render(RenderOptions.OutputTarget.LaTeX, doc, opts));
+    assertEquals("<code class=\"Aya\">hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, opts));
+    assertEquals("`hello`", opt.render(RenderOptions.OutputTarget.Plain, doc, opts));
   }
 }

--- a/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
+++ b/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
@@ -22,9 +22,10 @@ public class RenderOptionsTest {
     var doc = Doc.code("hello");
     var opt = new RenderOptions();
     opt.checkDeserialization();
-    var opts = new RenderOptions.Opts(false, false, false, true, -1);
+    var opts = new RenderOptions.Opts(false, false, false, true, -1, false);
     assertEquals("`hello'", opt.render(RenderOptions.OutputTarget.Unix, doc, opts));
     assertEquals("\\fbox{hello}", opt.render(RenderOptions.OutputTarget.LaTeX, doc, opts));
+    assertEquals("\\fbox{hello}", opt.render(RenderOptions.OutputTarget.KaTeX, doc, opts));
     assertEquals("<code class=\"Aya\">hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, opts));
     assertEquals("`hello`", opt.render(RenderOptions.OutputTarget.Plain, doc, opts));
   }

--- a/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
@@ -55,6 +55,7 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
   }
 
   protected void renderCssStyle(@NotNull Cursor cursor) {
+    if (!config.opt(SeparateStyle, false)) return;
     if (!config.opt(StyleCode, false)) return;
     cursor.invisibleContent("<style>");
     // colors are defined in global scope `:root`

--- a/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
@@ -153,12 +153,8 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
   }
 
   public static class Config extends StringPrinterConfig<Html5Stylist> {
-    public Config(boolean withHeader) {
-      this(Html5Stylist.DEFAULT, withHeader, true);
-    }
-
-    public Config(@NotNull Html5Stylist stylist, boolean headerCode, boolean styleCode) {
-      super(stylist, INFINITE_SIZE, true, headerCode, styleCode);
+    public Config(@NotNull Html5Stylist stylist) {
+      super(stylist);
     }
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/html/HtmlConstants.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/HtmlConstants.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.html;
 
@@ -82,7 +82,7 @@ public interface HtmlConstants {
     """;
   @SuppressWarnings("LanguageMismatch")
   @Language(value = "HTML")
-  @NotNull String HOVER_HIGHLIGHT_ALL_OCCURS_VUE = """
+  @NotNull String HOVER_ALL_OCCURS_SSR = """
     <script>
     export default {
       mounted() {

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -30,6 +30,7 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
   }
 
   protected void renderStyleCommand(@NotNull Cursor cursor) {
+    if (!config.opt(SeparateStyle, false)) return;
     if (!config.opt(StyleCode, false)) return;
     // colors are converted to `\definecolor` in package xcolor.
     var colors = TeXStylist.colorsToTex(config.getStylist().colorScheme);

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -14,12 +14,14 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.EnumSet;
 
+import static org.aya.pretty.backend.string.StringPrinterConfig.StyleOptions.*;
+
 /**
  * @author ice1000
  */
 public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
   @Override protected void renderHeader(@NotNull Cursor cursor) {
-    if (config.withHeader) {
+    if (config.opt(HeaderCode, false)) {
       // cursor.invisibleContent("\\noindent{}");
       // This prevents us from using \raggedright followed by a \setlength\parindent.
       // We should expect users to deal with indentations themselves.
@@ -28,7 +30,7 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
   }
 
   protected void renderStyleCommand(@NotNull Cursor cursor) {
-    if (!config.withStyleDef) return;
+    if (!config.opt(StyleCode, false)) return;
     // colors are converted to `\definecolor` in package xcolor.
     var colors = TeXStylist.colorsToTex(config.getStylist().colorScheme);
     cursor.invisibleContent(colors + "\n");
@@ -42,7 +44,7 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
   }
 
   @Override protected @NotNull StringStylist prepareStylist() {
-    return config.supportStyleCommand() ? new TeXStylist.ClassedPreset(config.getStylist()) : super.prepareStylist();
+    return config.opt(SeparateStyle, false) ? new TeXStylist.ClassedPreset(config.getStylist()) : super.prepareStylist();
   }
 
   @Override protected @NotNull String escapePlainText(@NotNull String content, EnumSet<Outer> outer) {
@@ -139,22 +141,12 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
    * @author ice1000
    */
   public static class Config extends StringPrinterConfig<TeXStylist> {
-    public final boolean withHeader;
-    public final boolean withStyleDef;
-
-    /** Set doc style with "\newcommand\xxx" and "\xxx" */
-    public boolean supportStyleCommand() {
-      return withHeader;
+    public Config() {
+      this(TeXStylist.DEFAULT, false, false);
     }
 
-    public Config(boolean withHeader, boolean withStyleDef) {
-      this(TeXStylist.DEFAULT, withHeader, withStyleDef);
-    }
-
-    public Config(@NotNull TeXStylist stylist, boolean withHeader, boolean withStyleDef) {
-      super(stylist, INFINITE_SIZE, false);
-      this.withHeader = withHeader;
-      this.withStyleDef = withStyleDef;
+    public Config(@NotNull TeXStylist stylist, boolean headerCode, boolean styleCode) {
+      super(stylist, INFINITE_SIZE, false, headerCode, styleCode);
     }
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -142,11 +142,11 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
    */
   public static class Config extends StringPrinterConfig<TeXStylist> {
     public Config() {
-      this(TeXStylist.DEFAULT, false, false);
+      this(TeXStylist.DEFAULT);
     }
 
-    public Config(@NotNull TeXStylist stylist, boolean headerCode, boolean styleCode) {
-      super(stylist, INFINITE_SIZE, false, headerCode, styleCode);
+    public Config(@NotNull TeXStylist stylist) {
+      super(stylist);
     }
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/TeXStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/TeXStylist.java
@@ -19,10 +19,14 @@ import org.jetbrains.annotations.Nullable;
 import java.util.EnumSet;
 
 public class TeXStylist extends ClosingStylist {
-  public static final @NotNull TeXStylist DEFAULT = new TeXStylist(AyaColorScheme.INTELLIJ, AyaStyleFamily.DEFAULT);
+  public static final @NotNull TeXStylist DEFAULT = new TeXStylist(AyaColorScheme.INTELLIJ, AyaStyleFamily.DEFAULT, false);
+  public static final @NotNull TeXStylist DEFAULT_KATEX = new TeXStylist(AyaColorScheme.INTELLIJ, AyaStyleFamily.DEFAULT, true);
 
-  public TeXStylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily) {
+  public final boolean KaTeX;
+
+  public TeXStylist(@NotNull ColorScheme colorScheme, @NotNull StyleFamily styleFamily, boolean KaTeX) {
     super(colorScheme, styleFamily);
+    this.KaTeX = KaTeX;
   }
 
   @Override protected @NotNull StyleToken formatItalic(EnumSet<StringPrinter.Outer> outer) {
@@ -42,8 +46,11 @@ public class TeXStylist extends ClosingStylist {
   }
 
   @Override protected @NotNull StyleToken formatColorHex(int rgb, boolean background) {
-    return new StyleToken("\\%s[HTML]{%06x}{".formatted(
-      background ? "colorbox" : "textcolor", rgb), "}", false);
+    var cmd = "\\%s%s{%06x}{".formatted(
+      background ? "colorbox" : "textcolor",
+      KaTeX ? "" : "[HTML]",
+      rgb);
+    return new StyleToken(cmd, "}", false);
   }
 
   public static class ClassedPreset extends Delegate {

--- a/pretty/src/main/java/org/aya/pretty/backend/md/DocMdPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/md/DocMdPrinter.java
@@ -166,13 +166,8 @@ public class DocMdPrinter extends DocHtmlPrinter<DocMdPrinter.Config> {
   }
 
   public static class Config extends DocHtmlPrinter.Config {
-    public Config(boolean ayaFlavored) {
-      this(MdStylist.DEFAULT, ayaFlavored, ayaFlavored, ayaFlavored);
-    }
-
-    public Config(@NotNull MdStylist stylist, boolean withHeader, boolean withStyleDef, boolean ayaFlavored) {
-      super(stylist, withHeader, withStyleDef);
-      set(StyleOptions.AyaFlavored, ayaFlavored);
+    public Config(@NotNull MdStylist stylist) {
+      super(stylist);
     }
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinter.java
@@ -11,6 +11,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.EnumSet;
 
+import static org.aya.pretty.backend.string.StringPrinterConfig.TextOptions.Unicode;
+
 /**
  * The class for all string-output printers.
  *
@@ -126,7 +128,7 @@ public class StringPrinter<Config extends StringPrinterConfig<?>> implements Pri
   );
 
   protected void renderSpecialSymbol(@NotNull Cursor cursor, @NotNull String text, EnumSet<Outer> outer) {
-    if (config.unicode) for (var k : unicodeMapping.keysView()) {
+    if (config.opt(Unicode, false)) for (var k : unicodeMapping.keysView()) {
       if (text.trim().equals(k)) {
         cursor.visibleContent(text.replace(k, unicodeMapping.get(k)));
         return;

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinterConfig.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinterConfig.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.string;
 
@@ -6,10 +6,27 @@ import org.aya.pretty.printer.PrinterConfig;
 import org.jetbrains.annotations.NotNull;
 
 public class StringPrinterConfig<S extends StringStylist> extends PrinterConfig.Basic<S> {
-  public final boolean unicode;
+  public enum TextOptions implements PrinterConfig.Options<Boolean> {
+    Unicode,
+  }
+
+  public enum StyleOptions implements PrinterConfig.Options<Boolean> {
+    ServerSideRendering,
+    AyaFlavored,
+    SeparateStyle,
+    HeaderCode,
+    StyleCode,
+  }
 
   public StringPrinterConfig(@NotNull S stylist, int pageWidth, boolean unicode) {
+    this(stylist, pageWidth, unicode, false, false);
+  }
+
+  public StringPrinterConfig(@NotNull S stylist, int pageWidth, boolean unicode, boolean headerCode, boolean styleCode) {
     super(pageWidth, INFINITE_SIZE, stylist);
-    this.unicode = unicode;
+    set(TextOptions.Unicode, unicode);
+    set(StyleOptions.HeaderCode, headerCode);
+    set(StyleOptions.StyleCode, styleCode);
+    set(StyleOptions.SeparateStyle, styleCode);
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinterConfig.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinterConfig.java
@@ -18,15 +18,7 @@ public class StringPrinterConfig<S extends StringStylist> extends PrinterConfig.
     StyleCode,
   }
 
-  public StringPrinterConfig(@NotNull S stylist, int pageWidth, boolean unicode) {
-    this(stylist, pageWidth, unicode, false, false);
-  }
-
-  public StringPrinterConfig(@NotNull S stylist, int pageWidth, boolean unicode, boolean headerCode, boolean styleCode) {
-    super(pageWidth, INFINITE_SIZE, stylist);
-    set(TextOptions.Unicode, unicode);
-    set(StyleOptions.HeaderCode, headerCode);
-    set(StyleOptions.StyleCode, styleCode);
-    set(StyleOptions.SeparateStyle, styleCode);
+  public StringPrinterConfig(@NotNull S stylist) {
+    super(stylist);
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/terminal/DocTermPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/terminal/DocTermPrinter.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.backend.terminal;
 
@@ -18,8 +18,8 @@ public class DocTermPrinter extends StringPrinter<DocTermPrinter.Config> {
   }
 
   public static class Config extends StringPrinterConfig<UnixTermStylist> {
-    public Config(@NotNull UnixTermStylist stylist, int pageWidth, boolean unicode) {
-      super(stylist, pageWidth, unicode);
+    public Config(@NotNull UnixTermStylist stylist) {
+      super(stylist);
     }
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -73,19 +73,19 @@ public sealed interface Doc extends Docile {
   }
 
   default @NotNull String renderToHtml(boolean withHeader) {
-    return render(new DocHtmlPrinter<>(), new DocHtmlPrinter.Config(withHeader, true));
+    return render(new DocHtmlPrinter<>(), new DocHtmlPrinter.Config(withHeader));
   }
 
   default @NotNull String renderToMd() {
-    return render(new DocMdPrinter(), new DocMdPrinter.Config(false, false, false));
+    return render(new DocMdPrinter(), new DocMdPrinter.Config(false));
   }
 
   default @NotNull String renderToAyaMd() {
-    return render(new DocMdPrinter(), new DocMdPrinter.Config(true, true, true));
+    return render(new DocMdPrinter(), new DocMdPrinter.Config(true));
   }
 
   default @NotNull String renderToTeX() {
-    return render(new DocTeXPrinter(), new DocTeXPrinter.Config(false, false));
+    return render(new DocTeXPrinter(), new DocTeXPrinter.Config());
   }
 
   default <Out, Config extends PrinterConfig>

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -7,8 +7,10 @@ import kala.collection.SeqLike;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
 import org.aya.pretty.backend.html.DocHtmlPrinter;
+import org.aya.pretty.backend.html.Html5Stylist;
 import org.aya.pretty.backend.latex.DocTeXPrinter;
 import org.aya.pretty.backend.md.DocMdPrinter;
+import org.aya.pretty.backend.md.MdStylist;
 import org.aya.pretty.backend.string.DebugStylist;
 import org.aya.pretty.backend.string.StringPrinter;
 import org.aya.pretty.backend.string.StringPrinterConfig;
@@ -52,12 +54,14 @@ public sealed interface Doc extends Docile {
 
   //region Doc APIs
   default @NotNull String renderToString(@NotNull StringPrinterConfig<?> config) {
-    var printer = new StringPrinter<>();
-    return render(printer, config);
+    return render(new StringPrinter<>(), config);
   }
 
   default @NotNull String renderToString(int pageWidth, boolean unicode) {
-    return renderToString(new StringPrinterConfig<>(DebugStylist.DEFAULT, pageWidth, unicode));
+    var config = new StringPrinterConfig<>(DebugStylist.DEFAULT);
+    config.set(PrinterConfig.PageOptions.PageWidth, pageWidth);
+    config.set(StringPrinterConfig.TextOptions.Unicode, unicode);
+    return renderToString(config);
   }
 
   default @NotNull String renderToTerminal() {
@@ -65,7 +69,10 @@ public sealed interface Doc extends Docile {
   }
 
   default @NotNull String renderToTerminal(int pageWidth, boolean unicode) {
-    return render(new DocTermPrinter(), new DocTermPrinter.Config(AdaptiveCliStylist.INSTANCE, pageWidth, unicode));
+    var config = new DocTermPrinter.Config(AdaptiveCliStylist.INSTANCE);
+    config.set(PrinterConfig.PageOptions.PageWidth, pageWidth);
+    config.set(StringPrinterConfig.TextOptions.Unicode, unicode);
+    return render(new DocTermPrinter(), config);
   }
 
   default @NotNull String renderToHtml() {
@@ -73,15 +80,26 @@ public sealed interface Doc extends Docile {
   }
 
   default @NotNull String renderToHtml(boolean withHeader) {
-    return render(new DocHtmlPrinter<>(), new DocHtmlPrinter.Config(withHeader));
+    var config = new DocHtmlPrinter.Config(Html5Stylist.DEFAULT);
+    config.set(StringPrinterConfig.StyleOptions.HeaderCode, withHeader);
+    config.set(StringPrinterConfig.StyleOptions.StyleCode, withHeader);
+    config.set(StringPrinterConfig.StyleOptions.SeparateStyle, withHeader);
+    config.set(StringPrinterConfig.TextOptions.Unicode, true);
+    return render(new DocHtmlPrinter<>(), config);
   }
 
   default @NotNull String renderToMd() {
-    return render(new DocMdPrinter(), new DocMdPrinter.Config(false));
+    return render(new DocMdPrinter(), new DocMdPrinter.Config(MdStylist.DEFAULT));
   }
 
   default @NotNull String renderToAyaMd() {
-    return render(new DocMdPrinter(), new DocMdPrinter.Config(true));
+    var config = new DocMdPrinter.Config(MdStylist.DEFAULT);
+    config.set(StringPrinterConfig.StyleOptions.AyaFlavored, true);
+    config.set(StringPrinterConfig.StyleOptions.HeaderCode, true);
+    config.set(StringPrinterConfig.StyleOptions.StyleCode, true);
+    config.set(StringPrinterConfig.StyleOptions.SeparateStyle, true);
+    config.set(StringPrinterConfig.TextOptions.Unicode, true);
+    return render(new DocMdPrinter(), config);
   }
 
   default @NotNull String renderToTeX() {

--- a/pretty/src/main/java/org/aya/pretty/printer/PrinterConfig.java
+++ b/pretty/src/main/java/org/aya/pretty/printer/PrinterConfig.java
@@ -45,18 +45,18 @@ public interface PrinterConfig {
   interface Options<T> {
   }
 
+  enum PageOptions implements Options<Integer> {
+    PageWidth, PageHeight,
+  }
+
   /**
    * Basic configure for other configs to easily extend config flags.
    */
   class Basic<S extends Stylist> implements PrinterConfig {
     protected final @NotNull MutableMap<Options<?>, Object> options = MutableMap.create();
-    private final int pageWidth;
-    private final int pageHeight;
     private final @NotNull S stylist;
 
-    public Basic(int pageWidth, int pageHeight, @NotNull S stylist) {
-      this.pageWidth = pageWidth;
-      this.pageHeight = pageHeight;
+    public Basic(@NotNull S stylist) {
       this.stylist = stylist;
     }
 
@@ -73,11 +73,11 @@ public interface PrinterConfig {
     }
 
     @Override public int getPageWidth() {
-      return pageWidth;
+      return opt(PageOptions.PageWidth, INFINITE_SIZE);
     }
 
     @Override public int getPageHeight() {
-      return pageHeight;
+      return opt(PageOptions.PageHeight, INFINITE_SIZE);
     }
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/printer/PrinterConfig.java
+++ b/pretty/src/main/java/org/aya/pretty/printer/PrinterConfig.java
@@ -1,7 +1,8 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty.printer;
 
+import kala.collection.mutable.MutableMap;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -41,10 +42,14 @@ public interface PrinterConfig {
 
   @NotNull Stylist getStylist();
 
+  interface Options<T> {
+  }
+
   /**
    * Basic configure for other configs to easily extend config flags.
    */
   class Basic<S extends Stylist> implements PrinterConfig {
+    protected final @NotNull MutableMap<Options<?>, Object> options = MutableMap.create();
     private final int pageWidth;
     private final int pageHeight;
     private final @NotNull S stylist;
@@ -53,6 +58,14 @@ public interface PrinterConfig {
       this.pageWidth = pageWidth;
       this.pageHeight = pageHeight;
       this.stylist = stylist;
+    }
+
+    @SuppressWarnings("unchecked") public @NotNull <T> T opt(@NotNull Options<T> key, @NotNull T defaultValue) {
+      return (T) options.getOrDefault(key, defaultValue);
+    }
+
+    public <T> void set(@NotNull Options<T> key, @NotNull T value) {
+      options.put(key, value);
     }
 
     @Override public @NotNull S getStylist() {


### PR DESCRIPTION
After merging this PR, please add `--pretty-ssr` to [aya-prover-docs](https://github.com/aya-prover/aya-prover-docs/blob/711029dffc6291c51f85756cbc2f7ca3f2fe5516/scripts/build-aya.js#L32).