### PR TITLE
Refactor the Class Name Generator of Compiler

### DIFF
--- a/base/src/main/java/org/aya/resolve/module/DumbModuleLoader.java
+++ b/base/src/main/java/org/aya/resolve/module/DumbModuleLoader.java
@@ -8,12 +8,13 @@ import org.aya.resolve.ResolveInfo;
 import org.aya.resolve.context.Context;
 import org.aya.syntax.concrete.stmt.Stmt;
 import org.aya.syntax.ref.ModulePath;
+import org.aya.syntax.ref.QPath;
 import org.aya.util.reporter.Reporter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class DumbModuleLoader implements ModuleLoader {
-  public static final @NotNull String DUMB_MODULE_NAME = "baka";
+  public static final @NotNull QPath DUMB_MODULE_NAME = new QPath(ModulePath.of("baka"), 1);
 
   public final @NotNull PrimFactory primFactory = new PrimFactory();
   public final @NotNull Context baseContext;
@@ -22,7 +23,7 @@ public class DumbModuleLoader implements ModuleLoader {
   }
 
   public @NotNull ResolveInfo resolve(@NotNull ImmutableSeq<Stmt> stmts) {
-    return resolveModule(primFactory, baseContext.derive(DUMB_MODULE_NAME), stmts, this);
+    return resolveModule(primFactory, baseContext.derive(DUMB_MODULE_NAME.module()), stmts, this);
   }
 
   @Override public @Nullable ResolveInfo load(@NotNull ModulePath path, @NotNull ModuleLoader recurseLoader) {

--- a/cli-impl/src/main/java/org/aya/cli/library/incremental/DiskCompilerAdvisor.java
+++ b/cli-impl/src/main/java/org/aya/cli/library/incremental/DiskCompilerAdvisor.java
@@ -86,8 +86,8 @@ public class DiskCompilerAdvisor implements CompilerAdvisor {
     @NotNull ImmutableSeq<TyckDef> defs
   ) throws IOException {
     var javaCode = new FileSerializer(resolveInfo.shapeFactory())
-      .serialize(new FileSerializer.FileResult(file.moduleName().dropLast(1), new ModuleSerializer.ModuleResult(
-        QPath.fileLevel(file.moduleName()), defs.filterIsInstance(TopLevelDef.class), ImmutableSeq.empty())))
+      .serialize(new ModuleSerializer.ModuleResult(
+        QPath.fileLevel(file.moduleName()), defs.filterIsInstance(TopLevelDef.class), ImmutableSeq.empty()))
       .result();
     var baseDir = computeBaseDir(file.owner()).toAbsolutePath();
     var javaSrcPath = FileUtil.resolveFile(baseDir.resolve(AyaSerializer.PACKAGE_BASE),

--- a/cli-impl/src/main/java/org/aya/cli/library/incremental/DiskCompilerAdvisor.java
+++ b/cli-impl/src/main/java/org/aya/cli/library/incremental/DiskCompilerAdvisor.java
@@ -13,6 +13,7 @@ import org.aya.resolve.module.ModuleLoader;
 import org.aya.syntax.core.def.TopLevelDef;
 import org.aya.syntax.core.def.TyckDef;
 import org.aya.syntax.ref.ModulePath;
+import org.aya.syntax.ref.QPath;
 import org.aya.util.FileUtil;
 import org.aya.util.reporter.Reporter;
 import org.jetbrains.annotations.NotNull;
@@ -73,7 +74,7 @@ public class DiskCompilerAdvisor implements CompilerAdvisor {
       var compiledAya = (CompiledModule) inputStream.readObject();
       var baseDir = computeBaseDir(owner);
       try (var cl = new URLClassLoader(new URL[]{baseDir.toUri().toURL()})) {
-        cl.loadClass(AbstractSerializer.getModuleReference(mod));
+        cl.loadClass(AbstractSerializer.getModuleReference(null /*TODO*/));
         return compiledAya.toResolveInfo(recurseLoader, context, cl);
       }
     }
@@ -84,10 +85,9 @@ public class DiskCompilerAdvisor implements CompilerAdvisor {
     @NotNull ResolveInfo resolveInfo,
     @NotNull ImmutableSeq<TyckDef> defs
   ) throws IOException {
-    var name = file.moduleName().last();
     var javaCode = new FileSerializer(resolveInfo.shapeFactory())
       .serialize(new FileSerializer.FileResult(file.moduleName().dropLast(1), new ModuleSerializer.ModuleResult(
-        name, defs.filterIsInstance(TopLevelDef.class), ImmutableSeq.empty())))
+        QPath.fileLevel(file.moduleName()), defs.filterIsInstance(TopLevelDef.class), ImmutableSeq.empty())))
       .result();
     var baseDir = computeBaseDir(file.owner()).toAbsolutePath();
     var javaSrcPath = FileUtil.resolveFile(baseDir.resolve(AyaSerializer.PACKAGE_BASE),

--- a/cli-impl/src/main/java/org/aya/cli/library/incremental/DiskCompilerAdvisor.java
+++ b/cli-impl/src/main/java/org/aya/cli/library/incremental/DiskCompilerAdvisor.java
@@ -74,7 +74,7 @@ public class DiskCompilerAdvisor implements CompilerAdvisor {
       var compiledAya = (CompiledModule) inputStream.readObject();
       var baseDir = computeBaseDir(owner);
       try (var cl = new URLClassLoader(new URL[]{baseDir.toUri().toURL()})) {
-        cl.loadClass(AbstractSerializer.getModuleReference(null /*TODO*/));
+        cl.loadClass(AbstractSerializer.getModuleReference(QPath.fileLevel(mod)));
         return compiledAya.toResolveInfo(recurseLoader, context, cl);
       }
     }

--- a/jit-compiler/src/main/java/org/aya/compiler/AbstractSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/AbstractSerializer.java
@@ -260,22 +260,36 @@ public abstract class AbstractSerializer<T> implements AyaSerializer<T> {
     return getReference(name.module(), name.name());
   }
 
-  /**
-   * Compute the reference of certain {@link QPath module}/symbol in {@link QPath module}.
-   */
+  public static @NotNull String getClassName(@NotNull QPath module, @Nullable String name) {
+    return getReference(module, name, "$");
+  }
+
   public static @NotNull String getReference(@NotNull QPath module, @Nullable String name) {
+    return getReference(module, name, ".");
+  }
+
+  /**
+   * Compute the qualified name for certain {@link QPath module}/symbol in {@link QPath module}.
+   * You may want to specify {@param separator} for different use.
+   */
+  public static @NotNull String getReference(@NotNull QPath module, @Nullable String name, @NotNull String separator) {
     // get package name of file level module
     var packageName = getModulePackageReference(module.fileModule());
     // get javify class name of each component
     var javifyComponent = module.traversal((path) -> javifyClassName(path, null)).view();
     if (name != null) javifyComponent = javifyComponent.appended(javifyClassName(module, name));
-    return STR."\{packageName}.\{javifyComponent.joinToString(".")}";
+    return STR."\{packageName}.\{javifyComponent.joinToString(separator)}";
   }
 
   protected static @NotNull String getCoreReference(@NotNull DefVar<?, ?> ref) {
     return getReference(TyckAnyDef.make(ref.core));
   }
 
+  /**
+   * Obtain the java qualified name of certain {@link AnyDef def}
+   *
+   * @see #getReference(QPath, String, String)
+   */
   protected static @NotNull String getReference(@NotNull AnyDef def) {
     return getReference(def.qualifiedName());
   }
@@ -311,7 +325,7 @@ public abstract class AbstractSerializer<T> implements AyaSerializer<T> {
   }
 
   /**
-   * Generate a java friendly name of {@param name}, this function should be one-to-one.
+   * Generate a java friendly name for {@param name}, this function should be one-to-one.
    * Note that the result may not be used for class name, see {@link #javifyClassName}
    */
   public static @NotNull String javify(String name) {

--- a/jit-compiler/src/main/java/org/aya/compiler/FileSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/FileSerializer.java
@@ -7,12 +7,7 @@ import org.aya.primitive.ShapeFactory;
 import org.aya.syntax.ref.ModulePath;
 import org.jetbrains.annotations.NotNull;
 
-public class FileSerializer extends AbstractSerializer<FileSerializer.FileResult> {
-  public record FileResult(
-    @NotNull ModulePath modulePath,
-    @NotNull ModuleSerializer.ModuleResult moduleResult
-  ) { }
-
+public class FileSerializer extends AbstractSerializer<ModuleSerializer.ModuleResult> {
   private final @NotNull ShapeFactory shapeFactory;
 
   public FileSerializer(@NotNull ShapeFactory factory) {
@@ -25,14 +20,15 @@ public class FileSerializer extends AbstractSerializer<FileSerializer.FileResult
   }
 
   @Override
-  public AyaSerializer<FileResult> serialize(FileResult unit) {
-    buildPackage(unit.modulePath);
+  public AyaSerializer<ModuleSerializer.ModuleResult> serialize(ModuleSerializer.ModuleResult unit) {
+    assert unit.name().isFileModule();
+    buildPackage(unit.name().module());
     appendLine();
     appendLine(AyaSerializer.IMPORT_BLOCK);
     appendLine();
 
     new ModuleSerializer(this, shapeFactory)
-      .serialize(unit.moduleResult);
+      .serialize(unit);
 
     return this;
   }

--- a/jit-compiler/src/main/java/org/aya/compiler/FileSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/FileSerializer.java
@@ -6,11 +6,10 @@ import org.aya.generic.NameGenerator;
 import org.aya.primitive.ShapeFactory;
 import org.aya.syntax.ref.ModulePath;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class FileSerializer extends AbstractSerializer<FileSerializer.FileResult> {
   public record FileResult(
-    @Nullable ModulePath parentModule,
+    @NotNull ModulePath modulePath,
     @NotNull ModuleSerializer.ModuleResult moduleResult
   ) { }
 
@@ -21,13 +20,13 @@ public class FileSerializer extends AbstractSerializer<FileSerializer.FileResult
     this.shapeFactory = factory;
   }
 
-  private void buildPackage(@Nullable ModulePath path) {
-    appendLine(STR."package \{getModuleReference(path)};");
+  private void buildPackage(@NotNull ModulePath path) {
+    appendLine(STR."package \{getModulePackageReference(path)};");
   }
 
   @Override
   public AyaSerializer<FileResult> serialize(FileResult unit) {
-    buildPackage(unit.parentModule);
+    buildPackage(unit.modulePath);
     appendLine();
     appendLine(AyaSerializer.IMPORT_BLOCK);
     appendLine();

--- a/jit-compiler/src/main/java/org/aya/compiler/JitTeleSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/JitTeleSerializer.java
@@ -71,7 +71,7 @@ public abstract class JitTeleSerializer<T extends TyckDef> extends AbstractSeria
   }
 
   private @NotNull String getClassName(@NotNull T unit) {
-    return javify(unit.ref());
+    return javifyClassName(unit.ref());
   }
 
   public void buildInstance(@NotNull String className) {

--- a/jit-compiler/src/main/java/org/aya/compiler/ModuleSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/ModuleSerializer.java
@@ -6,6 +6,7 @@ import kala.collection.immutable.ImmutableSeq;
 import org.aya.generic.NameGenerator;
 import org.aya.primitive.ShapeFactory;
 import org.aya.syntax.core.def.*;
+import org.aya.syntax.ref.QPath;
 import org.aya.util.IterableUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public final class ModuleSerializer extends AbstractSerializer<ModuleSerializer.ModuleResult> {
   public record ModuleResult(
-    @NotNull String name,
+    @NotNull QPath name,
     @NotNull ImmutableSeq<TopLevelDef> defs,
     @NotNull ImmutableSeq<ModuleResult> submodules
   ) { }
@@ -50,7 +51,7 @@ public final class ModuleSerializer extends AbstractSerializer<ModuleSerializer.
   }
 
   private void doSerialize(ModuleResult unit, boolean isTopLevel) {
-    var moduleName = javify(unit.name);
+    var moduleName = javifyClassName(unit.name, null);
 
     buildClass(moduleName, null, !isTopLevel, () -> {
       IterableUtil.forEach(unit.defs, this::appendLine, this::doSerialize);

--- a/jit-compiler/src/test/java/CompileTest.java
+++ b/jit-compiler/src/test/java/CompileTest.java
@@ -21,6 +21,7 @@ import org.aya.syntax.core.term.AppTerm;
 import org.aya.syntax.core.term.LamTerm;
 import org.aya.syntax.core.term.LocalTerm;
 import org.aya.syntax.core.term.call.ConCall;
+import org.aya.syntax.ref.ModulePath;
 import org.aya.util.error.SourceFile;
 import org.aya.util.reporter.ThrowingReporter;
 import org.intellij.lang.annotations.Language;
@@ -103,8 +104,8 @@ public class CompileTest {
 
   public static @NotNull String serializeFrom(@NotNull TyckResult result) {
     return new FileSerializer(result.info.shapeFactory())
-      .serialize(new FileSerializer.FileResult(null, new ModuleSerializer.ModuleResult(
-        DumbModuleLoader.DUMB_MODULE_NAME, result.defs.filterIsInstance(TopLevelDef.class), ImmutableSeq.empty())))
+      .serialize(new ModuleSerializer.ModuleResult(
+        DumbModuleLoader.DUMB_MODULE_NAME, result.defs.filterIsInstance(TopLevelDef.class), ImmutableSeq.empty()))
       .result();
   }
 

--- a/jit-compiler/src/test/java/CompileTest.java
+++ b/jit-compiler/src/test/java/CompileTest.java
@@ -21,7 +21,6 @@ import org.aya.syntax.core.term.AppTerm;
 import org.aya.syntax.core.term.LamTerm;
 import org.aya.syntax.core.term.LocalTerm;
 import org.aya.syntax.core.term.call.ConCall;
-import org.aya.syntax.ref.ModulePath;
 import org.aya.util.error.SourceFile;
 import org.aya.util.reporter.ThrowingReporter;
 import org.intellij.lang.annotations.Language;
@@ -51,9 +50,9 @@ public class CompileTest {
       tester.compile();
       var loader = tester.cl;
 
-      var fieldO = loader.loadClass("AYA.baka$Nat$O").getField("INSTANCE");
-      var fieldS = loader.loadClass("AYA.baka$Nat$S").getField("INSTANCE");
-      var fieldPlus = loader.loadClass("AYA.baka$plus").getField("INSTANCE");
+      var fieldO = loader.loadClass("AYA.$baka$$baka$Nat$$baka$Nat$O").getField("INSTANCE");
+      var fieldS = loader.loadClass("AYA.$baka$$baka$Nat$$baka$Nat$S").getField("INSTANCE");
+      var fieldPlus = loader.loadClass("AYA.$baka$$baka$plus").getField("INSTANCE");
       fieldO.setAccessible(true);
       fieldS.setAccessible(true);
       fieldPlus.setAccessible(true);

--- a/jit-compiler/src/test/java/MiscTest.java
+++ b/jit-compiler/src/test/java/MiscTest.java
@@ -1,0 +1,27 @@
+// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+import org.aya.compiler.AbstractSerializer;
+import org.aya.compiler.AyaSerializer;
+import org.aya.syntax.ref.ModulePath;
+import org.aya.syntax.ref.QName;
+import org.aya.syntax.ref.QPath;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MiscTest {
+  public static final @NotNull QPath TOP = new QPath(ModulePath.of("baka", "114514"), 2);
+  public static final @NotNull QPath SUB = TOP.derive("hentai");
+  public static final @NotNull QName NAME = new QName(SUB, "urusai");
+
+  @Test
+  public void test0() {
+    var result = AbstractSerializer.getReference(TOP, null);
+    assertEquals(STR."\{AyaSerializer.PACKAGE_BASE}.baka.$114514", result);
+    result = AbstractSerializer.getReference(SUB, null);
+    assertEquals(STR."\{AyaSerializer.PACKAGE_BASE}.baka.$114514.$114514$hentai", result);
+    result = AbstractSerializer.getReference(NAME.module(), NAME.name());
+    assertEquals(STR."\{AyaSerializer.PACKAGE_BASE}.baka.$114514.$114514$hentai.$114514$hentai$urusai", result);
+  }
+}

--- a/jit-compiler/src/test/java/RedBlackTreeTest.java
+++ b/jit-compiler/src/test/java/RedBlackTreeTest.java
@@ -12,6 +12,8 @@ import org.aya.syntax.core.term.call.DataCall;
 import org.aya.syntax.core.term.repr.IntegerTerm;
 import org.aya.syntax.core.term.repr.ListTerm;
 import org.aya.syntax.literate.CodeOptions;
+import org.aya.syntax.ref.ModulePath;
+import org.aya.syntax.ref.QPath;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -19,7 +21,8 @@ import java.util.Random;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 
-import static org.aya.compiler.AbstractSerializer.javify;
+import static org.aya.compiler.AbstractSerializer.getClassName;
+import static org.aya.compiler.AbstractSerializer.getReference;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class RedBlackTreeTest {
@@ -33,13 +36,15 @@ public class RedBlackTreeTest {
     var tester = new CompileTester(CompileTest.serializeFrom(result));
     tester.compile();
 
-    JitData List = tester.loadInstance("baka", "List");
-    JitCon nil = tester.loadInstance("baka", "List", javify("[]"));
-    JitCon cons = tester.loadInstance("baka", "List", javify(":>"));
-    JitData Nat = tester.loadInstance("baka", "Nat");
-    JitCon O = tester.loadInstance("baka", "Nat", "O");
-    JitCon S = tester.loadInstance("baka", "Nat", "S");
-    JitFn tree_sortNat = tester.loadInstance("baka", "tree_sortNat");
+    var baka = QPath.fileLevel(ModulePath.of("baka"));
+
+    JitData List = tester.loadInstance(getClassName(baka, "List"));
+    JitCon nil = tester.loadInstance(getClassName(baka.derive("List"), "[]"));
+    JitCon cons = tester.loadInstance(getClassName(baka.derive("List"), ":>"));
+    JitData Nat = tester.loadInstance(getClassName(baka, "Nat"));
+    JitCon O = tester.loadInstance(getClassName(baka.derive("Nat"), "O"));
+    JitCon S = tester.loadInstance(getClassName(baka.derive("Nat"), "S"));
+    JitFn tree_sortNat = tester.loadInstance(getClassName(baka, "tree_sortNat"));
 
     var NatCall = new DataCall(Nat, 0, ImmutableSeq.empty());
     var ListNatCall = new DataCall(List, 0, ImmutableSeq.of(NatCall));

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/ModuleName.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/ModuleName.java
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.syntax.concrete.stmt;
 
+import kala.collection.SeqLike;
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.util.error.Panic;
 import org.jetbrains.annotations.NotNull;
@@ -54,9 +55,9 @@ public sealed interface ModuleName extends Serializable {
 
   @NotNull ModuleName.ThisRef This = ThisRef.Obj;
 
-  static @NotNull ModuleName from(@NotNull ImmutableSeq<String> ids) {
+  static @NotNull ModuleName from(@NotNull SeqLike<String> ids) {
     if (ids.isEmpty()) return This;
-    return new Qualified(ids);
+    return new Qualified(ids.toImmutableSeq());
   }
 
   /**

--- a/syntax/src/main/java/org/aya/syntax/ref/QName.java
+++ b/syntax/src/main/java/org/aya/syntax/ref/QName.java
@@ -8,6 +8,9 @@ import org.jetbrains.annotations.NotNull;
 import java.io.Serializable;
 import java.util.Objects;
 
+/**
+ * A qualified name to some definition
+ */
 public record QName(@NotNull QPath module, @NotNull String name) implements Serializable {
   public QName(@NotNull DefVar<?, ?> ref) {
     this(Objects.requireNonNull(ref.module), ref.name());

--- a/syntax/src/main/java/org/aya/syntax/ref/QPath.java
+++ b/syntax/src/main/java/org/aya/syntax/ref/QPath.java
@@ -31,6 +31,10 @@ public record QPath(@NotNull ModulePath module, int fileModuleSize) implements S
     return new QPath(module.derive(name), fileModuleSize);
   }
 
+  public boolean isFileModule() {
+    return module.size() == fileModuleSize;
+  }
+
   /**
    * Iterate a {@link ModulePath} in file tree way, starts from {@link #fileModule}
    */

--- a/syntax/src/main/java/org/aya/syntax/ref/QPath.java
+++ b/syntax/src/main/java/org/aya/syntax/ref/QPath.java
@@ -2,16 +2,45 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.syntax.ref;
 
+import kala.collection.immutable.ImmutableSeq;
+import kala.collection.mutable.MutableArray;
+import kala.collection.mutable.MutableList;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.Serializable;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
+/**
+ * A qualified path to some module
+ */
 public record QPath(@NotNull ModulePath module, int fileModuleSize) implements Serializable {
+  public static @NotNull QPath fileLevel(@NotNull ModulePath fileLevelModule) {
+    return new QPath(fileLevelModule, fileLevelModule.size());
+  }
+
   public QPath {
     assert 0 < fileModuleSize && fileModuleSize <= module.module().size();
   }
 
   public @NotNull ModulePath fileModule() {
     return new ModulePath(module.module().take(fileModuleSize));
+  }
+
+  public @NotNull QPath derive(@NotNull String name) {
+    return new QPath(module.derive(name), fileModuleSize);
+  }
+
+  /**
+   * Iterate a {@link ModulePath} in file tree way, starts from {@link #fileModule}
+   */
+  public <R> @NotNull ImmutableSeq<R> traversal(Function<QPath, R> tabibito) {
+    var result = MutableList.<R>create();
+
+    for (int i = fileModuleSize; i <= module.size(); ++i) {
+      result.append(tabibito.apply(new QPath(new ModulePath(module.module().take(i)), fileModuleSize)));
+    }
+
+    return result.toImmutableSeq();
   }
 }


### PR DESCRIPTION
This PR uses a new version of the class name generator, consider a qualified name: `ayaPackage::ayaFile::subModule::foo`,
where `ayaPackage::ayaFile` is a qualified name to a file-level module, `ayaPackage::ayaFile::subModule` is a qualified name to a sub-level module.
The new generator will produce `$ayaFile$subModule$foo` as the class name of  `ayaPackage::ayaFile::subModule::foo`,
note that `ayaPackage` disappears, since it is a package name.