### PR TITLE
Initial `class` related code

### DIFF
--- a/base/src/main/java/org/aya/resolve/ResolveInfo.java
+++ b/base/src/main/java/org/aya/resolve/ResolveInfo.java
@@ -64,12 +64,8 @@ public record ResolveInfo(
       MutableMap.create(), MutableMap.create(), MutableMap.create(), MutableGraph.create());
   }
   public ExprTycker newTycker() { return newTycker(opSet.reporter); }
-  public ExprTycker newTycker(@NotNull Reporter reporter) {
-    return new ExprTycker(makeTyckState(), reporter);
-  }
-  public @NotNull TyckState makeTyckState() {
-    return new TyckState(shapeFactory, primFactory);
-  }
+  public ExprTycker newTycker(@NotNull Reporter reporter) { return new ExprTycker(makeTyckState(), reporter); }
+  public @NotNull TyckState makeTyckState() { return new TyckState(shapeFactory, primFactory); }
 
   public record ImportInfo(@NotNull ResolveInfo resolveInfo, boolean reExport) { }
   public record OpRenameInfo(

--- a/base/src/main/java/org/aya/resolve/visitor/StmtPreResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtPreResolver.java
@@ -112,7 +112,7 @@ public record StmtPreResolver(@NotNull ModuleLoader loader, @NotNull ResolveInfo
       case ClassDecl decl -> {
         var ctx = resolveTopLevelDecl(decl, context);
         var innerCtx = resolveChildren(decl, ctx, d -> d.members.view(), (mem, mCtx) ->
-          mCtx.defineSymbol(mem, Stmt.Accessibility.Public, mem.definition()));
+          mCtx.defineSymbol(mem.ref(), Stmt.Accessibility.Public, mem.ref().definition()));
         yield new ResolvingStmt.TopDecl(decl, innerCtx);
       }
       case FnDecl decl -> {

--- a/base/src/main/java/org/aya/resolve/visitor/StmtPreResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtPreResolver.java
@@ -13,10 +13,7 @@ import org.aya.resolve.error.NameProblem;
 import org.aya.resolve.error.PrimResolveError;
 import org.aya.resolve.module.ModuleLoader;
 import org.aya.syntax.concrete.stmt.*;
-import org.aya.syntax.concrete.stmt.decl.DataDecl;
-import org.aya.syntax.concrete.stmt.decl.Decl;
-import org.aya.syntax.concrete.stmt.decl.FnDecl;
-import org.aya.syntax.concrete.stmt.decl.PrimDecl;
+import org.aya.syntax.concrete.stmt.decl.*;
 import org.aya.syntax.core.def.AnyDef;
 import org.aya.syntax.core.def.PrimDef;
 import org.aya.syntax.ref.DefVar;
@@ -112,14 +109,15 @@ public record StmtPreResolver(@NotNull ModuleLoader loader, @NotNull ResolveInfo
         });
         yield new ResolvingStmt.TopDecl(decl, innerCtx);
       }
