### PR TITLE
Robustness

### DIFF
--- a/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
+++ b/base/src/main/java/org/aya/tyck/order/AyaSccTycker.java
@@ -150,13 +150,14 @@ public record AyaSccTycker(
   private void checkBody(@NotNull TyckOrder order, @NotNull TyckUnit stmt) {
     if (stmt instanceof Decl decl) {
       var def = tycker.check(decl);
-      if (!decl.isExample) {
+      if (!decl.isExample && def != null) {
         // In case I'm not an example, remember me and recognize my shape
         wellTyped.append(def);
         tycker.shapeFactory().bonjour(def);
       }
     }
-    if (reporter.anyError()) throw new SccTyckingFailed(ImmutableSeq.of(order));
+    if (reporter.anyError())
+      throw new SccTyckingFailed(ImmutableSeq.of(order));
   }
 
   /**

--- a/cli-impl/src/test/java/org/aya/test/fixtures/ParseError.java
+++ b/cli-impl/src/test/java/org/aya/test/fixtures/ParseError.java
@@ -34,4 +34,5 @@ public interface ParseError {
     | [{a}] => a
     | _ => 0
     """;
+  @Language("Aya") String testIncorrectReturn = "def lt_intersect : {A : Type} : A";
 }

--- a/cli-impl/src/test/java/org/aya/test/fixtures/PatTyckError.java
+++ b/cli-impl/src/test/java/org/aya/test/fixtures/PatTyckError.java
@@ -94,7 +94,11 @@ public interface PatTyckError {
     | test2 => test1
     """;
 
-  @Language("Aya") String testNewRepoIssue384 = """
-    def test : Type
+  @Language("Aya") String testNewRepoIssue384 = "def test : Type";
+  @Language("Aya") String testNewRepoIssue1245 = """
+    open inductive Wrap (A B : Type)
+    | _ => wrap B
+    // Should be skipped by the orga tycker
+    def test => wrap
     """;
 }

--- a/cli-impl/src/test/resources/negative/ParseError.txt
+++ b/cli-impl/src/test/resources/negative/ParseError.txt
@@ -112,3 +112,15 @@ Error: Implicit elements in a list pattern is disallowed
 1 error(s), 0 warning(s).
 Let's learn from that.
 
+IncorrectReturn:
+In file $FILE:1:17 ->
+
+  1 │   def lt_intersect : {A : Type} : A
+    │                    ╰╯
+
+Error: The return type syntax is incorrect.
+
+Parsing interrupted due to:
+1 error(s), 0 warning(s).
+Let's learn from that.
+

--- a/cli-impl/src/test/resources/negative/PatTyckError.txt
+++ b/cli-impl/src/test/resources/negative/PatTyckError.txt
@@ -234,3 +234,27 @@ Error: The empty pattern-matching function test does not have a telescope
 1 error(s), 0 warning(s).
 Let's learn from that.
 
+NewRepoIssue1245:
+In file $FILE:2:2 ->
+
+  1 │   open inductive Wrap (A B : Type)
+  2 │   | _ => wrap B
+    │     ╰╯
+  3 │   // Should be skipped by the orga tycker
+
+Error: There is no pattern for the parameter
+         (B : Type 0)
+
+In file $FILE:2:2 ->
+
+  1 │   open inductive Wrap (A B : Type)
+  2 │   | _ => wrap B
+    │     ╰╯
+  3 │   // Should be skipped by the orga tycker
+
+Error: There is no pattern for the parameter
+         (B : Type 0)
+
+2 error(s), 0 warning(s).
+Let's learn from that.
+

--- a/producer/src/main/java/org/aya/producer/AyaProducer.java
+++ b/producer/src/main/java/org/aya/producer/AyaProducer.java
@@ -860,7 +860,12 @@ public record AyaProducer(
   }
 
   public @NotNull WithPos<Expr> type(@NotNull GenericNode<?> node) {
-    return expr(node.child(EXPR));
+    var child = node.peekChild(EXPR);
+    if (child == null) {
+      reporter.report(new ParseError(sourcePosOf(node), "The return type syntax is incorrect."));
+      throw new ParsingInterruptedException();
+    }
+    return expr(child);
   }
 
   public @Nullable WithPos<Expr> typeOrNull(@Nullable GenericNode<?> node) {


### PR DESCRIPTION
Fix #1245, but it reports the same error twice. The reason is probably that when tycking the data body, the con is rechecked. We can find a way to avoid that, but I don't see an easy way right now.