### PR TITLE
pretty: support ansi16

### DIFF
--- a/cli-console/src/main/java/org/aya/cli/console/Main.java
+++ b/cli-console/src/main/java/org/aya/cli/console/Main.java
@@ -71,7 +71,7 @@ public class Main extends MainArgs implements Callable<Integer> {
       new FlclParser(reporter, file).computeAst());
     // Garbage code
     var setup = info.backendOpts(false);
-    var output = renderOptions.render(RenderOptions.OutputTarget.LaTeX, doc, setup);
+    var output = renderOptions.render(prettyFormat.target, doc, setup);
     if (outputPath != null) FileUtil.writeString(outputPath, output);
     else System.out.println(output);
     return 0;

--- a/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
+++ b/cli-impl/src/main/java/org/aya/cli/render/RenderOptions.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 public class RenderOptions {
   public enum OutputTarget {
     Unix(".txt"),
+    ANSI16(".txt"),
     LaTeX(".tex"),
     KaTeX(".katex"),
     AyaMd(".md"),
@@ -119,6 +120,7 @@ public class RenderOptions {
   public static @NotNull StringStylist defaultStylist(@NotNull OutputTarget output) {
     return switch (output) {
       case Unix -> AdaptiveCliStylist.INSTANCE;
+      case ANSI16 -> AdaptiveCliStylist.INSTANCE_16;
       case LaTeX -> TeXStylist.DEFAULT;
       case KaTeX -> TeXStylist.DEFAULT_KATEX;
       case AyaMd -> MdStylist.DEFAULT;
@@ -132,7 +134,7 @@ public class RenderOptions {
     final var c = buildColorScheme();
     final var s = buildStyleFamily();
     return switch (output) {
-      case Unix -> new UnixTermStylist(c, s);
+      case Unix, ANSI16 -> new UnixTermStylist(c, s);
       case LaTeX -> new TeXStylist(c, s, false);
       case KaTeX -> new TeXStylist(c, s, true);
       case AyaMd -> new MdStylist(c, s);
@@ -188,7 +190,8 @@ public class RenderOptions {
       case KaTeX, LaTeX -> doc.render(new DocTeXPrinter(), setup.setup(new DocTeXPrinter.Config((TeXStylist) stylist)));
       case HTML -> doc.render(new DocHtmlPrinter<>(), setup.setup(new DocHtmlPrinter.Config((Html5Stylist) stylist)));
       case AyaMd -> doc.render(new DocMdPrinter(), setup.setup(new DocMdPrinter.Config((MdStylist) stylist)));
-      case Unix -> doc.render(new DocTermPrinter(), setup.setup(new DocTermPrinter.Config((UnixTermStylist) stylist)));
+      case Unix, ANSI16 ->
+        doc.render(new DocTermPrinter(), setup.setup(new DocTermPrinter.Config((UnixTermStylist) stylist)));
     };
   }
 

--- a/cli-impl/src/main/java/org/aya/cli/utils/CliEnums.java
+++ b/cli-impl/src/main/java/org/aya/cli/utils/CliEnums.java
@@ -29,7 +29,8 @@ public interface CliEnums {
     latex(RenderOptions.OutputTarget.LaTeX),
     katex(RenderOptions.OutputTarget.KaTeX),
     markdown(RenderOptions.OutputTarget.AyaMd),
-    unix(RenderOptions.OutputTarget.Unix);
+    unix(RenderOptions.OutputTarget.Unix),
+    ansi16(RenderOptions.OutputTarget.ANSI16);
 
     public final @NotNull RenderOptions.OutputTarget target;
 

--- a/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
+++ b/cli-impl/src/test/java/org/aya/cli/RenderOptionsTest.java
@@ -25,6 +25,7 @@ public class RenderOptionsTest {
     opt.checkDeserialization();
     var opts = new RenderOptions.DefaultSetup(false, false, false, true, -1, false);
     assertEquals("`hello'", opt.render(RenderOptions.OutputTarget.Unix, doc, opts));
+    assertEquals("`hello'", opt.render(RenderOptions.OutputTarget.ANSI16, doc, opts));
     assertEquals("\\texttt{hello}", opt.render(RenderOptions.OutputTarget.LaTeX, doc, opts));
     assertEquals("\\texttt{hello}", opt.render(RenderOptions.OutputTarget.KaTeX, doc, opts));
     assertEquals("<code class=\"Aya\">hello</code>", opt.render(RenderOptions.OutputTarget.HTML, doc, opts));

--- a/pretty/src/main/java/org/aya/pretty/backend/terminal/AdaptiveCliStylist.java
+++ b/pretty/src/main/java/org/aya/pretty/backend/terminal/AdaptiveCliStylist.java
@@ -12,12 +12,13 @@ import org.jetbrains.annotations.NotNull;
 
 /** use colors from terminal instead of absolute colors to protect eyes */
 public class AdaptiveCliStylist extends UnixTermStylist {
-  public static final @NotNull AdaptiveCliStylist INSTANCE = new AdaptiveCliStylist();
+  public static final @NotNull AdaptiveCliStylist INSTANCE = new AdaptiveCliStylist(true);
+  public static final @NotNull AdaptiveCliStylist INSTANCE_16 = new AdaptiveCliStylist(false);
 
-  private AdaptiveCliStylist() {
+  private AdaptiveCliStylist(boolean use256Colors) {
     super(MutableMap::create, new AyaStyleFamily(MutableMap.ofEntries(
-      Tuple.of(AyaStyleKey.Keyword.key(), Style.color(ColorScheme.colorOf(1.0f, 0.43f, 0)).and()),
-      Tuple.of(AyaStyleKey.Prim.key(), Style.color(ColorScheme.colorOf(1.0f, 0.43f, 0)).and()),
+      Tuple.of(AyaStyleKey.Keyword.key(), (use256Colors ? Style.color(ColorScheme.colorOf(1.0f, 0.43f, 0)) : UnixTermStyle.TerminalRed).and()),
+      Tuple.of(AyaStyleKey.Prim.key(), (use256Colors ? Style.color(ColorScheme.colorOf(1.0f, 0.43f, 0)) : UnixTermStyle.TerminalRed).and()),
       Tuple.of(AyaStyleKey.Fn.key(), UnixTermStyle.TerminalYellow.and()),
       Tuple.of(AyaStyleKey.Data.key(), UnixTermStyle.TerminalGreen.and()),
       Tuple.of(AyaStyleKey.Clazz.key(), UnixTermStyle.TerminalGreen.and()),


### PR DESCRIPTION
This pull request aims to add a new render target, `ANSI16`, to provide better Discord code block support. It's basically Unix format but without 256-color ANSI codes.

Also introduced a quick fix for CLI not respecting output target when using together with the `--fake-literate` option.