### PR TITLE
test: hopefully this fixes all the issues I've seen so far

### DIFF
--- a/cli-impl/src/test/java/org/aya/test/literate/AyaMdParserTest.java
+++ b/cli-impl/src/test/java/org/aya/test/literate/AyaMdParserTest.java
@@ -83,7 +83,7 @@ public class AyaMdParserTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"wow", "test", "hoshino-said", "heading", "compiler-output"})
+  @ValueSource(strings = {"hoshino-said", "wow", "test", "heading", "compiler-output"})
   public void testHighlight(String caseName) throws IOException {
     var oneCase = new Case(caseName);
     var mdFile = new SingleAyaFile.CodeAyaFile(file(oneCase.mdFile()));

--- a/syntax/src/main/java/org/aya/syntax/literate/AyaBacktickParser.java
+++ b/syntax/src/main/java/org/aya/syntax/literate/AyaBacktickParser.java
@@ -104,12 +104,10 @@ public class AyaBacktickParser extends BacktickParser {
           .withNode(new Node(new IntRange(attrBeginIndex, endIndex), ATTR_SET))
           .withNodes(wellNodes.asJava());
         return attrIt;
-      } else {
-        result.withNode(codeSpanNode);
-        return endIterator;
       }
     }
-    return iterator;
+    result.withNode(codeSpanNode);
+    return endIterator;
   }
 
   private @NotNull TokensCache.Iterator skipWS(@NotNull TokensCache.Iterator it) {

--- a/tools-md/src/main/java/org/aya/literate/parser/BaseMdParser.java
+++ b/tools-md/src/main/java/org/aya/literate/parser/BaseMdParser.java
@@ -97,7 +97,7 @@ public class BaseMdParser {
   public static final TokenSet NATURAL_EOL = TokenSet.create(
     MarkdownElementTypes.PARAGRAPH, MarkdownElementTypes.BLOCK_QUOTE,
     MarkdownElementTypes.CODE_FENCE, MarkdownElementTypes.CODE_BLOCK,
-    MarkdownElementTypes.ORDERED_LIST, MarkdownElementTypes.UNORDERED_LIST,
+    MarkdownElementTypes.ORDERED_LIST, MarkdownElementTypes.UNORDERED_LIST, MarkdownElementTypes.LIST_ITEM,
     GFMElementTypes.TABLE, GFMElementTypes.BLOCK_MATH,
     FrontMatterHeaderProvider.FRONT_MATTER_HEADER
   );


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dbf61d81-1fab-451a-b4a2-1d5a93e18443)

Bugs like this, also non-Aya inline code blocks are not corrcetly parsed