### PR TITLE
Correctly count usage in recursive definitions

### DIFF
--- a/ide-lsp/src/main/java/org/aya/lsp/actions/LensMaker.java
+++ b/ide-lsp/src/main/java/org/aya/lsp/actions/LensMaker.java
@@ -40,7 +40,7 @@ public record LensMaker(
   @Override public void accept(@NotNull Stmt stmt) {
     if (stmt instanceof Decl maybe) {
       Resolver.withChildren(maybe).filter(dv -> dv.concrete != null).forEach(dv -> {
-        var refs = FindReferences.findRefs(SeqView.of(dv), libraries).toImmutableSeq();
+        var refs = FindReferences.findRefsOutsideDefs(SeqView.of(dv), libraries).toImmutableSeq();
         if (refs.size() > 0) {
           var sourcePos = dv.concrete.sourcePos();
           var uri = LspRange.toFileUri(sourcePos);

--- a/ide-lsp/src/main/java/org/aya/lsp/server/AyaLanguageServer.java
+++ b/ide-lsp/src/main/java/org/aya/lsp/server/AyaLanguageServer.java
@@ -328,7 +328,7 @@ public class AyaLanguageServer implements LanguageServer {
     var source = find(params.textDocument.uri);
     if (source == null) return Optional.empty();
     return Optional.of(FindReferences
-      .findRefs(source, libraries.view(), LspRange.pos(params.position))
+      .findRefsOutsideDefs(source, libraries.view(), LspRange.pos(params.position))
       .map(LspRange::toLoc)
       .collect(Collectors.toList()));
   }

--- a/ide-lsp/src/main/java/org/aya/lsp/server/AyaLanguageServer.java
+++ b/ide-lsp/src/main/java/org/aya/lsp/server/AyaLanguageServer.java
@@ -328,7 +328,7 @@ public class AyaLanguageServer implements LanguageServer {
     var source = find(params.textDocument.uri);
     if (source == null) return Optional.empty();
     return Optional.of(FindReferences
-      .findRefsOutsideDefs(source, libraries.view(), LspRange.pos(params.position))
+      .findRefs(source, libraries.view(), LspRange.pos(params.position))
       .map(LspRange::toLoc)
       .collect(Collectors.toList()));
   }

--- a/ide/src/main/java/org/aya/ide/action/FindReferences.java
+++ b/ide/src/main/java/org/aya/ide/action/FindReferences.java
@@ -45,7 +45,7 @@ public interface FindReferences {
     @NotNull SeqView<LibraryOwner> libraries
   ) {
     var defPos = vars.filterIsInstance(DefVar.class).map(def -> def.concrete.entireSourcePos());
-    return findRefs(vars, libraries).filter(ref -> !defPos.map(pos -> pos.containsIndex(ref)).contains(true));
+    return findRefs(vars, libraries).filter(ref -> defPos.noneMatch(pos -> pos.containsIndex(ref)));
   }
 
   static @NotNull SeqView<SourcePos> findOccurrences(


### PR DESCRIPTION
This addresses issue #872. It also affects the "Go to References" function in VSCode.

This doesn't handle mutual recursion, otherwise usage counts would all become 0.