### PR TITLE
Support LaTeX math formula in literate mode

### DIFF
--- a/base/src/main/java/module-info.java
+++ b/base/src/main/java/module-info.java
@@ -13,6 +13,8 @@ module aya.base {
   exports org.aya.concrete.desugar;
   exports org.aya.concrete.error;
   exports org.aya.concrete.remark;
+  exports org.aya.concrete.remark.code;
+  exports org.aya.concrete.remark.math;
   exports org.aya.concrete.stmt.decl;
   exports org.aya.concrete.stmt;
   exports org.aya.concrete.visitor;

--- a/base/src/main/java/org/aya/concrete/error/OperatorError.java
+++ b/base/src/main/java/org/aya/concrete/error/OperatorError.java
@@ -33,10 +33,10 @@ public interface OperatorError extends Problem {
     public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("Cannot figure out computation order because"),
-        Doc.code(Doc.plain(op1)),
+        Doc.code(op1),
         Doc.parened(Doc.plain(assoc1.name())),
         Doc.plain("and"),
-        Doc.code(Doc.plain(op2)),
+        Doc.code(op2),
         Doc.parened(Doc.plain(assoc1.name())),
         reason()
       );
@@ -61,9 +61,9 @@ public interface OperatorError extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("Ambiguous operator precedence detected between"),
-        Doc.code(Doc.plain(op1)),
+        Doc.code(op1),
         Doc.plain("and"),
-        Doc.code(Doc.plain(op2))
+        Doc.code(op2)
       );
     }
 