-      // case ClassDecl decl -> {
-      //   var ctx = resolveTopLevelDecl(decl, context);
-      //   var innerCtx = resolveChildren(decl, decl, ctx, s -> s.members.view(), (field, mockCtx) -> {
-      //     field.ref().module = mockCtx.modulePath().path();
-      //     field.ref().fileModule = resolveInfo.thisModule().modulePath().path();
-      //     mockCtx.defineSymbol(field.ref, Stmt.Accessibility.Public, field.sourcePos());
-      //   });
-      // }
+      case ClassDecl decl -> {
+        var ctx = resolveTopLevelDecl(decl, context);
+        // var innerCtx = resolveChildren(decl, decl, ctx, s -> s.members.view(), (field, mockCtx) -> {
+        //   field.ref().module = mockCtx.modulePath().path();
+        //   field.ref().fileModule = resolveInfo.thisModule().modulePath().path();
+        //   mockCtx.defineSymbol(field.ref, Stmt.Accessibility.Public, field.sourcePos());
+        // });
+        yield new ResolvingStmt.TopDecl(decl, ctx);
+      }
       case FnDecl decl -> {
         var innerCtx = resolveTopLevelDecl(decl, context);
         yield new ResolvingStmt.TopDecl(decl, innerCtx);

--- a/base/src/main/java/org/aya/resolve/visitor/StmtPreResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtPreResolver.java
@@ -112,7 +112,7 @@ public record StmtPreResolver(@NotNull ModuleLoader loader, @NotNull ResolveInfo
       case ClassDecl decl -> {
         var ctx = resolveTopLevelDecl(decl, context);
         var innerCtx = resolveChildren(decl, ctx, d -> d.members.view(), (mem, mCtx) ->
-          mCtx.defineSymbol(mem, Stmt.Accessibility.Public, mem.name.definition()));
+          mCtx.defineSymbol(mem, Stmt.Accessibility.Public, mem.definition()));
         yield new ResolvingStmt.TopDecl(decl, innerCtx);
       }
       case FnDecl decl -> {

--- a/base/src/main/java/org/aya/resolve/visitor/StmtPreResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtPreResolver.java
@@ -111,12 +111,9 @@ public record StmtPreResolver(@NotNull ModuleLoader loader, @NotNull ResolveInfo
       }
       case ClassDecl decl -> {
         var ctx = resolveTopLevelDecl(decl, context);
-        // var innerCtx = resolveChildren(decl, decl, ctx, s -> s.members.view(), (field, mockCtx) -> {
-        //   field.ref().module = mockCtx.modulePath().path();
-        //   field.ref().fileModule = resolveInfo.thisModule().modulePath().path();
-        //   mockCtx.defineSymbol(field.ref, Stmt.Accessibility.Public, field.sourcePos());
-        // });
-        yield new ResolvingStmt.TopDecl(decl, ctx);
+        var innerCtx = resolveChildren(decl, ctx, d -> d.members.view(), (mem, mCtx) ->
+          mCtx.defineSymbol(mem, Stmt.Accessibility.Public, mem.name.definition()));
+        yield new ResolvingStmt.TopDecl(decl, innerCtx);
       }
       case FnDecl decl -> {
         var innerCtx = resolveTopLevelDecl(decl, context);
@@ -141,7 +138,7 @@ public record StmtPreResolver(@NotNull ModuleLoader loader, @NotNull ResolveInfo
     };
   }
 
-  private <D extends Decl, Child extends Decl> PhysicalModuleContext resolveChildren(
+  private <D extends Decl, Child> PhysicalModuleContext resolveChildren(
     @NotNull D decl,
     @NotNull ModuleContext context,
     @NotNull Function<D, SeqView<Child>> childrenGet,

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -104,8 +104,8 @@ public record StmtTycker(
           }
         };
       }
-      case DataCon con -> Objects.requireNonNull(con.ref.core);   // see checkHeader
-      case PrimDecl prim -> Objects.requireNonNull(prim.ref.core);
+      case DataCon _, PrimDecl _, ClassDecl _ ->
+        Objects.requireNonNull(predecl.ref().core);   // see checkHeader
       case DataDecl data -> {
         var sig = data.ref.signature;
         assert sig != null;
@@ -120,6 +120,9 @@ public record StmtTycker(
     switch (decl) {
       case DataCon con -> checkKitsune(con, tycker);
       case PrimDecl prim -> checkPrim(tycker, prim);
+      case ClassDecl clazz -> {
+        throw new UnsupportedOperationException("TODO");
+      }
       case DataDecl data -> {
         var teleTycker = new TeleTycker.Default(tycker);
         var result = data.result;

--- a/base/src/test/java/org/aya/syntax/concrete/SyntaxTest.java
+++ b/base/src/test/java/org/aya/syntax/concrete/SyntaxTest.java
@@ -28,6 +28,11 @@ public class SyntaxTest {
         let open Nat in
         let n := a + b in n
       tighter + looser +
+      open class Cat
+      | A : Type
+      open class Monoid
+      | A : Type
+      | infixl + : Fn (a b : A) -> A
       """);
     for (var stmt : res) {
       assertNotNull(stmt.toDoc(AyaPrettierOptions.debug()).debugRender());

--- a/cli-impl/src/main/java/org/aya/cli/utils/LiteratePrettierOptions.java
+++ b/cli-impl/src/main/java/org/aya/cli/utils/LiteratePrettierOptions.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.cli.utils;
 
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 import java.io.IOException;
 
 /**
- * A JSON object for {@link org.aya.cli.render.RenderOptions} and {@link org.aya.prettier.AyaPrettierOptions }
+ * A JSON object for {@link RenderOptions} and {@link AyaPrettierOptions }
  *
  * @see org.aya.cli.interactive.ReplConfig
  * @see org.aya.cli.library.json.LibraryConfigData

--- a/jit-compiler/src/main/java/org/aya/compiler/CompiledModule.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/CompiledModule.java
@@ -88,7 +88,7 @@ public record CompiledModule(
     @NotNull ModulePath path, @NotNull ImmutableSeq<String> rename,
     boolean isPublic) implements Serializable { }
 
-  /** @see org.aya.syntax.concrete.stmt.UseHide */
+  /** @see UseHide */
   record SerUseHide(
     boolean isUsing,
     @NotNull ImmutableSeq<ImmutableSeq<String>> names,

--- a/jit-compiler/src/main/java/org/aya/compiler/ModuleSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/ModuleSerializer.java
@@ -44,6 +44,12 @@ public final class ModuleSerializer extends AbstractSerializer<ModuleSerializer.
         .serialize(conDef);
       case PrimDef primDef -> new PrimSerializer(this)
         .serialize(primDef);
+      case ClassDef classDef -> {
+        throw new UnsupportedOperationException("ClassDef");
+      }
+      case MemberDef memberDef -> {
+        throw new UnsupportedOperationException("MemberDef");
+      }
     }
   }
 

--- a/parser/src/main/grammar/AyaPsiParser.bnf
+++ b/parser/src/main/grammar/AyaPsiParser.bnf
@@ -158,7 +158,7 @@ private stmt_with_recover ::= !(<<eof>>) stmt {
 private stmt_recover ::= !(stmt_first)
 private stmt_first ::= KW_IMPORT | KW_MODULE | DOC_COMMENT | KW_PUBLIC
                      | KW_DEF | KW_CLASS | KW_PRIM | KW_DATA | KW_VARIABLE
-                     | declModifiers
+                     | declModifier
 
 private repl ::= REPL_COMMAND? expr
 
@@ -197,7 +197,7 @@ bindBlock ::= (tighters | loosers)+
 tighters ::= KW_TIGHTER qualifiedId+
 loosers ::= KW_LOOSER qualifiedId+
 
-fnDecl ::= declModifiers*
+fnDecl ::= declModifier*
  KW_DEF declNameOrInfix
  tele* type? fnBody bindBlock? { pin=2 }
 private simpleBody ::= IMPLIES expr { pin=1 }
@@ -213,28 +213,29 @@ primName ::= weakId
 primDecl ::= KW_PRIM primName tele* type? { pin=1 }
 
 // IMPORTANT NOTE: Adding all of these to stmt_first or you will get parser errors!
-declModifiers ::= KW_PRIVATE
-                | KW_EXAMPLE
-                | KW_OPAQUE
-                | KW_INLINE
-                | KW_OVERLAP
-                | KW_PARTIAL
-                | KW_OPEN
+declModifier ::= KW_PRIVATE
+               | KW_EXAMPLE
+               | KW_OPAQUE
+               | KW_INLINE
+               | KW_OVERLAP
+               | KW_PARTIAL
+               | KW_OPEN
 
 classDecl
-  ::= declModifiers*
+  ::= declModifier*
       KW_CLASS declNameOrInfix (KW_EXTENDS <<commaSep weakId>>)?
       bindBlock?
       (BAR classMember)*
 
+memberModifier ::= KW_CLASSIFIYING | KW_OVERRIDE | KW_COERCE
 classMember
-  ::= KW_CLASSIFIYING? KW_OVERRIDE?            declNameOrInfix tele* type? IMPLIES expr bindBlock?
-    | KW_CLASSIFIYING? KW_OVERRIDE? KW_COERCE? declNameOrInfix tele* type               bindBlock? {
+  ::= memberModifier* declNameOrInfix type? IMPLIES expr bindBlock?
+    | memberModifier* declNameOrInfix type               bindBlock? {
   mixin="org.aya.intellij.psi.impl.AyaPsiGenericDeclImpl"
   implements="org.aya.intellij.psi.AyaPsiGenericDecl"
 }
 
-dataDecl ::= declModifiers*
+dataDecl ::= declModifier*
  KW_DATA declNameOrInfix?
  tele* type? bindBlock? dataBody* { pin=2 }
 

--- a/producer/src/main/java/org/aya/producer/AyaProducer.java
+++ b/producer/src/main/java/org/aya/producer/AyaProducer.java
@@ -32,6 +32,7 @@ import org.aya.syntax.concrete.stmt.*;
 import org.aya.syntax.concrete.stmt.decl.*;
 import org.aya.syntax.ref.GeneralizedVar;
 import org.aya.syntax.ref.LocalVar;
+import org.aya.syntax.ref.MemberVar;
 import org.aya.syntax.ref.ModulePath;
 import org.aya.util.Arg;
 import org.aya.util.binop.Assoc;
@@ -223,7 +224,7 @@ public record AyaProducer(
     if (node.is(FN_DECL)) return fnDecl(node);
     if (node.is(PRIM_DECL)) return primDecl(node);
     if (node.is(DATA_DECL)) return dataDecl(node, additional);
-    // if (node.is(CLASS_DECL)) return classDecl(node, additional);
+    if (node.is(CLASS_DECL)) return classDecl(node, additional);
     return unreachable(node);
   }
 
@@ -251,8 +252,8 @@ public record AyaProducer(
   private record DeclParseData(
     @NotNull GenericNode<?> node,
     @NotNull DeclInfo info,
-    @Nullable String name
-    , @NotNull ModifierParser.Modifiers modifier
+    @Nullable String name,
+    @NotNull ModifierParser.Modifiers modifier
   ) {
     public @Nullable String checkName(@NotNull AyaProducer self) {
       if (name != null) return name;
@@ -260,9 +261,7 @@ public record AyaProducer(
     }
   }
 
-  private @NotNull DeclParseData declInfo(
-    @NotNull GenericNode<?> node, @NotNull ModifierParser.Filter filter
-  ) {
+  private @NotNull DeclParseData declInfo(@NotNull GenericNode<?> node, @NotNull ModifierParser.Filter filter) {
     var modifier = declModifiersOf(node, filter);
     var bind = node.peekChild(BIND_BLOCK);
     var nameOrInfix = Option.ofNullable(declNameOrInfix(node.peekChild(DECL_NAME_OR_INFIX)));
@@ -354,29 +353,28 @@ public record AyaProducer(
     return error(node.childrenView().getFirst(), "Expect a data constructor");
   }
 
-  // public @Nullable ClassDecl classDecl(@NotNull GenericNode<?> node, @NotNull MutableList<Stmt> additional) {
-  //   var info = declInfo(node, ModifierParser.DECL_FILTER);
-  //   var name = info.checkName(this);
-  //   if (name == null) return null;
-  //   var members = node.childrenOfType(CLASS_MEMBER).map(this::classMember).toImmutableSeq();
-  //   var decl = new ClassDecl(info.info, name, members);
-  //   giveMeOpen(info.modifier, decl, additional);
-  //   return decl;
-  // }
+  public @Nullable ClassDecl classDecl(@NotNull GenericNode<?> node, @NotNull MutableList<Stmt> additional) {
+    var info = declInfo(node, ModifierParser.DECL_FILTER);
+    var name = info.checkName(this);
+    if (name == null) return null;
+    var members = node.childrenOfType(CLASS_MEMBER).mapIndexed(this::classMember).toImmutableSeq();
+    var decl = new ClassDecl(name, info.info, members);
+    giveMeOpen(info.modifier, decl, additional);
+    return decl;
+  }
 
-  // public @NotNull ClassDecl.Member classMember(int index, GenericNode<?> node) {
-  //   var tele = telescope(node.childrenOfType(TELE).map(x -> x));
-  //   var info = declInfo(node, ModifierParser.SUBDECL_FILTER);
-  //   var name = info.checkName(this);
-  //   if (name == null) return unreachable(node);
-  //   return new ClassDecl.Member(
-  //     new MemberVar(index, name),
-  //     info.info, name, tele,
-  //     typeOrHole(node.peekChild(TYPE), info.info.sourcePos()),
-  //     Option.ofNullable(node.peekChild(EXPR)).map(this::expr),
-  //     node.peekChild(KW_COERCE) != null
-  //   );
-  // }
+  public @NotNull ClassDecl.Member classMember(int index, GenericNode<?> node) {
+    var info = declInfo(node, ModifierParser.SUBDECL_FILTER);
+    var name = info.checkName(this);
+    if (name == null) return unreachable(node);
+    var local = new LocalVar(name, info.info.sourcePos());
+    var typeExpr = typeOrHole(node.peekChild(TYPE), info.info.sourcePos());
+    return new ClassDecl.Member(
+      new MemberVar(index, local),
+      new Expr.Param(info.info.entireSourcePos(), local, typeExpr, true),
+      info.info.bindBlock(),
+      info.info.opInfo());
+  }
 
   private <T> @Nullable T error(@NotNull GenericNode<?> node, @NotNull String message) {
     reporter.report(new ParseError(sourcePosOf(node), message));

--- a/producer/src/main/java/org/aya/producer/AyaProducer.java
+++ b/producer/src/main/java/org/aya/producer/AyaProducer.java
@@ -356,7 +356,7 @@ public record AyaProducer(
 
   // public @Nullable ClassDecl classDecl(@NotNull GenericNode<?> node, @NotNull MutableList<Stmt> additional) {
   //   var info = declInfo(node, ModifierParser.DECL_FILTER);
-  //   var name = info.checkName(this, true);
+  //   var name = info.checkName(this);
   //   if (name == null) return null;
   //   var members = node.childrenOfType(CLASS_MEMBER).map(this::classMember).toImmutableSeq();
   //   var decl = new ClassDecl(info.info, name, members);
@@ -364,12 +364,13 @@ public record AyaProducer(
   //   return decl;
   // }
 
-  // public @NotNull TeleDecl.ClassMember classMember(GenericNode<?> node) {
+  // public @NotNull ClassDecl.Member classMember(int index, GenericNode<?> node) {
   //   var tele = telescope(node.childrenOfType(TELE).map(x -> x));
   //   var info = declInfo(node, ModifierParser.SUBDECL_FILTER);
-  //   var name = info.checkName(this, true);
+  //   var name = info.checkName(this);
   //   if (name == null) return unreachable(node);
-  //   return new TeleDecl.ClassMember(
+  //   return new ClassDecl.Member(
+  //     new MemberVar(index, name),
   //     info.info, name, tele,
   //     typeOrHole(node.peekChild(TYPE), info.info.sourcePos()),
   //     Option.ofNullable(node.peekChild(EXPR)).map(this::expr),

--- a/syntax/src/main/java/org/aya/generic/Constants.java
+++ b/syntax/src/main/java/org/aya/generic/Constants.java
@@ -26,16 +26,12 @@ public interface Constants {
 
   @NotNull @NonNls String ALTERNATIVE_EMPTY = "empty";
   @NotNull @NonNls String ALTERNATIVE_OR = "<|>";
-  @NotNull @NonNls String LIST_NIL = "nil";
-  @NotNull @NonNls String LIST_CONS = ":<";
   @NotNull @NonNls String APPLICATIVE_APP = "<*>";
   @NotNull @NonNls String FUNCTOR_PURE = "pure";
   @NotNull @NonNls String MONAD_BIND = ">>=";
 
   @NotNull Expr alternativeOr = new Expr.Unresolved(SourcePos.NONE, ALTERNATIVE_OR);
   @NotNull Expr alternativeEmpty = new Expr.Unresolved(SourcePos.NONE, ALTERNATIVE_EMPTY);
-  @NotNull Expr listNil = new Expr.Unresolved(SourcePos.NONE, LIST_NIL);
-  @NotNull Expr listCons = new Expr.Unresolved(SourcePos.NONE, LIST_CONS);
   @NotNull Expr applicativeApp = new Expr.Unresolved(SourcePos.NONE, APPLICATIVE_APP);
   @NotNull Expr functorPure = new Expr.Unresolved(SourcePos.NONE, FUNCTOR_PURE);
   @NotNull Expr monadBind = new Expr.Unresolved(SourcePos.NONE, MONAD_BIND);

--- a/syntax/src/main/java/org/aya/prettier/ConcretePrettier.java
+++ b/syntax/src/main/java/org/aya/prettier/ConcretePrettier.java
@@ -338,15 +338,12 @@ public class ConcretePrettier extends BasePrettier<Expr> {
 
   public @NotNull Doc decl(@NotNull Decl predecl) {
     return switch (predecl) {
-      /*case ClassDecl decl -> {
-        var prelude = MutableList.of(Doc.styled(KEYWORD, "class"));
-        prelude.append(linkDef(decl.ref, CLAZZ));
-        yield Doc.cat(Doc.sepNonEmpty(prelude),
-          Doc.emptyIf(decl.members.isEmpty(), () -> Doc.cat(Doc.line(), Doc.nest(2, Doc.vcat(
-            decl.members.view().map(this::decl))))),
-          visitBindBlock(decl.bindBlock())
-        );
-      }*/
+      case ClassDecl decl -> {
+        var prelude = MutableList.of(KW_CLASS);
+        prelude.append(defVar(decl.ref));
+        prelude.append(visitTele(decl.telescope));
+        yield Doc.cat(Doc.sepNonEmpty(prelude), visitBindBlock(decl.bindBlock()));
+      }
       case FnDecl decl -> {
         var prelude = declPrelude(decl);
         prelude.appendAll(Seq.from(decl.modifiers).view().map(this::visitModifier));

--- a/syntax/src/main/java/org/aya/prettier/Tokens.java
+++ b/syntax/src/main/java/org/aya/prettier/Tokens.java
@@ -38,6 +38,7 @@ public final class Tokens {
   public static final Doc KW_IN = Doc.styled(KEYWORD, "in");
   public static final Doc KW_DEF = Doc.styled(KEYWORD, "def");
   public static final Doc KW_DATA = Doc.styled(KEYWORD, "inductive");
+  public static final Doc KW_CLASS = Doc.styled(KEYWORD, "class");
   public static final Doc PAT_ABSURD = Doc.styled(KEYWORD, "()");
   public static final Doc KW_TIGHTER = Doc.styled(KEYWORD, "tighter");
   public static final Doc KW_LOOSER = Doc.styled(KEYWORD, "looser");

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/StmtVisitor.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/StmtVisitor.java
@@ -95,7 +95,7 @@ public interface StmtVisitor extends Consumer<Stmt> {
         visitTelescopic(decl);
         switch (decl) {
           case DataDecl data -> data.body.forEach(this);
-          case ClassDecl clazz -> clazz.members.forEach(m -> visitVarDecl(m.definition(), m, noType));
+          case ClassDecl clazz -> clazz.members.forEach(m -> visitVarDecl(m.ref().definition(), m.ref(), noType));
           case FnDecl fn -> {
             fn.body.forEach(this::visitExpr, cl -> cl.forEach(this::visitExpr,
               this::visitPattern));

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/StmtVisitor.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/StmtVisitor.java
@@ -95,7 +95,7 @@ public interface StmtVisitor extends Consumer<Stmt> {
         visitTelescopic(decl);
         switch (decl) {
           case DataDecl data -> data.body.forEach(this);
-          // case ClassDecl clazz -> clazz.members.forEach(this);
+          case ClassDecl clazz -> clazz.members.forEach(m -> visitVarDecl(m.definition(), m, noType));
           case FnDecl fn -> {
             fn.body.forEach(this::visitExpr, cl -> cl.forEach(this::visitExpr,
               this::visitPattern));
@@ -105,7 +105,6 @@ public interface StmtVisitor extends Consumer<Stmt> {
             }
           }
           case DataCon con -> con.patterns.forEach(cl -> visitPattern(cl.term()));
-          // case TeleDecl.ClassMember field -> field.body = field.body.map(this);
           case PrimDecl _ -> { }
         }
       }

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/ClassDecl.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/ClassDecl.java
@@ -4,18 +4,25 @@ package org.aya.syntax.concrete.stmt.decl;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.syntax.concrete.Expr;
-import org.aya.syntax.core.def.TyckDef;
+import org.aya.syntax.core.def.ClassDef;
 import org.aya.syntax.ref.DefVar;
+import org.aya.syntax.ref.MemberVar;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * The fields of a class is represented as a telescope,
+ * where we introduce the members as definition-level variables.
+ */
 public final class ClassDecl extends Decl {
-  public final @NotNull DefVar<?, ClassDecl> ref;
+  public final @NotNull DefVar<ClassDef, ClassDecl> ref;
+  public final @NotNull ImmutableSeq<MemberVar> members;
   public ClassDecl(
     @NotNull String name, @NotNull DeclInfo info,
     @NotNull ImmutableSeq<Expr.Param> telescope
   ) {
     super(info, telescope, null);
     this.ref = DefVar.concrete(this, name);
+    this.members = telescope.mapIndexed((i, param) -> new MemberVar(i, param.ref()));
   }
-  @Override public @NotNull DefVar<? extends TyckDef, ?> ref() { return ref; }
+  @Override public @NotNull DefVar<ClassDef, ClassDecl> ref() { return ref; }
 }

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/ClassDecl.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/ClassDecl.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.syntax.concrete.stmt.decl;
+
+import kala.collection.immutable.ImmutableSeq;
+import org.aya.syntax.concrete.Expr;
+import org.aya.syntax.core.def.TyckDef;
+import org.aya.syntax.ref.DefVar;
+import org.jetbrains.annotations.NotNull;
+
+public final class ClassDecl extends Decl {
+  public final @NotNull DefVar<?, ClassDecl> ref;
+  public ClassDecl(
+    @NotNull String name, @NotNull DeclInfo info,
+    @NotNull ImmutableSeq<Expr.Param> telescope
+  ) {
+    super(info, telescope, null);
+    this.ref = DefVar.concrete(this, name);
+  }
+  @Override public @NotNull DefVar<? extends TyckDef, ?> ref() { return ref; }
+}

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/ClassDecl.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/ClassDecl.java
@@ -4,10 +4,12 @@ package org.aya.syntax.concrete.stmt.decl;
 
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.syntax.concrete.Expr;
+import org.aya.syntax.concrete.stmt.BindBlock;
 import org.aya.syntax.core.def.ClassDef;
 import org.aya.syntax.ref.DefVar;
 import org.aya.syntax.ref.MemberVar;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * The fields of a class is represented as a telescope,
@@ -15,14 +17,20 @@ import org.jetbrains.annotations.NotNull;
  */
 public final class ClassDecl extends Decl {
   public final @NotNull DefVar<ClassDef, ClassDecl> ref;
-  public final @NotNull ImmutableSeq<MemberVar> members;
+  public final @NotNull ImmutableSeq<Member> members;
   public ClassDecl(
     @NotNull String name, @NotNull DeclInfo info,
-    @NotNull ImmutableSeq<Expr.Param> telescope
+    @NotNull ImmutableSeq<Member> members
   ) {
-    super(info, telescope, null);
+    super(info, members.map(Member::param), null);
     this.ref = DefVar.concrete(this, name);
-    this.members = telescope.mapIndexed((i, param) -> new MemberVar(i, param.ref()));
+    this.members = members;
   }
+  public record Member(
+    @NotNull MemberVar ref,
+    @NotNull Expr.Param param,
+    @NotNull BindBlock bindBlock,
+    @Nullable OpInfo opInfo
+  ) { }
   @Override public @NotNull DefVar<ClassDef, ClassDecl> ref() { return ref; }
 }

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/DataDecl.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/DataDecl.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
  * @see DataDef
  */
 public final class DataDecl extends Decl {
-  public final @NotNull DefVar<DataDef, org.aya.syntax.concrete.stmt.decl.DataDecl> ref;
+  public final @NotNull DefVar<DataDef, DataDecl> ref;
   public final @NotNull ImmutableSeq<DataCon> body;
 
   public DataDecl(
@@ -40,5 +40,5 @@ public final class DataDecl extends Decl {
     body.forEach(con -> con.descentInPlace(f, p));
   }
 
-  @Override public @NotNull DefVar<DataDef, org.aya.syntax.concrete.stmt.decl.DataDecl> ref() { return ref; }
+  @Override public @NotNull DefVar<DataDef, DataDecl> ref() { return ref; }
 }

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/Decl.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/Decl.java
@@ -59,6 +59,6 @@ public sealed abstract class Decl implements SourceNode, Stmt, TyckUnit, OpDecl
     modifyResult(f);
   }
 
-  @Contract(pure = true) public abstract @NotNull DefVar<? extends TyckDef, ?> ref();
+  @Contract(pure = true) public abstract @NotNull DefVar<?, ?> ref();
   public SeqView<LocalVar> teleVars() { return telescope.view().map(Expr.Param::ref); }
 }

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/Decl.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/Decl.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
  * @see Decl
  */
 public sealed abstract class Decl implements SourceNode, Stmt, TyckUnit, OpDecl
-  permits DataCon, DataDecl, FnDecl, PrimDecl {
+  permits ClassDecl, DataCon, DataDecl, FnDecl, PrimDecl {
   public @Nullable WithPos<Expr> result;
   // will change after resolve
   public @NotNull ImmutableSeq<Expr.Param> telescope;

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/FnDecl.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/FnDecl.java
@@ -23,7 +23,7 @@ import java.util.EnumSet;
  */
 public final class FnDecl extends Decl {
   public final @NotNull EnumSet<Modifier> modifiers;
-  public final @NotNull DefVar<FnDef, org.aya.syntax.concrete.stmt.decl.FnDecl> ref;
+  public final @NotNull DefVar<FnDef, FnDecl> ref;
   public @NotNull FnBody body;
 
   public FnDecl(
@@ -41,7 +41,7 @@ public final class FnDecl extends Decl {
     this.body = body;
   }
 
-  @Override public @NotNull DefVar<FnDef, org.aya.syntax.concrete.stmt.decl.FnDecl> ref() { return ref; }
+  @Override public @NotNull DefVar<FnDef, FnDecl> ref() { return ref; }
 
   @Override
   public void descentInPlace(@NotNull PosedUnaryOperator<Expr> f, @NotNull PosedUnaryOperator<Pattern> p) {

--- a/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/PrimDecl.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/stmt/decl/PrimDecl.java
@@ -13,12 +13,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * @implSpec the result field of {@link org.aya.syntax.concrete.stmt.decl.PrimDecl} might be {@link Expr.Error},
+ * @implSpec the result field of {@link PrimDecl} might be {@link Expr.Error},
  * which means it's unspecified in the concrete syntax.
  * @see PrimDef
  */
 public final class PrimDecl extends Decl {
-  public final @NotNull DefVar<PrimDef, org.aya.syntax.concrete.stmt.decl.PrimDecl> ref;
+  public final @NotNull DefVar<PrimDef, PrimDecl> ref;
 
   public PrimDecl(
     @NotNull SourcePos sourcePos, @NotNull SourcePos entireSourcePos,
@@ -30,5 +30,5 @@ public final class PrimDecl extends Decl {
     ref = DefVar.concrete(this, name);
   }
 
-  @Override public @NotNull DefVar<PrimDef, org.aya.syntax.concrete.stmt.decl.PrimDecl> ref() { return ref; }
+  @Override public @NotNull DefVar<PrimDef, PrimDecl> ref() { return ref; }
 }

--- a/syntax/src/main/java/org/aya/syntax/core/Closure.java
+++ b/syntax/src/main/java/org/aya/syntax/core/Closure.java
@@ -13,7 +13,7 @@ import java.util.function.UnaryOperator;
 
 /**
  * An "abstract" Lambda Term.<br/>
- * We also use it to represent a term that contains a "free" {@link org.aya.syntax.core.term.LocalTerm},
+ * We also use it to represent a term that contains a "free" {@link LocalTerm},
  * so we can handle them in a scope-safe manner.
  * Note that you shouldn't supply a {@link LocalTerm} to "DeBruijn Index"-lize a {@link Closure},
  * since it may contain another {@link Closure}, the safe way is to supply a {@link FreeTerm} then bind it,

--- a/syntax/src/main/java/org/aya/syntax/core/def/ClassDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/ClassDef.java
@@ -10,4 +10,9 @@ public record ClassDef(
   @Override @NotNull DefVar<ClassDef, ?> ref,
   @NotNull ImmutableSeq<MemberDef> members
 ) implements TopLevelDef {
+  public static class Delegate extends TyckAnyDef<ClassDef> {
+    public Delegate(@NotNull DefVar<ClassDef, ?> ref) {
+      super(ref);
+    }
+  }
 }

--- a/syntax/src/main/java/org/aya/syntax/core/def/ClassDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/ClassDef.java
@@ -11,8 +11,6 @@ public record ClassDef(
   @NotNull ImmutableSeq<MemberDef> members
 ) implements TopLevelDef {
   public static class Delegate extends TyckAnyDef<ClassDef> {
-    public Delegate(@NotNull DefVar<ClassDef, ?> ref) {
-      super(ref);
-    }
+    public Delegate(@NotNull DefVar<ClassDef, ?> ref) { super(ref); }
   }
 }

--- a/syntax/src/main/java/org/aya/syntax/core/def/ClassDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/ClassDef.java
@@ -1,0 +1,13 @@
+// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.syntax.core.def;
+
+import kala.collection.immutable.ImmutableSeq;
+import org.aya.syntax.ref.DefVar;
+import org.jetbrains.annotations.NotNull;
+
+public record ClassDef(
+  @Override @NotNull DefVar<ClassDef, ?> ref,
+  @NotNull ImmutableSeq<MemberDef> members
+) implements TopLevelDef {
+}

--- a/syntax/src/main/java/org/aya/syntax/core/def/ClassDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/ClassDef.java
@@ -3,11 +3,12 @@
 package org.aya.syntax.core.def;
 
 import kala.collection.immutable.ImmutableSeq;
+import org.aya.syntax.concrete.stmt.decl.ClassDecl;
 import org.aya.syntax.ref.DefVar;
 import org.jetbrains.annotations.NotNull;
 
 public record ClassDef(
-  @Override @NotNull DefVar<ClassDef, ?> ref,
+  @Override @NotNull DefVar<ClassDef, ClassDecl> ref,
   @NotNull ImmutableSeq<MemberDef> members
 ) implements TopLevelDef {
   public static class Delegate extends TyckAnyDef<ClassDef> {

--- a/syntax/src/main/java/org/aya/syntax/core/def/MemberDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/MemberDef.java
@@ -15,8 +15,6 @@ public record MemberDef(
   @Override @NotNull Term result
 ) implements TyckDef {
   public static class Delegate extends TyckAnyDef<MemberDef> {
-    public Delegate(@NotNull DefVar<MemberDef, ?> ref) {
-      super(ref);
-    }
+    public Delegate(@NotNull DefVar<MemberDef, ?> ref) { super(ref); }
   }
 }

--- a/syntax/src/main/java/org/aya/syntax/core/def/MemberDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/MemberDef.java
@@ -14,4 +14,9 @@ public record MemberDef(
   @Override ImmutableSeq<Param> telescope,
   @Override @NotNull Term result
 ) implements TyckDef {
+  public static class Delegate extends TyckAnyDef<MemberDef> {
+    public Delegate(@NotNull DefVar<MemberDef, ?> ref) {
+      super(ref);
+    }
+  }
 }

--- a/syntax/src/main/java/org/aya/syntax/core/def/MemberDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/MemberDef.java
@@ -1,0 +1,17 @@
+// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.syntax.core.def;
+
+import kala.collection.immutable.ImmutableSeq;
+import org.aya.syntax.core.term.Param;
+import org.aya.syntax.core.term.Term;
+import org.aya.syntax.ref.DefVar;
+import org.jetbrains.annotations.NotNull;
+
+public record MemberDef(
+  @NotNull DefVar<ClassDef, ?> classRef,
+  @Override @NotNull DefVar<MemberDef, ?> ref,
+  @Override ImmutableSeq<Param> telescope,
+  @Override @NotNull Term result
+) implements TyckDef {
+}

--- a/syntax/src/main/java/org/aya/syntax/core/def/TopLevelDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/TopLevelDef.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Top-level definitions.
  */
-public sealed interface TopLevelDef extends TyckDef permits DataDef, FnDef, PrimDef {
+public sealed interface TopLevelDef extends TyckDef permits ClassDef, DataDef, FnDef, PrimDef {
   @Override default @NotNull ImmutableSeq<Param> telescope() {
     var signature = ref().signature;
     assert signature != null;

--- a/syntax/src/main/java/org/aya/syntax/core/def/TyckAnyDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/TyckAnyDef.java
@@ -34,6 +34,8 @@ public non-sealed class TyckAnyDef<Interface extends TyckDef> implements AnyDef 
       case FnDef fn -> new FnDef.Delegate(fn.ref());
       case PrimDef prim -> new PrimDef.Delegate(prim.ref);
       case ConDef con -> new ConDef.Delegate(con.ref);
+      case ClassDef classDef -> new ClassDef.Delegate(classDef.ref());
+      case MemberDef memberDef -> new MemberDef.Delegate(memberDef.ref());
     };
   }
   @Override public @Nullable OpInfo opInfo() { return ref.concrete.opInfo(); }

--- a/syntax/src/main/java/org/aya/syntax/core/def/TyckDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/TyckDef.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @author zaoqi
  */
-public sealed interface TyckDef extends AyaDocile permits SubLevelDef, TopLevelDef {
+public sealed interface TyckDef extends AyaDocile permits MemberDef, SubLevelDef, TopLevelDef {
   @Override default @NotNull Doc toDoc(@NotNull PrettierOptions options) {
     return new CorePrettier(options).def(this);
   }

--- a/syntax/src/main/java/org/aya/syntax/core/def/TyckDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/TyckDef.java
@@ -46,7 +46,7 @@ public sealed interface TyckDef extends AyaDocile permits MemberDef, SubLevelDef
   /**
    * @see AnyDef#signature()
    */
-  static @NotNull AbstractTele defSignature(@NotNull DefVar<? extends TyckDef, ? extends Decl> defVar) {
+  static @NotNull AbstractTele defSignature(@NotNull DefVar<?, ? extends Decl> defVar) {
     if (defVar.core != null) return new AbstractTele.Locns(defVar.core.telescope(), defVar.core.result());
     // guaranteed as this is already a core term
     var signature = defVar.signature;
@@ -54,7 +54,7 @@ public sealed interface TyckDef extends AyaDocile permits MemberDef, SubLevelDef
     return new AbstractTele.Locns(signature.rawParams(), signature.result());
   }
 
-  @NotNull DefVar<? extends TyckDef, ?> ref();
+  @NotNull DefVar<?, ?> ref();
   @NotNull Term result();
   @NotNull ImmutableSeq<Param> telescope();
 }

--- a/syntax/src/main/java/org/aya/syntax/core/term/call/ClassCall.java
+++ b/syntax/src/main/java/org/aya/syntax/core/term/call/ClassCall.java
@@ -1,0 +1,21 @@
+// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.syntax.core.term.call;
+
+/**
+ * ClassCall is a very special construction in Aya.
+ * <ul>
+ *   <li>It is like a type when partially instantiated -- the type of "specifications" of the rest of the fields.</li>
+ *   <li>It is like a term when fully instantiated, whose type can be anything.</li>
+ *   <li>It can be applied like a function, which essentially inserts the nearest missing field.</li>
+ * </ul>
+ *
+ * @author kiva, ice1000
+ */
+// public record ClassCall(
+//   @NotNull LocalVar self,
+//   @Override @NotNull DefVar<ClassDef, ClassDecl> ref,
+//   @Override int ulift,
+//   @NotNull ImmutableMap<DefVar<MemberDef, TeleDecl.ClassMember>, Term> args
+// ) implements StableWHNF, Formation {
+// }

--- a/syntax/src/main/java/org/aya/syntax/ref/DefVar.java
+++ b/syntax/src/main/java/org/aya/syntax/ref/DefVar.java
@@ -39,8 +39,8 @@ public final class DefVar<Core extends TyckDef, Concrete extends Decl> implement
     return new DefVar<>(concrete, null, name);
   }
 
-  @Override public boolean equals(@Nullable Object o) {return this == o;}
-  @Override public int hashCode() {return System.identityHashCode(this);}
+  @Override public boolean equals(@Nullable Object o) { return this == o; }
+  @Override public int hashCode() { return System.identityHashCode(this); }
 
   public boolean isInModule(@NotNull ModulePath moduleName) {
     return module != null && module.module().isInModule(moduleName);

--- a/syntax/src/main/java/org/aya/syntax/ref/GeneralizedVar.java
+++ b/syntax/src/main/java/org/aya/syntax/ref/GeneralizedVar.java
@@ -3,10 +3,11 @@
 package org.aya.syntax.ref;
 
 import org.aya.syntax.concrete.stmt.Generalize;
+import org.aya.util.error.SourceNode;
 import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 
-public final class GeneralizedVar implements AnyVar {
+public final class GeneralizedVar implements AnyVar, SourceNode {
   public final @NotNull String name;
   public final @NotNull SourcePos sourcePos;
   public Generalize owner;
@@ -20,7 +21,6 @@ public final class GeneralizedVar implements AnyVar {
     return new LocalVar(name, sourcePos, new GenerateKind.Generalized(this));
   }
 
-  public @NotNull String name() {
-    return name;
-  }
+  public @NotNull String name() { return name; }
+  @Override public @NotNull SourcePos sourcePos() { return sourcePos; }
 }

--- a/syntax/src/main/java/org/aya/syntax/ref/MemberVar.java
+++ b/syntax/src/main/java/org/aya/syntax/ref/MemberVar.java
@@ -1,0 +1,15 @@
+// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.syntax.ref;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class MemberVar implements AnyVar {
+  public final int index;
+  public final @NotNull LocalVar name;
+  public MemberVar(int index, @NotNull LocalVar name) {
+    this.index = index;
+    this.name = name;
+  }
+  @Override public @NotNull String name() { return name.name(); }
+}

--- a/syntax/src/main/java/org/aya/syntax/ref/MemberVar.java
+++ b/syntax/src/main/java/org/aya/syntax/ref/MemberVar.java
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.syntax.ref;
 
+import org.aya.util.error.SourcePos;
 import org.jetbrains.annotations.NotNull;
 
 public final class MemberVar implements AnyVar {
@@ -12,4 +13,5 @@ public final class MemberVar implements AnyVar {
     this.name = name;
   }
   @Override public @NotNull String name() { return name.name(); }
+  public @NotNull SourcePos definition() { return name.definition(); }
 }

--- a/syntax/src/main/java/org/aya/syntax/telescope/Signature.java
+++ b/syntax/src/main/java/org/aya/syntax/telescope/Signature.java
@@ -45,7 +45,7 @@ public record Signature(
     return vars.foldLeftIndexed(this, (idx, acc, var) -> acc.bindAt(var, idx));
   }
 
-  public @NotNull Signature descent(@NotNull UnaryOperator<org.aya.syntax.core.term.Term> f) {
+  public @NotNull Signature descent(@NotNull UnaryOperator<Term> f) {
     return new Signature(param.map(p -> p.map(q -> q.descent(f))), f.apply(result));
   }
 

--- a/tools-repl/src/main/java/org/aya/repl/Command.java
+++ b/tools-repl/src/main/java/org/aya/repl/Command.java
@@ -9,10 +9,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 public abstract class Command {
-  @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+  @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
   public @interface Entry { }
 

--- a/tools-repl/src/main/java/org/aya/repl/ReplParser.java
+++ b/tools-repl/src/main/java/org/aya/repl/ReplParser.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.repl;
 
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @param shellLike see {@link org.aya.repl.CommandArg#shellLike}
+ * @param shellLike see {@link CommandArg#shellLike}
  */
 public record ReplParser<T>(
   @NotNull CommandManager cmd, @NotNull ReplLexer<T> lexer,


### PR DESCRIPTION
My proposed design on the concrete:

1. `ClazzDecl` only has a telescope, it will never have `result`
2. The telescope's local bindings are copied into a list of `MemberVar`s
3. The resolver should replace the local vars with `MemberVar`s if there exists a corresponding one
4. The tycker should deal with the `self` invocation