### PR TITLE
Respect `--pretty-dir` for libraries

### DIFF
--- a/cli-console/src/main/java/org/aya/cli/console/MainArgs.java
+++ b/cli-console/src/main/java/org/aya/cli/console/MainArgs.java
@@ -83,7 +83,7 @@ public class MainArgs {
   public PrettyStage prettyStage;
   @Option(names = {"--pretty-format"}, description = "Pretty print format." + CANDIDATES, defaultValue = "markdown")
   public PrettyFormat prettyFormat;
-  @Option(names = {"--pretty-dir"}, description = "Specify output directory of pretty printing.", defaultValue = ".")
+  @Option(names = {"--pretty-dir"}, description = "Specify output directory of pretty printing.")
   public String prettyDir;
   @Option(names = {"--pretty-color"}, description = "The color theme of pretty printing." + CANDIDATES, defaultValue = "emacs")
   public PredefinedStyle prettyColor;


### PR DESCRIPTION
In the past, the literated library is always saved to `<project-root>/build/pretty`. Now we can specify the output location through `--pretty-dir`