--- a/base/src/main/java/org/aya/concrete/remark/CodeOptions.java
+++ b/base/src/main/java/org/aya/concrete/remark/CodeOptions.java
@@ -20,7 +20,7 @@ public record CodeOptions(
   public static @NotNull Literate analyze(@NotNull Code code, @NotNull SourcePos sourcePos) {
     return switch (code.getFirstChild()) {
       case CodeAttrProcessor.Attr attr -> new Literate.Code(code.getLiteral(), sourcePos, attr.options);
-      default -> new Literate.Raw(Doc.code(code.getLiteral()));
+      case default, null -> new Literate.Raw(Doc.code(code.getLiteral()));
     };
   }
 

--- a/base/src/main/java/org/aya/concrete/remark/CodeOptions.java
+++ b/base/src/main/java/org/aya/concrete/remark/CodeOptions.java
@@ -3,7 +3,6 @@
 package org.aya.concrete.remark;
 
 import org.aya.generic.util.NormalizeMode;
-import org.aya.prettier.AyaPrettierOptions;
 import org.aya.pretty.doc.Doc;
 import org.aya.util.error.SourcePos;
 import org.aya.util.prettier.PrettierOptions;
@@ -18,14 +17,11 @@ public record CodeOptions(
   @NotNull PrettierOptions options,
   @NotNull ShowCode showCode
 ) {
-  public static final @NotNull CodeOptions DEFAULT =
-    new CodeOptions(NormalizeMode.NULL, AyaPrettierOptions.pretty(), ShowCode.Core);
-
   public static @NotNull Literate analyze(@NotNull Code code, @NotNull SourcePos sourcePos) {
-    if (code.getFirstChild() instanceof CodeAttrProcessor.Attr attr) {
-      return new Literate.Code(code.getLiteral(), sourcePos, attr.options);
-    } else return new Literate.Raw(Doc.code("", Doc.plain(code.getLiteral())));
-    // ^ should not use `Doc.code()` because it assumes valid aya code.
+    return switch (code.getFirstChild()) {
+      case CodeAttrProcessor.Attr attr -> new Literate.Code(code.getLiteral(), sourcePos, attr.options);
+      default -> new Literate.Raw(Doc.code(code.getLiteral()));
+    };
   }
 
   public enum ShowCode {

--- a/base/src/main/java/org/aya/concrete/remark/Literate.java
+++ b/base/src/main/java/org/aya/concrete/remark/Literate.java
@@ -7,10 +7,7 @@ import kala.value.MutableValue;
 import org.aya.concrete.Expr;
 import org.aya.core.def.UserDef;
 import org.aya.prettier.AyaPrettierOptions;
-import org.aya.pretty.doc.Doc;
-import org.aya.pretty.doc.Docile;
-import org.aya.pretty.doc.Link;
-import org.aya.pretty.doc.Style;
+import org.aya.pretty.doc.*;
 import org.aya.ref.AnyVar;
 import org.aya.ref.DefVar;
 import org.aya.tyck.Result;
@@ -131,7 +128,7 @@ public sealed interface Literate extends Docile {
     @Override public @NotNull Doc toDoc() {
       if (language.equalsIgnoreCase("aya-hidden")) return Doc.empty();
       var doc = isAya() && highlighted != null ? highlighted : Doc.plain(raw);
-      return Doc.codeBlock(language, doc);
+      return Doc.codeBlock(Language.of(language), doc);
     }
   }
 

--- a/base/src/main/java/org/aya/concrete/remark/Literate.java
+++ b/base/src/main/java/org/aya/concrete/remark/Literate.java
@@ -45,6 +45,13 @@ public sealed interface Literate extends Docile {
     }
   }
 
+  record Math(boolean inline, @NotNull ImmutableSeq<Literate> children) implements Literate {
+    @Override public @NotNull Doc toDoc() {
+      var child = Doc.cat(this.children().map(Literate::toDoc));
+      return inline ? Doc.math(child) : Doc.mathBlock(child);
+    }
+  }
+
   record Many(@Nullable Style style, @NotNull ImmutableSeq<Literate> children) implements Literate {
     @Override public @NotNull Doc toDoc() {
       var child = Doc.cat(this.children().map(Literate::toDoc));

--- a/base/src/main/java/org/aya/concrete/remark/Literate.java
+++ b/base/src/main/java/org/aya/concrete/remark/Literate.java
@@ -5,6 +5,7 @@ package org.aya.concrete.remark;
 import kala.collection.immutable.ImmutableSeq;
 import kala.value.MutableValue;
 import org.aya.concrete.Expr;
+import org.aya.concrete.remark.code.CodeOptions;
 import org.aya.core.def.UserDef;
 import org.aya.prettier.AyaPrettierOptions;
 import org.aya.pretty.doc.*;

--- a/base/src/main/java/org/aya/concrete/remark/Literate.java
+++ b/base/src/main/java/org/aya/concrete/remark/Literate.java
@@ -88,11 +88,11 @@ public sealed interface Literate extends Docile {
 
     @Override public @NotNull Doc toDoc() {
       if (tyckResult == null) {
-        if (expr != null) return Doc.code(expr.toDoc(options.options()));
+        if (expr != null) return Doc.code(Language.Builtin.Aya, expr.toDoc(options.options()));
         else return Doc.code("Error");
       }
       assert expr != null;
-      return Doc.code((switch (options.showCode()) {
+      return Doc.code(Language.Builtin.Aya, (switch (options.showCode()) {
         case Concrete -> expr;
         case Core -> tyckResult.wellTyped();
         case Type -> tyckResult.type();

--- a/base/src/main/java/org/aya/concrete/remark/code/CodeAttrProcessor.java
+++ b/base/src/main/java/org/aya/concrete/remark/code/CodeAttrProcessor.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
-package org.aya.concrete.remark;
+package org.aya.concrete.remark.code;
 
 import com.intellij.openapi.util.text.StringUtil;
 import kala.collection.mutable.MutableList;

--- a/base/src/main/java/org/aya/concrete/remark/code/CodeOptions.java
+++ b/base/src/main/java/org/aya/concrete/remark/code/CodeOptions.java
@@ -1,7 +1,8 @@
 // Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
-package org.aya.concrete.remark;
+package org.aya.concrete.remark.code;
 
+import org.aya.concrete.remark.Literate;
 import org.aya.generic.util.NormalizeMode;
 import org.aya.pretty.doc.Doc;
 import org.aya.util.error.SourcePos;

--- a/base/src/main/java/org/aya/concrete/remark/code/CodeOptions.java
+++ b/base/src/main/java/org/aya/concrete/remark/code/CodeOptions.java
@@ -5,6 +5,7 @@ package org.aya.concrete.remark.code;
 import org.aya.concrete.remark.Literate;
 import org.aya.generic.util.NormalizeMode;
 import org.aya.pretty.doc.Doc;
+import org.aya.pretty.doc.Language;
 import org.aya.util.error.SourcePos;
 import org.aya.util.prettier.PrettierOptions;
 import org.commonmark.node.Code;
@@ -21,7 +22,7 @@ public record CodeOptions(
   public static @NotNull Literate analyze(@NotNull Code code, @NotNull SourcePos sourcePos) {
     return switch (code.getFirstChild()) {
       case CodeAttrProcessor.Attr attr -> new Literate.Code(code.getLiteral(), sourcePos, attr.options);
-      case default, null -> new Literate.Raw(Doc.code(code.getLiteral()));
+      case default, null -> new Literate.Raw(Doc.code(Language.Builtin.Plain, Doc.plain(code.getLiteral())));
     };
   }
 

--- a/base/src/main/java/org/aya/concrete/remark/math/InlineMath.java
+++ b/base/src/main/java/org/aya/concrete/remark/math/InlineMath.java
@@ -1,0 +1,64 @@
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.concrete.remark.math;
+
+import org.commonmark.node.CustomNode;
+import org.commonmark.node.Delimited;
+import org.commonmark.node.Nodes;
+import org.commonmark.node.SourceSpans;
+import org.commonmark.parser.delimiter.DelimiterProcessor;
+import org.commonmark.parser.delimiter.DelimiterRun;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * see: <a href="https://github.com/commonmark/commonmark-java/blob/main/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/Strikethrough.java">...</a>
+ */
+public class InlineMath extends CustomNode implements Delimited {
+  private static final @NotNull String DELIMITER = "$";
+
+  @Override public @NotNull String getOpeningDelimiter() {
+    return DELIMITER;
+  }
+
+  @Override public @NotNull String getClosingDelimiter() {
+    return DELIMITER;
+  }
+
+  public enum Processor implements DelimiterProcessor {
+    INSTANCE;
+
+    @Override public char getOpeningCharacter() {
+      return '$';
+    }
+
+    @Override public char getClosingCharacter() {
+      return '$';
+    }
+
+    @Override public int getMinLength() {
+      return 1;
+    }
+
+    @Override public int process(@NotNull DelimiterRun openingRun, @NotNull DelimiterRun closingRun) {
+      if (openingRun.length() == closingRun.length() && openingRun.length() == getMinLength()) {
+        var opener = openingRun.getOpener();
+        // Wrap nodes between delimiters in the node.
+        var math = new InlineMath();
+
+        var sourceSpans = new SourceSpans();
+        sourceSpans.addAllFrom(openingRun.getOpeners(openingRun.length()));
+        for (var node : Nodes.between(opener, closingRun.getCloser())) {
+          math.appendChild(node);
+          sourceSpans.addAll(node.getSourceSpans());
+        }
+        sourceSpans.addAllFrom(closingRun.getClosers(closingRun.length()));
+        math.setSourceSpans(sourceSpans.getSourceSpans());
+
+        opener.insertAfter(math);
+        return openingRun.length();
+      } else {
+        return 0;
+      }
+    }
+  }
+}

--- a/base/src/main/java/org/aya/concrete/remark/math/MathBlock.java
+++ b/base/src/main/java/org/aya/concrete/remark/math/MathBlock.java
@@ -5,7 +5,6 @@ package org.aya.concrete.remark.math;
 import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.Block;
 import org.commonmark.node.CustomBlock;
-import org.commonmark.parser.Parser;
 import org.commonmark.parser.SourceLine;
 import org.commonmark.parser.block.*;
 import org.jetbrains.annotations.NotNull;
@@ -22,24 +21,15 @@ public class MathBlock extends CustomBlock {
   public String literal;
 
   /**
-   * see: <a href="https://github.com/commonmark/commonmark-java/blob/main/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/YamlFrontMatterExtension.java">...</a>
-   */
-  public static class Extension implements Parser.ParserExtension {
-    @Override public void extend(Parser.Builder parserBuilder) {
-      parserBuilder.customBlockParserFactory(new Processor.Factory());
-    }
-  }
-
-  /**
    * @see org.commonmark.internal.FencedCodeBlockParser
    */
-  public static class Processor extends AbstractBlockParser {
+  public static class Parser extends AbstractBlockParser {
     private final @NotNull MathBlock block = new MathBlock();
 
     private @Nullable String firstLine;
     private final @NotNull StringBuilder otherLines = new StringBuilder();
 
-    public Processor(char fenceChar, int fenceLength, int fenceIndent) {
+    public Parser(char fenceChar, int fenceLength, int fenceIndent) {
       block.fenceChar = fenceChar;
       block.fenceLength = fenceLength;
       block.fenceIndent = fenceIndent;
@@ -81,32 +71,6 @@ public class MathBlock extends CustomBlock {
       block.literal = otherLines.toString();
     }
 
-    public static class Factory extends AbstractBlockParserFactory {
-      @Override public @Nullable BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
-        int indent = state.getIndent();
-        if (indent >= Parsing.CODE_BLOCK_INDENT) {
-          return BlockStart.none();
-        }
-
-        int nextNonSpace = state.getNextNonSpaceIndex();
-        var blockParser = checkOpener(state.getLine().getContent(), nextNonSpace, indent);
-        if (blockParser != null) {
-          return BlockStart.of(blockParser).atIndex(nextNonSpace + blockParser.block.fenceLength);
-        } else {
-          return BlockStart.none();
-        }
-      }
-    }
-
-    private static @Nullable MathBlock.Processor checkOpener(CharSequence line, int index, int indent) {
-      int backticks = 0;
-      for (int i = index; i < line.length(); i++) {
-        if (line.charAt(i) == '$') backticks++;
-        else break;
-      }
-      return backticks == 2 ? new Processor('$', backticks, indent) : null;
-    }
-
     // spec: The content of the code block consists of all subsequent lines, until a closing code fence of the same type
     // as the code block began with (backticks or tildes), and with at least as many backticks or tildes as the opening
     // code fence.
@@ -121,5 +85,33 @@ public class MathBlock extends CustomBlock {
       int after = Parsing.skipSpaceTab(line, index + fences, line.length());
       return after == line.length();
     }
+  }
+
+  public static class Factory extends AbstractBlockParserFactory {
+    public static final @NotNull Factory INSTANCE = new Factory();
+
+    @Override public @Nullable BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
+      int indent = state.getIndent();
+      if (indent >= Parsing.CODE_BLOCK_INDENT) {
+        return BlockStart.none();
+      }
+
+      int nextNonSpace = state.getNextNonSpaceIndex();
+      var blockParser = checkOpener(state.getLine().getContent(), nextNonSpace, indent);
+      if (blockParser != null) {
+        return BlockStart.of(blockParser).atIndex(nextNonSpace + blockParser.block.fenceLength);
+      } else {
+        return BlockStart.none();
+      }
+    }
+  }
+
+  private static @Nullable MathBlock.Parser checkOpener(CharSequence line, int index, int indent) {
+    int backticks = 0;
+    for (int i = index; i < line.length(); i++) {
+      if (line.charAt(i) == '$') backticks++;
+      else break;
+    }
+    return backticks == 2 ? new Parser('$', backticks, indent) : null;
   }
 }

--- a/base/src/main/java/org/aya/concrete/remark/math/MathBlock.java
+++ b/base/src/main/java/org/aya/concrete/remark/math/MathBlock.java
@@ -1,0 +1,125 @@
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.concrete.remark.math;
+
+import org.commonmark.internal.util.Parsing;
+import org.commonmark.node.Block;
+import org.commonmark.node.CustomBlock;
+import org.commonmark.parser.Parser;
+import org.commonmark.parser.SourceLine;
+import org.commonmark.parser.block.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @see org.commonmark.node.FencedCodeBlock
+ */
+public class MathBlock extends CustomBlock {
+  public char fenceChar;
+  public int fenceLength;
+  public int fenceIndent;
+
+  public String literal;
+
+  /**
+   * see: <a href="https://github.com/commonmark/commonmark-java/blob/main/commonmark-ext-yaml-front-matter/src/main/java/org/commonmark/ext/front/matter/YamlFrontMatterExtension.java">...</a>
+   */
+  public static class Extension implements Parser.ParserExtension {
+    @Override public void extend(Parser.Builder parserBuilder) {
+      parserBuilder.customBlockParserFactory(new Processor.Factory());
+    }
+  }
+
+  /**
+   * @see org.commonmark.internal.FencedCodeBlockParser
+   */
+  public static class Processor extends AbstractBlockParser {
+    private final @NotNull MathBlock block = new MathBlock();
+
+    private @Nullable String firstLine;
+    private final @NotNull StringBuilder otherLines = new StringBuilder();
+
+    public Processor(char fenceChar, int fenceLength, int fenceIndent) {
+      block.fenceChar = fenceChar;
+      block.fenceLength = fenceLength;
+      block.fenceIndent = fenceIndent;
+    }
+
+    @Override public Block getBlock() {
+      return block;
+    }
+
+    @Override public BlockContinue tryContinue(ParserState state) {
+      int nextNonSpace = state.getNextNonSpaceIndex();
+      int newIndex = state.getIndex();
+      var line = state.getLine().getContent();
+      if (state.getIndent() < Parsing.CODE_BLOCK_INDENT && nextNonSpace < line.length() && line.charAt(nextNonSpace) == block.fenceChar && isClosing(line, nextNonSpace)) {
+        // closing fence - we're at the end of line, so we can finalize now
+        return BlockContinue.finished();
+      } else {
+        // skip optional spaces of fence indent
+        int i = block.fenceIndent;
+        int length = line.length();
+        while (i > 0 && newIndex < length && line.charAt(newIndex) == ' ') {
+          newIndex++;
+          i--;
+        }
+      }
+      return BlockContinue.atIndex(newIndex);
+    }
+
+    @Override public void addLine(SourceLine line) {
+      if (firstLine == null) {
+        firstLine = line.getContent().toString();
+      } else {
+        otherLines.append(line.getContent());
+        otherLines.append('\n');
+      }
+    }
+
+    @Override public void closeBlock() {
+      block.literal = otherLines.toString();
+    }
+
+    public static class Factory extends AbstractBlockParserFactory {
+      @Override public @Nullable BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
+        int indent = state.getIndent();
+        if (indent >= Parsing.CODE_BLOCK_INDENT) {
+          return BlockStart.none();
+        }
+
+        int nextNonSpace = state.getNextNonSpaceIndex();
+        var blockParser = checkOpener(state.getLine().getContent(), nextNonSpace, indent);
+        if (blockParser != null) {
+          return BlockStart.of(blockParser).atIndex(nextNonSpace + blockParser.block.fenceLength);
+        } else {
+          return BlockStart.none();
+        }
+      }
+    }
+
+    private static @Nullable MathBlock.Processor checkOpener(CharSequence line, int index, int indent) {
+      int backticks = 0;
+      for (int i = index; i < line.length(); i++) {
+        if (line.charAt(i) == '$') backticks++;
+        else break;
+      }
+      return backticks == 2 ? new Processor('$', backticks, indent) : null;
+    }
+
+    // spec: The content of the code block consists of all subsequent lines, until a closing code fence of the same type
+    // as the code block began with (backticks or tildes), and with at least as many backticks or tildes as the opening
+    // code fence.
+    private boolean isClosing(CharSequence line, int index) {
+      char fenceChar = block.fenceChar;
+      int fenceLength = block.fenceLength;
+      int fences = Parsing.skip(fenceChar, line, index, line.length()) - index;
+      if (fences < fenceLength) {
+        return false;
+      }
+      // spec: The closing code fence [...] may be followed only by spaces, which are ignored.
+      int after = Parsing.skipSpaceTab(line, index + fences, line.length());
+      return after == line.length();
+    }
+  }
+}

--- a/base/src/main/java/org/aya/resolve/error/NameProblem.java
+++ b/base/src/main/java/org/aya/resolve/error/NameProblem.java
@@ -35,7 +35,7 @@ public interface NameProblem extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.vcat(Doc.sep(
           Doc.english("The unqualified name"),
-          Doc.code(Doc.plain(name)),
+          Doc.code(name),
           Doc.english("is ambiguous")),
         Doc.english("Did you mean:"),
         Doc.nest(2, Doc.vcat(didYouMean().map(Doc::code))));
@@ -53,7 +53,7 @@ public interface NameProblem extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.vcat(Doc.sep(
         Doc.english("The name"),
-        Doc.code(Doc.plain(name)),
+        Doc.code(name),
         Doc.english("introduces ambiguity and can only be accessed through a qualified name")));
     }
   }
@@ -65,7 +65,7 @@ public interface NameProblem extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("The name"),
-        Doc.code(Doc.plain(name)),
+        Doc.code(name),
         Doc.english("being exported clashes with another exported definition with the same name"));
     }
 
@@ -81,7 +81,7 @@ public interface NameProblem extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("The module name"),
-        Doc.code(Doc.plain(modName.toString())),
+        Doc.code(modName.toString()),
         Doc.english("is already defined elsewhere")
       );
     }
@@ -123,7 +123,7 @@ public interface NameProblem extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("The module name"),
-        Doc.code(Doc.plain(modName.toString())),
+        Doc.code(modName.toString()),
         Doc.english("is not defined in the current scope")
       );
     }
@@ -136,7 +136,7 @@ public interface NameProblem extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("The module name"),
-        Doc.code(Doc.plain(path.toString())),
+        Doc.code(path.toString()),
         Doc.english("is not found")
       );
     }
@@ -149,7 +149,7 @@ public interface NameProblem extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("The module name"),
-        Doc.code(Doc.plain(modName.toString())),
+        Doc.code(modName.toString()),
         Doc.english("shadows a previous definition from outer scope")
       );
     }
@@ -161,7 +161,7 @@ public interface NameProblem extends Problem {
   ) implements NameProblem.Warn {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(Doc.english("The name"),
-        Doc.code(Doc.plain(name)),
+        Doc.code(name),
         Doc.english("shadows a previous local definition from outer scope")
       );
     }
@@ -175,7 +175,7 @@ public interface NameProblem extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("The qualified name"),
-        Doc.code(Doc.plain(modName.resolve(name).toString())),
+        Doc.code(modName.resolve(name).toString()),
         Doc.english("is not defined in the current scope")
       );
     }
