### PR TITLE
Fix highlight lost when converting non-literal file to literal file

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -29,7 +29,7 @@ Aya is under active development, so please expect bugs, usability or performance
 + Overlapping and order-independent patterns. Very [useful][oop] in theorem proving.
 + A literate programming mode with inline code fragment support, inspired from Agda and [1lab].
   You may preview the features (in Chinese)
-  [here](https://blog.imkiva.org/2023/04/02/intro-literate-aya/).
+  [here](https://blog.imkiva.org/posts/intro-literate-aya.html).
 + Binary operators, with precedence specified by a partial ordering
   (instead of a number like in Haskell or Agda)
   which is useful for [equation reasoning][assoc].

--- a/base/src/main/java/org/aya/concrete/GenericAyaFile.java
+++ b/base/src/main/java/org/aya/concrete/GenericAyaFile.java
@@ -46,6 +46,6 @@ public interface GenericAyaFile {
     var code = originalFile().sourceCode();
     var mockPos = new SourcePos(originalFile(), 0, code.length(), -1, -1, -1, -1);
     // ^ we only need index, so it's fine to use a mocked line/column
-    return AyaLiterate.visibleAyaCodeBlock(code, mockPos);
+    return new AyaLiterate.AyaVisibleCodeBlock("aya", code, mockPos);
   }
 }

--- a/base/src/main/java/org/aya/concrete/remark/AyaLiterate.java
+++ b/base/src/main/java/org/aya/concrete/remark/AyaLiterate.java
@@ -23,10 +23,6 @@ public interface AyaLiterate {
     AyaHiddenCodeBlock::new);
   @NotNull ImmutableSeq<InterestingLanguage<?>> AYA = ImmutableSeq.of(VISIBLE_AYA, HIDDEN_AYA);
 
-  static @NotNull Literate.CodeBlock visibleAyaCodeBlock(@NotNull String code, @NotNull SourcePos sourcePos) {
-    return new Literate.CodeBlock("aya", code, sourcePos);
-  }
-
   class AyaCodeBlock extends Literate.CodeBlock {
     public AyaCodeBlock(@NotNull String language, @NotNull String code, @Nullable SourcePos sourcePos) {
       super(language, code, sourcePos);


### PR DESCRIPTION
as  title