### PR TITLE
Fix Wrong Implementation of `JitCon#selfTele`

### DIFF
--- a/syntax/src/main/java/org/aya/syntax/core/def/ConDefLike.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/ConDefLike.java
@@ -20,6 +20,12 @@ public sealed interface ConDefLike extends AnyDef permits JitCon, ConDef.Delegat
   @NotNull Term equality(Seq<Term> args, boolean is0);
   int selfTeleSize();
   int ownerTeleSize();
+
+  /**
+   * Returns the telescope introduced by the constructor, data telescope/pattern binds telescope is not included.
+   *
+   * @return A telescope which has {@link #ownerTeleSize} many de-bruijn indices are free
+   */
   @NotNull ImmutableSeq<Param> selfTele(@NotNull ImmutableSeq<Term> ownerArgs);
 
   @SuppressWarnings("unchecked") static @NotNull ConDefLike from(@NotNull AnyDefVar var) {


### PR DESCRIPTION
The old `JitCon#selfTele` returns with lost var, which is incorrect. This PR intends to fix it.
However, the test didn't fail due to incorrect behavior, which may imply potential bugs.