@@ -189,7 +189,7 @@ public interface NameProblem extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       var head = Doc.sep(
         Doc.english("The name"),
-        Doc.code(Doc.plain(name)),
+        Doc.code(name),
         Doc.english("is not defined in the current scope"));
       var possible = didYouMean();
       if (possible.isEmpty()) return head;
@@ -221,7 +221,7 @@ public interface NameProblem extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("Unknown operator"),
-        Doc.code(Doc.plain(name)),
+        Doc.code(name),
         Doc.english("used in bind statement")
       );
     }

--- a/base/src/main/java/org/aya/resolve/error/PrimResolveError.java
+++ b/base/src/main/java/org/aya/resolve/error/PrimResolveError.java
@@ -21,7 +21,7 @@ public interface PrimResolveError extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("Unknown primitive"),
-        Doc.code(Doc.plain(name)));
+        Doc.code(name));
     }
   }
 
@@ -31,7 +31,7 @@ public interface PrimResolveError extends Problem {
   ) implements PrimResolveError {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(Doc.english("Redefinition of primitive"),
-        Doc.code(Doc.plain(name)));
+        Doc.code(name));
     }
   }
 
@@ -46,9 +46,9 @@ public interface PrimResolveError extends Problem {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       assert lack.isNotEmpty();
       return Doc.sep(
-        Doc.english("The primitive"), Doc.code(Doc.plain(name)),
+        Doc.english("The primitive"), Doc.code(name),
         Doc.english("depends on undeclared primitive(s):"),
-        Doc.commaList(lack.map(name -> Doc.code(Doc.plain(name.id)))));
+        Doc.commaList(lack.map(name -> Doc.code(name.id))));
     }
   }
 
