### PR TITLE
Eliminate Unnecessary Shadow Warning

### DIFF
--- a/base/src/main/java/org/aya/resolve/context/NoExportContext.java
+++ b/base/src/main/java/org/aya/resolve/context/NoExportContext.java
@@ -11,9 +11,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
 
-/**
- * Used for `let open`
- */
+/// Used for `let open` and `example`
 public record NoExportContext(
   @NotNull Context parent,
   @NotNull ModuleSymbol<AnyVar> symbols,

--- a/base/src/main/java/org/aya/resolve/visitor/StmtPreResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtPreResolver.java
@@ -151,7 +151,7 @@ public record StmtPreResolver(@NotNull ModuleLoader loader, @NotNull ResolveInfo
     var r = new SuppressingReporter(reporter);
     decl.suppresses.forEach(suppress -> {
       switch (suppress) {
-        case Shadowing -> r.suppress(NameProblem.ShadowingWarn.class);
+        case LocalShadow -> r.suppress(NameProblem.ShadowingWarn.class);
       }
     });
     return r;

--- a/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
+++ b/base/src/main/java/org/aya/resolve/visitor/StmtResolver.java
@@ -64,7 +64,7 @@ public interface StmtResolver {
             resolveElim(resolver, body.inner());
             var clausesResolver = resolver.deriveRestrictive();
             clausesResolver.reference().append(new TyckOrder.Head(decl));
-            decl.body = body.map(clausesResolver::clause);
+            decl.body = body.map(x -> clausesResolver.clause(decl.teleVars().toImmutableSeq(), x));
             addReferences(info, new TyckOrder.Body(decl), clausesResolver);
           }
           case FnBody.ExprBody(var expr) -> {
@@ -84,7 +84,9 @@ public interface StmtResolver {
           var mCtx = MutableValue.create(resolver.ctx());
           bodyResolver.reference().append(new TyckOrder.Head(data));
           bodyResolver.enter(Where.ConPattern);
-          con.patterns = con.patterns.map(pat -> pat.descent(pattern -> bodyResolver.resolvePattern(pattern, mCtx)));
+          con.patterns = con.patterns.map(pat ->
+            pat.descent(pattern ->
+              bodyResolver.resolvePattern(pattern, data.teleVars().toImmutableSeq(), mCtx)));
           bodyResolver.exit();
           resolveMemberSignature(con, bodyResolver, mCtx);
           addReferences(info, new TyckOrder.Head(con), bodyResolver);

--- a/cli-impl/src/test/java/org/aya/test/fixtures/ScopeError.java
+++ b/cli-impl/src/test/java/org/aya/test/fixtures/ScopeError.java
@@ -90,4 +90,17 @@ public interface ScopeError {
     open class Cls | A : Type
     def test (c : Cls) => c.B
     """;
+  @Language("Aya") String testLocalShadow = """
+    def test (A : Type) (a : A) : A =>
+      let | x : A := a
+          | x : A := a
+      in x
+    """;
+  @Language("Aya") String testLocalShadowSuppress = """
+    @suppress(LocalShadow)
+    def test (A : Type) (a : A) : A =>
+      let | x : A := a
+          | x : A := a
+      in x
+    """;
 }

--- a/cli-impl/src/test/resources/negative/ScopeError.txt
+++ b/cli-impl/src/test/resources/negative/ScopeError.txt
@@ -303,3 +303,18 @@ Resolving interrupted due to:
 1 error(s), 0 warning(s).
 Let's learn from that.
 
+LocalShadow:
+In file $FILE:3:8 ->
+
+  1 │   def test (A : Type) (a : A) : A =>
+  2 │     let | x : A := a
+  3 │         | x : A := a
+    │           ╰╯
+
+Warning: The name `x` shadows a previous local definition from outer scope
+
+That looks right!
+
+LocalShadowSuppress:
+That looks right!
+

--- a/cli-impl/src/test/resources/shared/src/data/list/base.aya
+++ b/cli-impl/src/test/resources/shared/src/data/list/base.aya
@@ -28,12 +28,10 @@ def rev' (buf xs : List A) : List A elim xs
 
 def rev (xs : List A) : List A => rev' [ ] xs
 
-
 overlap def take (n : Nat) (xs : List A) : List A
 | _, [ ] => [ ]
 | 0, _ => [ ]
 | suc n, x :< xs => x :< (take n xs)
-
 
 overlap def drop (n : Nat) (xs : List A) : List A
 | _, [ ] => [ ]

--- a/cli-impl/src/test/resources/shared/src/data/list/base.aya
+++ b/cli-impl/src/test/resources/shared/src/data/list/base.aya
@@ -28,13 +28,13 @@ def rev' (buf xs : List A) : List A elim xs
 
 def rev (xs : List A) : List A => rev' [ ] xs
 
-@suppress(Shadowing)
+
 overlap def take (n : Nat) (xs : List A) : List A
 | _, [ ] => [ ]
 | 0, _ => [ ]
 | suc n, x :< xs => x :< (take n xs)
 
-@suppress(Shadowing)
+
 overlap def drop (n : Nat) (xs : List A) : List A
 | _, [ ] => [ ]
 | 0, _ => xs

--- a/cli-impl/src/test/resources/shared/src/data/list/properties.aya
+++ b/cli-impl/src/test/resources/shared/src/data/list/properties.aya
@@ -29,19 +29,19 @@ def head-def (x : A) (xs : List A) : A elim xs
 | [ ] => x
 | a :< _ => a
 
-@suppress(Shadowing)
+
 def ++-assoc (xs ys zs : List A) : (xs ++ ys) ++ zs = xs ++ (ys ++ zs) elim xs
 | [ ] => refl
 | x :< xs => pmap (x :<) (++-assoc xs ys zs)
 
-@suppress(Shadowing)
+
 private def rev'-map (f : A -> B) (buf xs : List A) : map f (rev' buf xs) = rev' (map f buf) (map f xs) elim xs
 | [ ] => refl
 | x :< xs => rev'-map f (x :< buf) xs
 
 def rev-map (f : A -> B) (xs : List A) : map f (rev xs) = rev (map f xs) => rev'-map f [ ] xs
 
-@suppress(Shadowing)
+
 private def rev'-++ (buf xs : List A) : rev' buf xs = rev xs ++ buf elim xs
 | [ ] => refl
 | x :< xs =>
@@ -51,7 +51,7 @@ private def rev'-++ (buf xs : List A) : rev' buf xs = rev xs ++ buf elim xs
   | step2 : (rev xs ++ [ x ]) ++ buf = rev xs ++ (x :< buf) := ++-assoc (rev xs) [ x ] buf
   in step0 <=> pinv step2 <=> pinv step1
 
-@suppress(Shadowing)
+
 def rev-distrib-++ (xs ys : List A) : rev (xs ++ ys) = (rev ys ++ rev xs) elim xs
 | [ ] => refl
 | x :< xs =>

--- a/cli-impl/src/test/resources/shared/src/data/list/properties.aya
+++ b/cli-impl/src/test/resources/shared/src/data/list/properties.aya
@@ -29,18 +29,15 @@ def head-def (x : A) (xs : List A) : A elim xs
 | [ ] => x
 | a :< _ => a
 
-
 def ++-assoc (xs ys zs : List A) : (xs ++ ys) ++ zs = xs ++ (ys ++ zs) elim xs
 | [ ] => refl
 | x :< xs => pmap (x :<) (++-assoc xs ys zs)
-
 
 private def rev'-map (f : A -> B) (buf xs : List A) : map f (rev' buf xs) = rev' (map f buf) (map f xs) elim xs
 | [ ] => refl
 | x :< xs => rev'-map f (x :< buf) xs
 
 def rev-map (f : A -> B) (xs : List A) : map f (rev xs) = rev (map f xs) => rev'-map f [ ] xs
-
 
 private def rev'-++ (buf xs : List A) : rev' buf xs = rev xs ++ buf elim xs
 | [ ] => refl
@@ -50,7 +47,6 @@ private def rev'-++ (buf xs : List A) : rev' buf xs = rev xs ++ buf elim xs
   | step1 := pmap (++ buf) (rev'-++ [ x ] xs)
   | step2 : (rev xs ++ [ x ]) ++ buf = rev xs ++ (x :< buf) := ++-assoc (rev xs) [ x ] buf
   in step0 <=> pinv step2 <=> pinv step1
-
 
 def rev-distrib-++ (xs ys : List A) : rev (xs ++ ys) = (rev ys ++ rev xs) elim xs
 | [ ] => refl

--- a/cli-impl/src/test/resources/shared/src/data/vec/base.aya
+++ b/cli-impl/src/test/resources/shared/src/data/vec/base.aya
@@ -1,6 +1,5 @@
 open import prelude hiding (++)
 
-
 open inductive Vec (n : Nat) (A : Type) elim n
 | 0 => []
 | suc n => infixr :> A (Vec n A)

--- a/cli-impl/src/test/resources/shared/src/data/vec/base.aya
+++ b/cli-impl/src/test/resources/shared/src/data/vec/base.aya
@@ -1,6 +1,6 @@
 open import prelude hiding (++)
 
-@suppress(Shadowing)
+
 open inductive Vec (n : Nat) (A : Type) elim n
 | 0 => []
 | suc n => infixr :> A (Vec n A)

--- a/cli-impl/src/test/resources/shared/src/data/vec/properties.aya
+++ b/cli-impl/src/test/resources/shared/src/data/vec/properties.aya
@@ -13,7 +13,7 @@ def ++-assoc (xs : Vec n A) (ys : Vec m A) (zs : Vec o A)
 | [] => refl
 | x :> xs' => pmapd _ (\i => x :>) (++-assoc xs' ys zs)
 
-@suppress(Shadowing)
+
 def vmap-distrib-++ (f : A -> B) (xs : Vec n A) (ys : Vec m A) : vmap f (xs ++ ys) = vmap f xs ++ vmap f ys elim xs
 | [] => refl
 | x :> xs => pmap (f x :>) (vmap-distrib-++ f xs ys)

--- a/cli-impl/src/test/resources/shared/src/data/vec/properties.aya
+++ b/cli-impl/src/test/resources/shared/src/data/vec/properties.aya
@@ -13,7 +13,6 @@ def ++-assoc (xs : Vec n A) (ys : Vec m A) (zs : Vec o A)
 | [] => refl
 | x :> xs' => pmapd _ (\i => x :>) (++-assoc xs' ys zs)
 
-
 def vmap-distrib-++ (f : A -> B) (xs : Vec n A) (ys : Vec m A) : vmap f (xs ++ ys) = vmap f xs ++ vmap f ys elim xs
 | [] => refl
 | x :> xs => pmap (f x :>) (vmap-distrib-++ f xs ys)

--- a/cli-impl/src/test/resources/shared/src/relation/binary/nat_cmp.aya
+++ b/cli-impl/src/test/resources/shared/src/relation/binary/nat_cmp.aya
@@ -54,7 +54,6 @@ def <=-case {a b : Nat} (p : a <= b) : Sum (a < b) (a = b) =>
   | _ because reflect_false np => inr (some-lemma p np)
   }
 
-
 def ¬<→>= {a b : Nat} (np : neg (a < b)) : a >= b
 | {_}, {0}, np => refl
 | {0}, {suc b}, np => exfalso (np refl)

--- a/cli-impl/src/test/resources/shared/src/relation/binary/nat_cmp.aya
+++ b/cli-impl/src/test/resources/shared/src/relation/binary/nat_cmp.aya
@@ -47,14 +47,14 @@ private def some-lemma {a b : Nat} (p : subTrunc a b = 0) (np : neg (subTrunc (s
 | suc a, 0 => exfalso (z≠s (pinv p))
 | suc a, suc b => pmap suc (some-lemma p np)
 
-@suppress(Shadowing)
+
 def <=-case {a b : Nat} (p : a <= b) : Sum (a < b) (a = b) =>
   match a <? b {
   | _ because reflect_true p => inl p
   | _ because reflect_false np => inr (some-lemma p np)
   }
 
-@suppress(Shadowing)
+
 def ¬<→>= {a b : Nat} (np : neg (a < b)) : a >= b
 | {_}, {0}, np => refl
 | {0}, {suc b}, np => exfalso (np refl)

--- a/syntax/src/main/java/org/aya/generic/Suppress.java
+++ b/syntax/src/main/java/org/aya/generic/Suppress.java
@@ -3,7 +3,7 @@
 package org.aya.generic;
 
 public enum Suppress {
-  Shadowing,
+  LocalShadow,
   UnimportedCon,
   UnreachableClause,
   MostGeneralSolution;


### PR DESCRIPTION
This PR intends to eliminate unnecessary and annoying shadow warnings. However, the following code will not report any shadow warning even if the pattern shadows a local variable of another parameter:

```aya
def test (A : Type) (a : A) : A
| a, A => A
```

This is because we cannot tell the parameter of a pattern, this part is done in PatTycker, but it should can be done in desugarer.