@@ -58,13 +58,13 @@ public interface PrimResolveError extends Problem {
   ) implements PrimResolveError {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(Doc.english("The primitive"),
-        Doc.code(Doc.plain(name)),
+        Doc.code(name),
         Doc.english("is not designed to be used as a function"));
     }
 
     @Override public @NotNull Doc hint(@NotNull PrettierOptions options) {
       return Doc.sep(Doc.english("Use the projection syntax instead, like:"),
-        Doc.code(Doc.plain("." + name)));
+        Doc.code("." + name));
     }
   }
 }

--- a/base/src/main/java/org/aya/tyck/error/BadTypeError.java
+++ b/base/src/main/java/org/aya/tyck/error/BadTypeError.java
@@ -67,7 +67,7 @@ public record BadTypeError(
 
   public static @NotNull BadTypeError structAcc(@NotNull TyckState state, @NotNull Expr expr, @NotNull String fieldName, @NotNull Term actualType) {
     return new BadTypeError(expr, actualType,
-      Doc.sep(Doc.english("access field"), Doc.code(Doc.plain(fieldName)), Doc.plain("of")),
+      Doc.sep(Doc.english("access field"), Doc.code(fieldName), Doc.plain("of")),
       Doc.english("of what you accessed"),
       options -> Doc.english("struct type"),
       state);
@@ -75,7 +75,7 @@ public record BadTypeError(
 
   public static @NotNull BadTypeError projPropStruct(@NotNull TyckState state, @NotNull Expr expr, @NotNull String fieldName, @NotNull Term actualType) {
     return new BadTypeError(expr, actualType,
-      Doc.sep(Doc.english("access field"), Doc.code(Doc.plain(fieldName)), Doc.plain("of")),
+      Doc.sep(Doc.english("access field"), Doc.code(fieldName), Doc.plain("of")),
       Doc.english("of what you accessed"),
       options -> Doc.english("non-Prop struct type"),
       state);

--- a/base/src/main/java/org/aya/tyck/error/FieldError.java
+++ b/base/src/main/java/org/aya/tyck/error/FieldError.java
@@ -29,8 +29,7 @@ public sealed interface FieldError extends TyckError {
   ) implements FieldError {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(Doc.english("No such field(s):"),
-        Doc.commaList(notFound.view()
-          .map(m -> Doc.code(Doc.plain(m))))
+        Doc.commaList(notFound.view().map(Doc::code))
       );
     }
   }
@@ -42,7 +41,7 @@ public sealed interface FieldError extends TyckError {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
       return Doc.sep(
         Doc.english("Unknown field"),
-        Doc.code(Doc.plain(name)),
+        Doc.code(name),
         Doc.english("projected")
       );
     }

--- a/base/src/test/java/org/aya/literate/AyaMdParserTest.java
+++ b/base/src/test/java/org/aya/literate/AyaMdParserTest.java
@@ -40,31 +40,17 @@ public class AyaMdParserTest {
     public final static @NotNull String PREFIX_EXPECTED = "expected-";
     public final static @NotNull String EXTENSION_AYA_MD = Constants.AYA_LITERATE_POSTFIX;
     public final static @NotNull String EXTENSION_AYA = Constants.AYA_POSTFIX;
-    public final static @NotNull String EXTENSION_HTML = EXTENSION_AYA_MD + ".html";
+    public final static @NotNull String EXTENSION_HTML = ".html";
     public final static @NotNull String EXTENSION_TEX = ".tex";
-
-    public @NotNull String mdName() {
-      return modName + EXTENSION_AYA_MD;
-    }
+    public final static @NotNull String EXTENSION_PLAIN_TEXT = ".txt";
+    public final static @NotNull String EXTENSION_OUT_MD = ".out.md";
 
     public @NotNull String ayaName() {
       return modName + EXTENSION_AYA;
     }
 
-    public @NotNull String expectedAyaName() {
-      return PREFIX_EXPECTED + ayaName();
-    }
-
-    public @NotNull String htmlName() {
-      return modName + EXTENSION_HTML;
-    }
-
-    public @NotNull String texName() {
-      return modName + EXTENSION_TEX;
-    }
-
     public @NotNull Path mdFile() {
-      return TEST_DIR.resolve(mdName());
+      return TEST_DIR.resolve(modName + EXTENSION_AYA_MD);
     }
 
     public @NotNull Path ayaFile() {
@@ -72,19 +58,23 @@ public class AyaMdParserTest {
     }
 
     public @NotNull Path expectedAyaFile() {
-      return TEST_DIR.resolve(expectedAyaName());
+      return TEST_DIR.resolve(PREFIX_EXPECTED + ayaName());
     }
 
     public @NotNull Path htmlFile() {
-      return TEST_DIR.resolve(htmlName());
+      return TEST_DIR.resolve(modName + EXTENSION_HTML);
     }
 
     public @NotNull Path outMdFile() {
-      return TEST_DIR.resolve(htmlName() + ".out.md");
+      return TEST_DIR.resolve(modName + EXTENSION_OUT_MD);
     }
 
     public @NotNull Path texFile() {
-      return TEST_DIR.resolve(texName());
+      return TEST_DIR.resolve(modName + EXTENSION_TEX);
+    }
+
+    public @NotNull Path plainTextFile() {
+      return TEST_DIR.resolve(modName + EXTENSION_PLAIN_TEXT);
     }
   }
 
@@ -135,6 +125,7 @@ public class AyaMdParserTest {
     Files.writeString(oneCase.htmlFile(), doc.renderToHtml());
     Files.writeString(oneCase.outMdFile(), expectedMd);
     Files.writeString(oneCase.texFile(), actualTexInlinedStyle);
+    Files.writeString(oneCase.plainTextFile(), doc.debugRender());
 
     // test single file compiler
     var compiler = new SingleFileCompiler(AyaThrowingReporter.INSTANCE, null, null);

--- a/base/src/test/resources/literate/.gitignore
+++ b/base/src/test/resources/literate/.gitignore
@@ -3,3 +3,4 @@
 *.html
 *.out.md
 *.tex
+*.txt

--- a/base/src/test/resources/literate/syntax.aya.md
+++ b/base/src/test/resources/literate/syntax.aya.md
@@ -21,3 +21,13 @@ For the following `code block`, you'll never see it:
 ```aya-hidden
 example def foo => justId
 ```
+
+This is a math block, and it is saying $\frac{1}{2} = \frac{1}{2}$:
+
+$$
+\begin{align*}
+  \frac{1}{2} &= \frac{1}{2} \\
+  \frac{1}{2} &= \frac{1}{2} \\
+  \frac{1}{2} &= \frac{1}{2} \\
+\end{align*}
+$$

--- a/base/src/test/resources/literate/syntax.aya.md
+++ b/base/src/test/resources/literate/syntax.aya.md
@@ -22,6 +22,17 @@ For the following `code block`, you'll never see it:
 example def foo => justId
 ```
 
+The following code block will not be highlighted, since Aya
+don't know how to type check a [Java](https://jdk.java.net/) program:
+
+```java
+public class Main {
+  public static void main(String[] args) {
+    System.out.println("hello");
+  }
+}
+```
+
 This is a math block, and it is saying $\frac{1}{2} = \frac{1}{2}$:
 
 $$

--- a/cli-impl/src/main/java/org/aya/cli/literate/AyaMdParser.java
+++ b/cli-impl/src/main/java/org/aya/cli/literate/AyaMdParser.java
@@ -6,7 +6,10 @@ import kala.collection.Seq;
 import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
+import kala.tuple.Tuple;
+import kala.tuple.Tuple2;
 import kala.tuple.primitive.IntObjTuple2;
+import kala.value.LazyValue;
 import kala.value.MutableValue;
 import org.aya.concrete.remark.Literate;
 import org.aya.concrete.remark.LiterateConsumer;
@@ -107,6 +110,18 @@ public class AyaMdParser {
     return children.toImmutableSeq();
   }
 
+  private @NotNull Tuple2<LazyValue<SourcePos>, String> stripTrailingNewline(@NotNull String literal, @NotNull Block owner) {
+    var spans = owner.getSourceSpans();
+    if (spans != null && spans.size() >= 2) {   // always contains '```aya' and '```'
+      var inner = ImmutableSeq.from(spans).view().drop(1).dropLast(1).toImmutableSeq();
+      // remove the last line break if not empty
+      if (!literal.isEmpty())
+        literal = literal.substring(0, literal.length() - 1);
+      return Tuple.of(LazyValue.of(() -> fromSourceSpans(inner)), literal);
+    }
+    throw new InternalException("SourceSpans");
+  }
+
   private @NotNull Literate mapAST(@NotNull Node node) {
     return switch (node) {
       case Text text -> new Literate.Raw(Doc.plain(text.getLiteral()));
@@ -128,19 +143,15 @@ public class AyaMdParser {
       case Document d -> flatten(mapChildren(d));
       case HtmlBlock html when html.getLiteral().startsWith("<!--") -> new Literate.Raw(Doc.empty());
       case ThematicBreak t -> new Literate.Many(MdStyle.GFM.ThematicBreak, mapChildren(t));
-      case MathBlock math -> new Literate.Math(false, ImmutableSeq.of(new Literate.Raw(Doc.plain(math.literal))));
       case InlineMath math -> new Literate.Math(true, mapChildren(math));
+      case MathBlock math -> {
+        var formula = stripTrailingNewline(math.literal, math).component2();
+        yield new Literate.Math(false, ImmutableSeq.of(new Literate.Raw(Doc.plain(formula))));
+      }
       case FencedCodeBlock codeBlock -> {
         var language = codeBlock.getInfo();
-        var raw = codeBlock.getLiteral();
-        var spans = codeBlock.getSourceSpans();
-        if (spans != null && spans.size() >= 2) {   // always contains '```aya' and '```'
-          var inner = ImmutableSeq.from(spans).view().drop(1).dropLast(1).toImmutableSeq();
-          // remove the last line break if not empty
-          if (!raw.isEmpty()) raw = raw.substring(0, raw.length() - 1);
-          yield new Literate.CodeBlock(fromSourceSpans(inner), language, raw);
-        }
-        throw new InternalException("SourceSpans");
+        var code = stripTrailingNewline(codeBlock.getLiteral(), codeBlock);
+        yield new Literate.CodeBlock(code.component1().get(), language, code.component2());
       }
       case Code inlineCode -> {
         var spans = inlineCode.getSourceSpans();

--- a/cli-impl/src/main/java/org/aya/cli/literate/AyaMdParser.java
+++ b/cli-impl/src/main/java/org/aya/cli/literate/AyaMdParser.java
@@ -8,7 +8,12 @@ import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
 import kala.tuple.primitive.IntObjTuple2;
 import kala.value.MutableValue;
-import org.aya.concrete.remark.*;
+import org.aya.concrete.remark.Literate;
+import org.aya.concrete.remark.LiterateConsumer;
+import org.aya.concrete.remark.UnsupportedMarkdown;
+import org.aya.concrete.remark.code.CodeAttrProcessor;
+import org.aya.concrete.remark.code.CodeOptions;
+import org.aya.concrete.remark.math.MathBlock;
 import org.aya.generic.util.InternalException;
 import org.aya.pretty.backend.md.MdStyle;
 import org.aya.pretty.doc.Doc;
@@ -39,6 +44,7 @@ public class AyaMdParser {
 
   public @NotNull Literate parseLiterate() {
     var parser = Parser.builder()
+      .extensions(ImmutableSeq.of(new MathBlock.Extension()))
       .customDelimiterProcessor(CodeAttrProcessor.INSTANCE)
       .includeSourceSpans(IncludeSourceSpans.BLOCKS_AND_INLINES)
       .postProcessor(FillCodeBlock.INSTANCE)
@@ -143,6 +149,11 @@ public class AyaMdParser {
           yield CodeOptions.analyze(inlineCode, sourcePos);
         }
         throw new InternalException("SourceSpans");
+      }
+      case MathBlock math -> {
+        // TODO: improve
+        var fence = Doc.plain("$".repeat(math.fenceLength));
+        yield new Literate.Raw(Doc.cat(fence, Doc.line(), Doc.escaped(math.literal), fence));
       }
       default -> {
         var spans = node.getSourceSpans();

--- a/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
+++ b/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
@@ -26,7 +26,7 @@ public class RenderOptionsTest {
     assertEquals("`hello'", opt.render(RenderOptions.OutputTarget.Unix, doc, opts));
     assertEquals("\\texttt{hello}", opt.render(RenderOptions.OutputTarget.LaTeX, doc, opts));
     assertEquals("\\texttt{hello}", opt.render(RenderOptions.OutputTarget.KaTeX, doc, opts));
-    assertEquals("<code class=\"Aya\">hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, opts));
+    assertEquals("<code>hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, opts));
     assertEquals("`hello`", opt.render(RenderOptions.OutputTarget.Plain, doc, opts));
   }
 }

--- a/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
+++ b/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
@@ -26,7 +26,7 @@ public class RenderOptionsTest {
     assertEquals("`hello'", opt.render(RenderOptions.OutputTarget.Unix, doc, opts));
     assertEquals("\\texttt{hello}", opt.render(RenderOptions.OutputTarget.LaTeX, doc, opts));
     assertEquals("\\texttt{hello}", opt.render(RenderOptions.OutputTarget.KaTeX, doc, opts));
-    assertEquals("<code>hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, opts));
+    assertEquals("<code class=\"\">hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, opts));
     assertEquals("`hello`", opt.render(RenderOptions.OutputTarget.Plain, doc, opts));
   }
 }

--- a/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
+++ b/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
@@ -26,7 +26,7 @@ public class RenderOptionsTest {
     assertEquals("`hello'", opt.render(RenderOptions.OutputTarget.Unix, doc, opts));
     assertEquals("\\texttt{hello}", opt.render(RenderOptions.OutputTarget.LaTeX, doc, opts));
     assertEquals("\\texttt{hello}", opt.render(RenderOptions.OutputTarget.KaTeX, doc, opts));
-    assertEquals("<code class=\"\">hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, opts));
+    assertEquals("<code class=\"Aya\">hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, opts));
     assertEquals("`hello`", opt.render(RenderOptions.OutputTarget.Plain, doc, opts));
   }
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
@@ -27,7 +27,7 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
     <title>Aya file</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    """ + HtmlConstants.HOVER_ALL_OCCURS + HtmlConstants.HOVER_STYLE + HtmlConstants.HOVER_POPUP_STYLE;
+    """ + HtmlConstants.HOVER_STYLE + HtmlConstants.HOVER_POPUP_STYLE;
 
   /**
    * <a href="https://developer.mozilla.org/en-US/docs/Glossary/Entity">Mozilla doc: entity</a>
@@ -45,6 +45,13 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
   @Override protected void renderHeader(@NotNull Cursor cursor) {
     if (config.opt(HeaderCode, false)) {
       cursor.invisibleContent(HEAD);
+      if (config.opt(ServerSideRendering, false)) {
+        cursor.invisibleContent(HtmlConstants.HOVER_ALL_OCCURS_SSR);
+        // TODO: KaTeX server side rendering
+      } else {
+        cursor.invisibleContent(HtmlConstants.HOVER_ALL_OCCURS);
+        cursor.invisibleContent(HtmlConstants.KATEX_AUTO_RENDER);
+      }
       renderCssStyle(cursor);
       cursor.invisibleContent("</head><body>");
     }
@@ -75,7 +82,8 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
   }
 
   @Override protected @NotNull String escapePlainText(@NotNull String content, EnumSet<Outer> outer) {
-    // note: HTML always needs escaping, regardless of `outer`
+    // HTML always needs escaping, unless we are in KaTeX math mode
+    if (outer.contains(Outer.Math)) return content;
     return entityPattern.matcher(content).replaceAll(
       result -> entityMapping.get(result.group()));   // fail if bug
   }
@@ -137,6 +145,19 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
     cursor.invisibleContent("<pre class=\"" + capitalize(block.language()) + "\">");
     renderDoc(cursor, block.code(), EnumSet.of(Outer.EnclosingTag)); // Even in code mode, we still need to escape
     cursor.invisibleContent("</pre>");
+  }
+
+  @Override
+  protected void renderInlineMath(@NotNull Cursor cursor, Doc.@NotNull InlineMath code, EnumSet<Outer> outer) {
+    // https://katex.org/docs/autorender.html
+    formatInline(cursor, code.formula(), "<span class=\"doc-katex-input\">\\(", "\\)</span>", EnumSet.of(Outer.Math));
+  }
+
+  @Override protected void renderMathBlock(@NotNull Cursor cursor, Doc.@NotNull MathBlock block, EnumSet<Outer> outer) {
+    cursor.invisibleContent("<pre><div class=\"doc-katex-input\">");
+    // https://katex.org/docs/autorender.html
+    formatBlock(cursor, block.formula(), "\\[", "\\]", EnumSet.of(Outer.Math));
+    cursor.invisibleContent("</div></pre>");
   }
 
   @Override

--- a/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/DocHtmlPrinter.java
@@ -126,6 +126,8 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
 
   @Override
   protected void renderInlineCode(@NotNull Cursor cursor, Doc.@NotNull InlineCode code, EnumSet<Outer> outer) {
+    // `<code class="" />` is valid, see:
+    // https://stackoverflow.com/questions/30748847/is-an-empty-class-attribute-valid-html
     cursor.invisibleContent("<code class=\"" + capitalize(code.language()) + "\">");
     renderDoc(cursor, code.code(), EnumSet.of(Outer.EnclosingTag)); // Even in code mode, we still need to escape
     cursor.invisibleContent("</code>");
@@ -149,8 +151,9 @@ public class DocHtmlPrinter<Config extends DocHtmlPrinter.Config> extends String
     cursor.invisibleContent("</" + tag + ">");
   }
 
-  private @NotNull String capitalize(@NotNull String s) {
-    return s.isEmpty() ? s : s.substring(0, 1).toUpperCase() + s.substring(1);
+  private @NotNull String capitalize(@NotNull org.aya.pretty.doc.Language s) {
+    var name = s.displayName();
+    return name.isEmpty() ? name : name.substring(0, 1).toUpperCase() + name.substring(1);
   }
 
   public static class Config extends StringPrinterConfig<Html5Stylist> {

--- a/pretty/src/main/java/org/aya/pretty/backend/html/HtmlConstants.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/HtmlConstants.java
@@ -42,6 +42,7 @@ public interface HtmlConstants {
   @NotNull String HOVER_STYLE = """
     <style>
     .Aya a { text-decoration: none; }
+    .Aya a:hover { text-decoration: none; }
     .Aya a[href]:hover { background-color: #B4EEB4; }
     .Aya [href].hover-highlight { background-color: #B4EEB4; }
     </style>

--- a/pretty/src/main/java/org/aya/pretty/backend/html/HtmlConstants.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/html/HtmlConstants.java
@@ -93,4 +93,32 @@ public interface HtmlConstants {
     }
     </script>
     """;
+
+  /** <a href="https://katex.org/docs/autorender.html">Auto Render</a> */
+  @Language(value = "HTML")
+  @NotNull String KATEX_AUTO_RENDER_EXTERNAL_RESOURCES = """
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css" integrity="sha384-vKruj+a13U8yHIkAyGgK1J3ArTLzrFGBbBc0tDp4ad/EyewESeXE/Iv67Aj8gKZ0" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.js" integrity="sha384-PwRUT/YqbnEjkZO0zZxNqcxACrXe+j766U2amXcgMg5457rve2Y7I6ZJSm2A0mS4" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"></script>
+    """;
+  @Language(value = "JavaScript")
+  @NotNull String KATEX_AUTO_RENDER_INIT = """
+    document.addEventListener("DOMContentLoaded", function() {
+        var blocks = document.getElementsByClassName('doc-katex-input');
+        for (var i = 0; i < blocks.length; i++) {
+          var block = blocks[i];
+          renderMathInElement(block, {
+            throwOnError : false
+          });
+        }
+    });
+    """;
+  @SuppressWarnings("LanguageMismatch")
+  @Language(value = "HTML")
+  @NotNull String KATEX_AUTO_RENDER =
+    KATEX_AUTO_RENDER_EXTERNAL_RESOURCES + """
+    <script>
+    """ + KATEX_AUTO_RENDER_INIT + """
+    </script>
+    """;
 }

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -132,7 +132,7 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
 
   @Override
   protected void renderCodeBlock(@NotNull Cursor cursor, Doc.@NotNull CodeBlock code, EnumSet<Outer> outer) {
-    if (code.language().isAya() && config.opt(AyaFlavored, false)) {
+    if (code.language().isAya()) {
       super.renderCodeBlock(cursor, code, outer); // `Outer.Code` is only for minted. Do not switch to code mode.
       return;
     }

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -123,14 +123,14 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
   @Override
   protected void renderInlineCode(@NotNull Cursor cursor, Doc.@NotNull InlineCode code, EnumSet<Outer> outer) {
     cursor.invisibleContent("\\texttt{");
-    renderDoc(cursor, code.code(), outer);
+    renderDoc(cursor, code.code(), EnumSet.of(Outer.Code));
     cursor.invisibleContent("}");
   }
 
   @Override
   protected void renderCodeBlock(@NotNull Cursor cursor, Doc.@NotNull CodeBlock code, EnumSet<Outer> outer) {
     cursor.invisibleContent("\\begin{minted}[c]");
-    renderDoc(cursor, code.code(), outer);
+    renderDoc(cursor, code.code(), EnumSet.of(Outer.Code));
     cursor.invisibleContent("\\end{minted}[c]");
   }
 

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -128,6 +128,13 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
   }
 
   @Override
+  protected void renderCodeBlock(@NotNull Cursor cursor, Doc.@NotNull CodeBlock code, EnumSet<Outer> outer) {
+    cursor.invisibleContent("\\begin{minted}[c]");
+    renderDoc(cursor, code.code(), outer);
+    cursor.invisibleContent("\\end{minted}[c]");
+  }
+
+  @Override
   protected void renderList(@NotNull Cursor cursor, Doc.@NotNull List list, EnumSet<Outer> outer) {
     var env = list.isOrdered() ? "enumerate" : "itemize";
     cursor.invisibleContent("\\begin{" + env + "}");

--- a/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/latex/DocTeXPrinter.java
@@ -149,9 +149,9 @@ public class DocTeXPrinter extends StringPrinter<DocTeXPrinter.Config> {
   }
 
   @Override protected void renderMathBlock(@NotNull Cursor cursor, Doc.@NotNull MathBlock block, EnumSet<Outer> outer) {
-    cursor.invisibleContent("\\begin{align*}");
+    cursor.invisibleContent("\\[");
     renderDoc(cursor, block.formula(), EnumSet.of(Outer.Math));
-    cursor.invisibleContent("\\end{align*}");
+    cursor.invisibleContent("\\]");
   }
 
   @Override

--- a/pretty/src/main/java/org/aya/pretty/backend/md/DocMdPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/md/DocMdPrinter.java
@@ -108,8 +108,7 @@ public class DocMdPrinter extends DocHtmlPrinter<DocMdPrinter.Config> {
     // assumption: inline code cannot be nested in markdown, but don't assert it.
     Runnable pureMd = () -> formatInlineCode(cursor, code.code(), "`", "`", outer);
     runSwitch(pureMd, () -> {
-      var isAya = code.language().equalsIgnoreCase("aya");
-      if (isAya) formatInlineCode(cursor, code.code(),
+      if (code.language().isAya()) formatInlineCode(cursor, code.code(),
         "<code class=\"Aya\">", "</code>",
         EnumSet.of(Outer.EnclosingTag));
       else pureMd.run();
@@ -122,11 +121,10 @@ public class DocMdPrinter extends DocHtmlPrinter<DocMdPrinter.Config> {
 
   @Override protected void renderCodeBlock(@NotNull Cursor cursor, @NotNull Doc.CodeBlock block, EnumSet<Outer> outer) {
     // assumption: code block cannot be nested in markdown, but don't assert it.
-    Runnable pureMd = () -> formatCodeBlock(cursor, block.code(), "```" + block.language(), "```", outer);
+    Runnable pureMd = () -> formatCodeBlock(cursor, block.code(), "```" + block.language().displayName().toLowerCase(), "```", outer);
     runSwitch(pureMd,
       () -> {
-        var isAya = block.language().equalsIgnoreCase("aya");
-        if (isAya) formatCodeBlock(cursor, block.code(),
+        if (block.language().isAya()) formatCodeBlock(cursor, block.code(),
           "<pre class=\"Aya\">", "</pre>",
           "<code>", "</code>",
           EnumSet.of(Outer.EnclosingTag));

--- a/pretty/src/main/java/org/aya/pretty/backend/md/DocMdPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/md/DocMdPrinter.java
@@ -16,7 +16,8 @@ import static org.aya.pretty.backend.string.StringPrinterConfig.StyleOptions.*;
 
 public class DocMdPrinter extends DocHtmlPrinter<DocMdPrinter.Config> {
   public static final Pattern MD_ESCAPE = Pattern.compile("[#&()*+;<>\\[\\\\\\]_`|~]");
-  public static final Pattern MD_NO_ESCAPE_BACKSLASH = Pattern.compile("(^\\s*\\d+)\\.( |$)", Pattern.MULTILINE);
+  /** `Doc.plain("1. hello")` should not be rendered as a list, see MdStyleTest */
+  public static final Pattern MD_ESCAPE_FAKE_LIST = Pattern.compile("(^\\s*\\d+)\\.( |$)", Pattern.MULTILINE);
 
   @Override protected void renderHeader(@NotNull Cursor cursor) {
   }
@@ -61,10 +62,8 @@ public class DocMdPrinter extends DocHtmlPrinter<DocMdPrinter.Config> {
         return "\\\\" + chara;
       });
 
-    // avoiding escape `\`.
-    content = MD_NO_ESCAPE_BACKSLASH
-      .matcher(content)
-      .replaceAll("$1\\\\.$2");
+    // escape fake lists
+    content = MD_ESCAPE_FAKE_LIST.matcher(content).replaceAll("$1\\\\.$2");
 
     return content;
   }

--- a/pretty/src/main/java/org/aya/pretty/backend/md/DocMdPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/md/DocMdPrinter.java
@@ -102,10 +102,14 @@ public class DocMdPrinter extends DocHtmlPrinter<DocMdPrinter.Config> {
     cursor.invisibleContent(")");
   }
 
+  @Override protected void renderList(@NotNull Cursor cursor, @NotNull Doc.List list, EnumSet<Outer> outer) {
+    StringPrinter.renderList(this, cursor, list, outer);
+  }
+
   @Override
   protected void renderInlineCode(@NotNull Cursor cursor, @NotNull Doc.InlineCode code, EnumSet<Outer> outer) {
     // assumption: inline code cannot be nested in markdown, but don't assert it.
-    Runnable pureMd = () -> formatInlineCode(cursor, code.code(), "`", "`", outer);
+    Runnable pureMd = () -> formatInlineCode(cursor, code.code(), "`", "`", EnumSet.of(Outer.Code));
     runSwitch(pureMd, () -> {
       if (code.language().isAya()) formatInlineCode(cursor, code.code(),
         "<code class=\"Aya\">", "</code>",
@@ -114,13 +118,11 @@ public class DocMdPrinter extends DocHtmlPrinter<DocMdPrinter.Config> {
     });
   }
 
-  @Override protected void renderList(@NotNull Cursor cursor, @NotNull Doc.List list, EnumSet<Outer> outer) {
-    StringPrinter.renderList(this, cursor, list, outer);
-  }
-
   @Override protected void renderCodeBlock(@NotNull Cursor cursor, @NotNull Doc.CodeBlock block, EnumSet<Outer> outer) {
     // assumption: code block cannot be nested in markdown, but don't assert it.
-    Runnable pureMd = () -> formatCodeBlock(cursor, block.code(), "```" + block.language().displayName().toLowerCase(), "```", outer);
+    Runnable pureMd = () -> formatCodeBlock(cursor, block.code(),
+      "```" + block.language().displayName().toLowerCase(), "```",
+      EnumSet.of(Outer.Code));
     runSwitch(pureMd,
       () -> {
         if (block.language().isAya()) formatCodeBlock(cursor, block.code(),

--- a/pretty/src/main/java/org/aya/pretty/backend/md/DocMdPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/md/DocMdPrinter.java
@@ -143,10 +143,8 @@ public class DocMdPrinter extends DocHtmlPrinter<DocMdPrinter.Config> {
       EnumSet.of(Outer.Code));
     runSwitch(pureMd,
       () -> {
-        if (block.language().isAya()) formatBlock(cursor, block.code(),
-          "<pre class=\"Aya\">", "</pre>",
-          "<code>", "</code>",
-          EnumSet.of(Outer.EnclosingTag));
+        if (block.language().isAya()) formatBlock(cursor, "<pre class=\"Aya\">", "</pre>", outer,
+          () -> formatInline(cursor, block.code(), "<code>", "</code>", EnumSet.of(Outer.EnclosingTag)));
         else pureMd.run();
       });
   }

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinter.java
@@ -68,6 +68,8 @@ public class StringPrinter<Config extends StringPrinterConfig<?>> implements Pri
       case Doc.PageWidth pageWidth -> predictWidth(cursor, pageWidth.docBuilder().apply(config.getPageWidth()));
       case Doc.CodeBlock codeBlock -> predictWidth(cursor, codeBlock.code());
       case Doc.InlineCode inlineCode -> predictWidth(cursor, inlineCode.code());
+      case Doc.InlineMath inlineMath -> predictWidth(cursor, inlineMath.formula());
+      case Doc.MathBlock mathBlock -> predictWidth(cursor, mathBlock.formula());
       case Doc.List list -> list.items().view().map(x -> predictWidth(cursor, x)).reduce(Integer::sum);
     };
   }
@@ -102,9 +104,11 @@ public class StringPrinter<Config extends StringPrinterConfig<?>> implements Pri
       case Doc.Column column -> renderDoc(cursor, column.docBuilder().apply(cursor.getCursor()), outer);
       case Doc.Nesting nesting -> renderDoc(cursor, nesting.docBuilder().apply(cursor.getNestLevel()), outer);
       case Doc.PageWidth pageWidth -> renderDoc(cursor, pageWidth.docBuilder().apply(config.getPageWidth()), outer);
-      case Doc.CodeBlock codeBlock -> renderCodeBlock(cursor, codeBlock, EnumSet.of(Outer.Code));
-      case Doc.InlineCode inlineCode -> renderInlineCode(cursor, inlineCode, EnumSet.of(Outer.Code));
+      case Doc.CodeBlock codeBlock -> renderCodeBlock(cursor, codeBlock, outer);
+      case Doc.InlineCode inlineCode -> renderInlineCode(cursor, inlineCode, outer);
       case Doc.List list -> renderList(cursor, list, outer);
+      case Doc.InlineMath inlineMath -> renderInlineMath(cursor, inlineMath, outer);
+      case Doc.MathBlock mathBlock -> renderMathBlock(cursor, mathBlock, outer);
       case Doc.Empty $ -> {}
     }
   }
@@ -187,6 +191,15 @@ public class StringPrinter<Config extends StringPrinterConfig<?>> implements Pri
     cursor.visibleContent("`");
     renderDoc(cursor, code.code(), outer);
     cursor.visibleContent("`");
+  }
+
+  protected void renderMathBlock(@NotNull Cursor cursor, @NotNull Doc.MathBlock block, EnumSet<Outer> outer) {
+    makeSureLineStart(cursor, outer);
+    renderDoc(cursor, block.formula(), outer);
+  }
+
+  protected void renderInlineMath(@NotNull Cursor cursor, @NotNull Doc.InlineMath code, EnumSet<Outer> outer) {
+    renderDoc(cursor, code.formula(), outer);
   }
 
   protected void renderList(@NotNull Cursor cursor, @NotNull Doc.List list, EnumSet<Outer> outer) {

--- a/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/string/StringPrinter.java
@@ -22,6 +22,7 @@ public class StringPrinter<Config extends StringPrinterConfig<?>> implements Pri
   /** renderer: where am I? */
   public enum Outer {
     Code,
+    Math,
     EnclosingTag,
     List,
   }

--- a/pretty/src/main/java/org/aya/pretty/backend/terminal/DocTermPrinter.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/terminal/DocTermPrinter.java
@@ -13,7 +13,7 @@ import java.util.EnumSet;
 public class DocTermPrinter extends StringPrinter<DocTermPrinter.Config> {
   @Override protected void renderInlineCode(@NotNull Cursor cursor, Doc.@NotNull InlineCode code, EnumSet<Outer> outer) {
     cursor.invisibleContent("`");
-    renderDoc(cursor, code.code(), outer);
+    renderDoc(cursor, code.code(), EnumSet.of(Outer.Code));
     cursor.invisibleContent("'");
   }
 

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -171,11 +171,11 @@ public sealed interface Doc extends Docile {
   }
 
   /** Inline code, with special escape settings compared to {@link PlainText} */
-  record InlineCode(@NotNull String language, @NotNull Doc code) implements Doc {
+  record InlineCode(@NotNull Language language, @NotNull Doc code) implements Doc {
   }
 
   /** Code block, with special escape settings compared to {@link PlainText} */
-  record CodeBlock(@NotNull String language, @NotNull Doc code) implements Doc {
+  record CodeBlock(@NotNull Language language, @NotNull Doc code) implements Doc {
   }
 
   /**
@@ -276,23 +276,23 @@ public sealed interface Doc extends Docile {
   }
 
   static @NotNull Doc code(@NotNull String code) {
-    return code("aya", plain(code));
+    return code(Language.Builtin.Plain, plain(code));
   }
 
   static @NotNull Doc code(@NotNull Doc code) {
-    return code("aya", code);
+    return code(Language.Builtin.Plain, code);
   }
 
-  static @NotNull Doc code(@NotNull String language, @NotNull Doc code) {
+  static @NotNull Doc code(@NotNull Language language, @NotNull Doc code) {
     return new InlineCode(language, code);
   }
 
-  static @NotNull Doc codeBlock(@NotNull String code) {
-    return codeBlock("aya", plain(code));
+  static @NotNull Doc codeBlock(@NotNull Language language, @NotNull Doc code) {
+    return new CodeBlock(language, code);
   }
 
-  static @NotNull Doc codeBlock(@NotNull String language, @NotNull Doc code) {
-    return new CodeBlock(language, code);
+  static @NotNull Doc codeBlock(@NotNull Language language, @NotNull String code) {
+    return codeBlock(language, plain(code));
   }
 
   static @NotNull Doc styled(@NotNull Style style, @NotNull Doc doc) {

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -284,11 +284,11 @@ public sealed interface Doc extends Docile {
   }
 
   static @NotNull Doc code(@NotNull String code) {
-    return code(Language.Builtin.Plain, plain(code));
+    return code(Language.Builtin.Aya, plain(code));
   }
 
   static @NotNull Doc code(@NotNull Doc code) {
-    return code(Language.Builtin.Plain, code);
+    return code(Language.Builtin.Aya, code);
   }
 
   static @NotNull Doc code(@NotNull Language language, @NotNull Doc code) {

--- a/pretty/src/main/java/org/aya/pretty/doc/Doc.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Doc.java
@@ -178,6 +178,14 @@ public sealed interface Doc extends Docile {
   record CodeBlock(@NotNull Language language, @NotNull Doc code) implements Doc {
   }
 
+  /** Inline math, with special escape settings compared to {@link PlainText} */
+  record InlineMath(@NotNull Doc formula) implements Doc {
+  }
+
+  /** Math block, with special escape settings compared to {@link PlainText} */
+  record MathBlock(@NotNull Doc formula) implements Doc {
+  }
+
   /**
    * Styled document
    */
@@ -293,6 +301,14 @@ public sealed interface Doc extends Docile {
 
   static @NotNull Doc codeBlock(@NotNull Language language, @NotNull String code) {
     return codeBlock(language, plain(code));
+  }
+
+  static @NotNull Doc math(@NotNull Doc formula) {
+    return new InlineMath(formula);
+  }
+
+  static @NotNull Doc mathBlock(@NotNull Doc formula) {
+    return new MathBlock(formula);
   }
 
   static @NotNull Doc styled(@NotNull Style style, @NotNull Doc doc) {

--- a/pretty/src/main/java/org/aya/pretty/doc/Language.java
+++ b/pretty/src/main/java/org/aya/pretty/doc/Language.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.pretty.doc;
+
+import kala.collection.immutable.ImmutableSeq;
+import org.jetbrains.annotations.NotNull;
+
+/** Languages supported by {@link Doc#code} and {@link Doc#codeBlock} */
+public interface Language {
+  @NotNull String displayName();
+  @NotNull ImmutableSeq<Language> parentLanguage();
+
+  default boolean isAya() {
+    return this == Builtin.Aya || parentLanguage().anyMatch(Language::isAya);
+  }
+
+  static @NotNull Language of(@NotNull String displayName) {
+    for (var e : Builtin.values()) {
+      if (e.displayName.equalsIgnoreCase(displayName)) return e;
+    }
+    return new Some(displayName);
+  }
+
+  record Some(@NotNull String displayName) implements Language {
+    @Override public @NotNull ImmutableSeq<Language> parentLanguage() {
+      return ImmutableSeq.empty();
+    }
+  }
+
+  enum Builtin implements Language {
+    Plain(""),
+    Aya("aya");
+
+    final String displayName;
+
+    Builtin(@NotNull String displayName) {
+      this.displayName = displayName;
+    }
+
+    @Override public @NotNull String displayName() {
+      return displayName;
+    }
+
+    @Override public @NotNull ImmutableSeq<Language> parentLanguage() {
+      return ImmutableSeq.empty();
+    }
+  }
+}

--- a/pretty/src/test/java/org/aya/pretty/MdStyleTest.java
+++ b/pretty/src/test/java/org/aya/pretty/MdStyleTest.java
@@ -1,9 +1,10 @@
-// Copyright (c) 2020-2022 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.pretty;
 
 import org.aya.pretty.backend.md.MdStyle;
 import org.aya.pretty.doc.Doc;
+import org.aya.pretty.doc.Language;
 import org.aya.pretty.doc.Link;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -57,7 +58,7 @@ public class MdStyleTest {
       Doc.styled(MdStyle.GFM.Paragraph, "I love Java"),
       Doc.styled(MdStyle.GFM.Paragraph, "I love Aya"),
       Doc.styled(MdStyle.GFM.Paragraph, "I love Aya's pretty printer."),
-      Doc.codeBlock("data Nat | zero | suc Nat"),
+      Doc.codeBlock(Language.Builtin.Aya, "data Nat | zero | suc Nat"),
       Doc.styled(MdStyle.GFM.Paragraph, "Look! She is beautiful")
     );
   }
@@ -106,7 +107,7 @@ public class MdStyleTest {
   }
 
   @NotNull private Doc escapeDoc17() {
-    return Doc.code("", Doc.plain("\\[\\`"));
+    return Doc.code("\\[\\`");
   }
 
   @Test

--- a/pretty/src/test/java/org/aya/pretty/Reproduction.java
+++ b/pretty/src/test/java/org/aya/pretty/Reproduction.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Reproduction {
   @Test public void mock() {
-    var doc = Doc.nest(2, Doc.code(Doc.plain("hey")));
+    var doc = Doc.nest(2, Doc.code("hey"));
     assertEquals("  `hey'", doc.renderToTerminal());
     assertEquals("\\hspace{1.0em}\\texttt{hey}", doc.renderToTeX());
   }


### PR DESCRIPTION
Example:
```md
Inline math: $\mathrm{type}$.
Math block:

$$
\LaTeX
$$
```

This works with markdown processors that support KaTeX (like Vuepress/Vitepress)