### PR TITLE
Simplify confluence check

### DIFF
--- a/base/src/main/java/org/aya/normalize/Normalizer.java
+++ b/base/src/main/java/org/aya/normalize/Normalizer.java
@@ -15,7 +15,6 @@ import kala.control.Result;
 import org.aya.generic.Modifier;
 import org.aya.syntax.compile.JitFn;
 import org.aya.syntax.compile.JitMatchy;
-import org.aya.syntax.core.def.FnClauseBody;
 import org.aya.syntax.core.def.FnDef;
 import org.aya.syntax.core.def.Matchy;
 import org.aya.syntax.core.pat.PatMatcher;
@@ -93,8 +92,8 @@ public final class Normalizer implements UnaryOperator<Term> {
               term = body.instTele(args.view());
               continue;
             }
-            case Either.Right(FnClauseBody(var clauses)): {
-              var result = tryUnfoldClauses(clauses.view().map(WithPos::data),
+            case Either.Right(var body): {
+              var result = tryUnfoldClauses(body.clauses.view().map(WithPos::data),
                 args, core.is(Modifier.Overlap), ulift);
               // we may get stuck
               if (result == null) return defaultValue;

--- a/base/src/main/java/org/aya/normalize/Normalizer.java
+++ b/base/src/main/java/org/aya/normalize/Normalizer.java
@@ -1,6 +1,11 @@
-// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.normalize;
+
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
+
+import static org.aya.generic.State.Stuck;
 
 import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableSeq;
@@ -10,6 +15,7 @@ import kala.control.Result;
 import org.aya.generic.Modifier;
 import org.aya.syntax.compile.JitFn;
 import org.aya.syntax.compile.JitMatchy;
+import org.aya.syntax.core.def.FnClauseBody;
 import org.aya.syntax.core.def.FnDef;
 import org.aya.syntax.core.def.Matchy;
 import org.aya.syntax.core.pat.PatMatcher;
@@ -28,11 +34,6 @@ import org.aya.tyck.tycker.Stateful;
 import org.aya.util.error.WithPos;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.BiFunction;
-import java.util.function.UnaryOperator;
-
-import static org.aya.generic.State.Stuck;
 
 /**
  * Unlike in pre-v0.30 Aya, we use only one normalizer, only doing head reduction,
@@ -92,7 +93,7 @@ public final class Normalizer implements UnaryOperator<Term> {
               term = body.instTele(args.view());
               continue;
             }
-            case Either.Right(var clauses): {
+            case Either.Right(FnClauseBody(var clauses)): {
               var result = tryUnfoldClauses(clauses.view().map(WithPos::data),
                 args, core.is(Modifier.Overlap), ulift);
               // we may get stuck

--- a/base/src/main/java/org/aya/normalize/Normalizer.java
+++ b/base/src/main/java/org/aya/normalize/Normalizer.java
@@ -30,7 +30,6 @@ import org.aya.syntax.ref.AnyVar;
 import org.aya.syntax.ref.LocalVar;
 import org.aya.tyck.TyckState;
 import org.aya.tyck.tycker.Stateful;
-import org.aya.util.error.WithPos;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -93,7 +92,7 @@ public final class Normalizer implements UnaryOperator<Term> {
               continue;
             }
             case Either.Right(var body): {
-              var result = tryUnfoldClauses(body.clauses.view().map(WithPos::data),
+              var result = tryUnfoldClauses(body.matchingsView(),
                 args, core.is(Modifier.Overlap), ulift);
               // we may get stuck
               if (result == null) return defaultValue;

--- a/base/src/main/java/org/aya/primitive/ShapeMatcher.java
+++ b/base/src/main/java/org/aya/primitive/ShapeMatcher.java
@@ -1,6 +1,11 @@
-// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.primitive;
+
+import java.util.Objects;
+import java.util.function.BiPredicate;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
 
 import kala.collection.SeqLike;
 import kala.collection.immutable.ImmutableMap;
@@ -27,11 +32,6 @@ import org.aya.util.error.Panic;
 import org.aya.util.error.WithPos;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Objects;
-import java.util.function.BiPredicate;
-import java.util.function.BooleanSupplier;
-import java.util.function.Function;
 
 /**
  * @author kiva
@@ -123,7 +123,7 @@ public record ShapeMatcher(
     return switch (new Pair<>(shape.body(), def.body())) {
       case Pair(Either.Left(var termShape), Either.Left(var term)) ->
         matchInside(() -> captures.put(shape.name(), def.ref()), () -> matchTerm(termShape, term));
-      case Pair(Either.Right(var clauseShapes), Either.Right(var clauses)) -> {
+      case Pair(Either.Right(var clauseShapes), Either.Right(FnClauseBody(var clauses))) -> {
         var mode = def.is(Modifier.Overlap) ? MatchMode.Sub : MatchMode.Eq;
         yield matchInside(() -> captures.put(shape.name(), def.ref()), () ->
           matchMany(mode, clauseShapes, clauses.view().map(WithPos::data), this::matchClause));

--- a/base/src/main/java/org/aya/primitive/ShapeMatcher.java
+++ b/base/src/main/java/org/aya/primitive/ShapeMatcher.java
@@ -29,7 +29,6 @@ import org.aya.syntax.ref.DefVar;
 import org.aya.util.Pair;
 import org.aya.util.RepoLike;
 import org.aya.util.error.Panic;
-import org.aya.util.error.WithPos;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -126,7 +125,7 @@ public record ShapeMatcher(
       case Pair(Either.Right(var clauseShapes), Either.Right(var body)) -> {
         var mode = def.is(Modifier.Overlap) ? MatchMode.Sub : MatchMode.Eq;
         yield matchInside(() -> captures.put(shape.name(), def.ref()), () ->
-          matchMany(mode, clauseShapes, body.clauses.view().map(WithPos::data), this::matchClause));
+          matchMany(mode, clauseShapes, body.matchingsView(), this::matchClause));
       }
       default -> false;
     };

--- a/base/src/main/java/org/aya/primitive/ShapeMatcher.java
+++ b/base/src/main/java/org/aya/primitive/ShapeMatcher.java
@@ -123,10 +123,10 @@ public record ShapeMatcher(
     return switch (new Pair<>(shape.body(), def.body())) {
       case Pair(Either.Left(var termShape), Either.Left(var term)) ->
         matchInside(() -> captures.put(shape.name(), def.ref()), () -> matchTerm(termShape, term));
-      case Pair(Either.Right(var clauseShapes), Either.Right(FnClauseBody(var clauses))) -> {
+      case Pair(Either.Right(var clauseShapes), Either.Right(var body)) -> {
         var mode = def.is(Modifier.Overlap) ? MatchMode.Sub : MatchMode.Eq;
         yield matchInside(() -> captures.put(shape.name(), def.ref()), () ->
-          matchMany(mode, clauseShapes, clauses.view().map(WithPos::data), this::matchClause));
+          matchMany(mode, clauseShapes, body.clauses.view().map(WithPos::data), this::matchClause));
       }
       default -> false;
     };

--- a/base/src/main/java/org/aya/terck/CallResolver.java
+++ b/base/src/main/java/org/aya/terck/CallResolver.java
@@ -139,7 +139,7 @@ public record CallResolver(
   }
 
   public void check() {
-    var clauses = caller.body().getRightValue().clauses();
+    var clauses = caller.body().getRightValue().clauses;
     clauses.view().map(WithPos::data).forEach(this);
   }
 

--- a/base/src/main/java/org/aya/terck/CallResolver.java
+++ b/base/src/main/java/org/aya/terck/CallResolver.java
@@ -24,7 +24,6 @@ import org.aya.syntax.core.term.repr.IntegerTerm;
 import org.aya.syntax.core.term.xtt.PAppTerm;
 import org.aya.tyck.TyckState;
 import org.aya.tyck.tycker.Stateful;
-import org.aya.util.error.WithPos;
 import org.aya.util.terck.CallGraph;
 import org.aya.util.terck.CallMatrix;
 import org.aya.util.terck.Relation;
@@ -139,8 +138,8 @@ public record CallResolver(
   }
 
   public void check() {
-    var clauses = caller.body().getRightValue().clauses;
-    clauses.view().map(WithPos::data).forEach(this);
+    var clauses = caller.body().getRightValue().matchingsView();
+    clauses.forEach(this);
   }
 
   @Override public void accept(@NotNull Term.Matching matching) {

--- a/base/src/main/java/org/aya/terck/CallResolver.java
+++ b/base/src/main/java/org/aya/terck/CallResolver.java
@@ -1,6 +1,8 @@
-// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.terck;
+
+import java.util.function.Consumer;
 
 import kala.collection.Set;
 import kala.collection.immutable.ImmutableSeq;
@@ -27,8 +29,6 @@ import org.aya.util.terck.CallGraph;
 import org.aya.util.terck.CallMatrix;
 import org.aya.util.terck.Relation;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.function.Consumer;
 
 /**
  * Resolve calls and build call graph of recursive functions,
@@ -139,7 +139,7 @@ public record CallResolver(
   }
 
   public void check() {
-    var clauses = caller.body().getRightValue();
+    var clauses = caller.body().getRightValue().clauses();
     clauses.view().map(WithPos::data).forEach(this);
   }
 

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -191,8 +191,7 @@ public final class ExprTycker extends AbstractTycker implements Unifiable {
       ImmutableSeq.fill(discriminant.size(), i ->
         new LocalVar("match" + i, discriminant.get(i).sourcePos(), GenerateKind.Basic.Tyck)),
       ImmutableSeq.empty(), clauses);
-    var wellClauses = clauseTycker.check(exprPos)
-      .wellTyped().clauses.map(WithPos::data);
+    var wellClauses = clauseTycker.check(exprPos).wellTyped().matchingsView();
 
     // Find free occurrences
     var usages = new FreeCollector();
@@ -203,7 +202,8 @@ public final class ExprTycker extends AbstractTycker implements Unifiable {
     var captures = usages.collected();
     var lifted = new Matchy(type.bindTele(wellArgs.size(), captures.view()),
       new QName(QPath.fileLevel(fileModule), "match-" + exprPos.lineColumnString()),
-      wellClauses.map(clause -> clause.update(clause.body().bindTele(clause.bindCount(), captures.view()))));
+      wellClauses.map(clause -> clause.update(clause.body().bindTele(clause.bindCount(), captures.view())))
+        .toImmutableSeq());
 
     var wellTerms = wellArgs.map(Jdg::wellTyped);
     return new MatchCall(lifted, wellTerms, captures.map(FreeTerm::new));

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -192,8 +192,7 @@ public final class ExprTycker extends AbstractTycker implements Unifiable {
         new LocalVar("match" + i, discriminant.get(i).sourcePos(), GenerateKind.Basic.Tyck)),
       ImmutableSeq.empty(), clauses);
     var wellClauses = clauseTycker.check(exprPos)
-      .clauses()
-      .map(WithPos::data);
+      .wellTyped().clauses.map(WithPos::data);
 
     // Find free occurrences
     var usages = new FreeCollector();

--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -2,7 +2,10 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck;
 
-import kala.collection.AbstractSeqView;
+import java.util.Comparator;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.immutable.ImmutableTreeSeq;
 import kala.collection.mutable.MutableList;
@@ -50,10 +53,6 @@ import org.aya.util.error.WithPos;
 import org.aya.util.reporter.Reporter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Comparator;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 public final class ExprTycker extends AbstractTycker implements Unifiable {
   public final @NotNull MutableTreeSet<WithPos<Expr.WithTerm>> withTerms =
@@ -193,7 +192,7 @@ public final class ExprTycker extends AbstractTycker implements Unifiable {
         new LocalVar("match" + i, discriminant.get(i).sourcePos(), GenerateKind.Basic.Tyck)),
       ImmutableSeq.empty(), clauses);
     var wellClauses = clauseTycker.check(exprPos)
-      .wellTyped()
+      .clauses()
       .map(WithPos::data);
 
     // Find free occurrences

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck;
 
+import static org.aya.tyck.tycker.TeleTycker.loadTele;
+
 import kala.collection.immutable.ImmutableSeq;
 import kala.control.Either;
 import kala.control.Option;
@@ -44,8 +46,6 @@ import org.aya.util.reporter.SuppressingReporter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.aya.tyck.tycker.TeleTycker.loadTele;
-
 public record StmtTycker(
   @NotNull SuppressingReporter reporter, @NotNull ModulePath fileModule,
   @NotNull ShapeFactory shapeFactory, @NotNull PrimFactory primFactory
@@ -85,8 +85,6 @@ public record StmtTycker(
       case FnDecl fnDecl -> {
         var fnRef = fnDecl.ref;
         assert fnRef.signature != null;
-
-        var factory = FnDef.factory(body -> new FnDef(fnRef, fnDecl.modifiers, body));
         var teleVars = fnDecl.telescope.map(Expr.Param::ref);
 
         yield switch (fnDecl.body) {
@@ -100,7 +98,7 @@ public record StmtTycker(
             var zonker = new Finalizer.Zonk<>(tycker);
             var resultTerm = zonker.zonk(result).bindTele(teleVars.view());
             fnRef.signature = fnRef.signature.descent(zonker::zonk);
-            yield factory.apply(Either.left(resultTerm));
+            yield new FnDef(fnRef, fnDecl.modifiers, Either.left(resultTerm));
           }
           case FnBody.BlockBody body -> {
             var clauses = body.clauses();
@@ -120,10 +118,12 @@ public record StmtTycker(
             var orderIndependent = fnDecl.modifiers.contains(Modifier.Overlap);
             FnDef def;
             ClauseTycker.TyckResult patResult;
+            FnClauseBody coreBody;
             if (orderIndependent) {
               // Order-independent.
               patResult = clauseTycker.checkNoClassify();
-              def = factory.apply(Either.right(patResult.wellTyped()));
+              coreBody = new FnClauseBody(patResult.wellTyped());
+              def = new FnDef(fnRef, fnDecl.modifiers, Either.right(coreBody));
               if (!patResult.hasLhsError()) {
                 var rawParams = signature.params();
                 var confluence = new YouTrack(rawParams, tycker, fnDecl.sourcePos());
@@ -132,9 +132,13 @@ public record StmtTycker(
               }
             } else {
               patResult = clauseTycker.check(fnDecl.entireSourcePos());
-              def = factory.apply(Either.right(patResult.wellTyped()));
+              coreBody = new FnClauseBody(patResult.wellTyped());
+              def = new FnDef(fnRef, fnDecl.modifiers, Either.right(coreBody));
             }
-            if (!patResult.hasLhsError()) new IApplyConfl(def, tycker, fnDecl.sourcePos()).check();
+            if (!patResult.hasLhsError()) {
+              var hitConflChecker = new IApplyConfl(def, tycker, fnDecl.sourcePos());
+              hitConflChecker.check();
+            }
             yield def;
           }
         };

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -130,13 +130,13 @@ public record StmtTycker(
                 var confluence = new YouTrack(rawParams, tycker, fnDecl.sourcePos());
                 var classes = PatClassifier.classify(patResult.clauses().view(),
                   rawParams.view(), tycker, fnDecl.sourcePos());
-                coreBody.classes = classes;
+                var absurds = patResult.absurdPrefixCount();
+                coreBody.classes = classes.map(cls -> cls.ignoreAbsurd(absurds));
                 confluence.check(patResult, signature.result(), classes);
               }
             } else {
               var patResult = clauseTycker.check(fnDecl.entireSourcePos());
-              coreBody = new FnClauseBody(patResult.clauses());
-              coreBody.classes = patResult.classes();
+              coreBody = patResult.wellTyped();
               hasLhsError = patResult.hasLhsError();
               def = new FnDef(fnRef, fnDecl.modifiers, Either.right(coreBody));
             }

--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -132,7 +132,7 @@ public record StmtTycker(
                   rawParams.view(), tycker, fnDecl.sourcePos());
                 var absurds = patResult.absurdPrefixCount();
                 coreBody.classes = classes.map(cls -> cls.ignoreAbsurd(absurds));
-                confluence.check(patResult, signature.result(), classes);
+                confluence.check(coreBody, signature.result());
               }
             } else {
               var patResult = clauseTycker.check(fnDecl.entireSourcePos());

--- a/base/src/main/java/org/aya/tyck/pat/ClauseTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/ClauseTycker.java
@@ -7,6 +7,8 @@ import java.util.function.UnaryOperator;
 
 import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableSeq;
+import kala.collection.immutable.primitive.ImmutableIntArray;
+import kala.collection.immutable.primitive.ImmutableIntSeq;
 import kala.value.primitive.MutableBooleanValue;
 import org.aya.generic.Renamer;
 import org.aya.normalize.Finalizer;
@@ -14,6 +16,7 @@ import org.aya.prettier.AyaPrettierOptions;
 import org.aya.syntax.concrete.Expr;
 import org.aya.syntax.concrete.Pattern;
 import org.aya.syntax.core.Jdg;
+import org.aya.syntax.core.def.FnClauseBody;
 import org.aya.syntax.core.pat.Pat;
 import org.aya.syntax.core.pat.PatToTerm;
 import org.aya.syntax.core.pat.TypeEraser;
@@ -47,6 +50,18 @@ public final class ClauseTycker implements Problematic, Stateful {
   public record TyckResult(@NotNull ImmutableSeq<Pat.Preclause<Term>> clauses, boolean hasLhsError) {
     public @NotNull ImmutableSeq<WithPos<Term.Matching>> wellTyped() {
       return clauses.flatMap(Pat.Preclause::lift);
+    }
+    /// @return null if there is no absurd pattern
+    public @Nullable ImmutableIntSeq absurdPrefixCount() {
+      var ints = new int[clauses.size()];
+      var count = 0;
+      for (int i = 0; i < clauses.size(); i++) {
+        var clause = clauses.get(i);
+        if (clause.expr() == null) count++;
+        ints[i] = count;
+      }
+      if (count == 0) return null;
+      return ImmutableIntArray.Unsafe.wrap(ints);
     }
   }
 
@@ -91,11 +106,7 @@ public final class ClauseTycker implements Problematic, Stateful {
     }
   }
 
-  public record WorkerResult(
-    ImmutableSeq<WithPos<Term.Matching>> clauses,
-    @Nullable ImmutableSeq<PatClass<ImmutableSeq<Term>>> classes,
-    boolean hasLhsError
-  ) { }
+  public record WorkerResult(FnClauseBody wellTyped, boolean hasLhsError) { }
   public record Worker(
     @NotNull ClauseTycker parent,
     @NotNull ImmutableSeq<Param> telescope,
@@ -107,8 +118,9 @@ public final class ClauseTycker implements Problematic, Stateful {
     public @NotNull WorkerResult check(@NotNull SourcePos overallPos) {
       var lhs = checkAllLhs();
 
-      ImmutableSeq<PatClass<ImmutableSeq<Term>>> classes = null;
-      if (lhs.noneMatch(r -> r.hasError)) {
+      ImmutableSeq<PatClass<ImmutableSeq<Term>>> classes;
+      var hasError = lhs.anyMatch(LhsResult::hasError);
+      if (!hasError) {
         classes = PatClassifier.classify(
           lhs.view().map(LhsResult::clause),
           telescope.view().concat(unpi.params()), parent.exprTycker, overallPos);
@@ -116,10 +128,18 @@ public final class ClauseTycker implements Problematic, Stateful {
           var usages = PatClassifier.firstMatchDomination(clauses, parent, classes);
           // refinePatterns(lhs, usages, classes);
         }
+      } else {
+        classes = null;
       }
 
-      var rhs = parent.checkAllRhs(teleVars, lhs.map(cl -> cl.mapPats(new TypeEraser())));
-      return new WorkerResult(rhs.wellTyped(), classes, rhs.hasLhsError);
+      var map = lhs.map(cl -> cl.mapPats(new TypeEraser()));
+      var rhs = parent.checkAllRhs(teleVars, map, hasError);
+      var wellTyped = new FnClauseBody(rhs.wellTyped());
+      if (classes != null) {
+        var absurds = rhs.absurdPrefixCount();
+        wellTyped.classes = classes.map(cl -> cl.ignoreAbsurd(absurds));
+      }
+      return new WorkerResult(wellTyped, hasError);
     }
 
     public @NotNull ImmutableSeq<LhsResult> checkAllLhs() {
@@ -129,7 +149,8 @@ public final class ClauseTycker implements Problematic, Stateful {
     }
 
     public @NotNull TyckResult checkNoClassify() {
-      return parent.checkAllRhs(teleVars, checkAllLhs());
+      var lhsResults = checkAllLhs();
+      return parent.checkAllRhs(teleVars, lhsResults, lhsResults.anyMatch(LhsResult::hasError));
     }
   }
 
@@ -147,9 +168,9 @@ public final class ClauseTycker implements Problematic, Stateful {
 
   public @NotNull TyckResult checkAllRhs(
     @NotNull ImmutableSeq<LocalVar> vars,
-    @NotNull ImmutableSeq<LhsResult> lhsResults
+    @NotNull ImmutableSeq<LhsResult> lhsResults,
+    boolean lhsError
   ) {
-    var lhsError = lhsResults.anyMatch(LhsResult::hasError);
     var rhsResult = lhsResults.map(x -> checkRhs(vars, x));
 
     // inline terms in rhsResult

--- a/base/src/main/java/org/aya/tyck/pat/IApplyConfl.java
+++ b/base/src/main/java/org/aya/tyck/pat/IApplyConfl.java
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck.pat;
 
+import java.util.function.UnaryOperator;
+
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.generic.Modifier;
 import org.aya.syntax.core.def.FnDef;
@@ -17,8 +19,6 @@ import org.aya.util.error.Panic;
 import org.aya.util.error.SourcePos;
 import org.aya.util.error.WithPos;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.function.UnaryOperator;
 
 /// This is XTT-specific confluence check, very simple: we check for all combinations.
 /// So, if we do
@@ -42,7 +42,7 @@ public record IApplyConfl(
   boolean orderIndep, @NotNull SourcePos sourcePos, @NotNull ExprTycker tycker
 ) {
   public IApplyConfl(@NotNull FnDef def, @NotNull ExprTycker tycker, @NotNull SourcePos pos) {
-    this(def, def.body().getRightValue(), def.is(Modifier.Overlap), pos, tycker);
+    this(def, def.body().getRightValue().clauses(), def.is(Modifier.Overlap), pos, tycker);
   }
   public void check() {
     // A matcher that does not normalize the arguments.

--- a/base/src/main/java/org/aya/tyck/pat/IApplyConfl.java
+++ b/base/src/main/java/org/aya/tyck/pat/IApplyConfl.java
@@ -42,7 +42,7 @@ public record IApplyConfl(
   boolean orderIndep, @NotNull SourcePos sourcePos, @NotNull ExprTycker tycker
 ) {
   public IApplyConfl(@NotNull FnDef def, @NotNull ExprTycker tycker, @NotNull SourcePos pos) {
-    this(def, def.body().getRightValue().clauses(), def.is(Modifier.Overlap), pos, tycker);
+    this(def, def.body().getRightValue().clauses, def.is(Modifier.Overlap), pos, tycker);
   }
   public void check() {
     // A matcher that does not normalize the arguments.

--- a/base/src/main/java/org/aya/tyck/pat/YouTrack.java
+++ b/base/src/main/java/org/aya/tyck/pat/YouTrack.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.tyck.pat;
 
@@ -76,9 +76,8 @@ public record YouTrack(
         .flatMapToObj(i -> Pat.Preclause.lift(clauses.clauses().get(i))
           .map(matching -> new Info(i, matching)));
       for (int i = 1, size = contents.size(); i < size; i++) {
-        var ix = i;
         try (var _ = tycker.subscope()) {
-          unifyClauses(type, contents.get(ix - 1), contents.get(ix), doms);
+          unifyClauses(type, contents.get(i - 1), contents.get(i), doms);
         }
       }
     });

--- a/base/src/main/java/org/aya/tyck/pat/YouTrack.java
+++ b/base/src/main/java/org/aya/tyck/pat/YouTrack.java
@@ -7,7 +7,7 @@ import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableLinkedSet;
 import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableSet;
-import org.aya.syntax.core.pat.Pat;
+import org.aya.syntax.core.def.FnClauseBody;
 import org.aya.syntax.core.term.FreeTerm;
 import org.aya.syntax.core.term.Param;
 import org.aya.syntax.core.term.Term;
@@ -17,7 +17,6 @@ import org.aya.tyck.error.ClausesProblem;
 import org.aya.tyck.error.UnifyInfo;
 import org.aya.util.error.SourcePos;
 import org.aya.util.error.WithPos;
-import org.aya.util.tyck.pat.PatClass;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -66,15 +65,10 @@ public record YouTrack(
       doms.add(new ClausesProblem.Domination(lhsIx + 1, rhsIx + 1, matching.sourcePos()));
   }
 
-  public void check(
-    @NotNull ClauseTycker.TyckResult clauses, @NotNull Term type,
-    @NotNull ImmutableSeq<PatClass<ImmutableSeq<Term>>> mct
-  ) {
+  public void check(@NotNull FnClauseBody body, @NotNull Term type) {
     var doms = MutableLinkedSet.<ClausesProblem.Domination>create();
-    mct.forEach(results -> {
-      var contents = results.cls()
-        .flatMapToObj(i -> Pat.Preclause.lift(clauses.clauses().get(i))
-          .map(matching -> new Info(i, matching)));
+    body.classes.forEach(results -> {
+      var contents = results.cls().mapToObj(i -> new Info(i, body.clauses.get(i)));
       for (int i = 1, size = contents.size(); i < size; i++) {
         try (var _ = tycker.subscope()) {
           unifyClauses(type, contents.get(i - 1), contents.get(i), doms);

--- a/syntax/src/main/java/org/aya/prettier/CorePrettier.java
+++ b/syntax/src/main/java/org/aya/prettier/CorePrettier.java
@@ -36,7 +36,6 @@ import org.aya.syntax.ref.GenerateKind.Basic;
 import org.aya.syntax.ref.LocalVar;
 import org.aya.util.Arg;
 import org.aya.util.error.SourcePos;
-import org.aya.util.error.WithPos;
 import org.aya.util.prettier.PrettierOptions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -286,7 +285,7 @@ public class CorePrettier extends BasePrettier<Term> {
         yield switch (def.body()) {
           case Either.Left(var term) -> Doc.sep(line1sep, FN_DEFINED_AS, term(Outer.Free, term.instTele(subst)));
           case Either.Right(var body) -> Doc.vcat(line1sep,
-            Doc.nest(2, visitClauses(body.clauses.view().map(WithPos::data), tele.view().map(ParamLike::explicit))));
+            Doc.nest(2, visitClauses(body.matchingsView(), tele.view().map(ParamLike::explicit))));
         };
       }
       case MemberDef field -> Doc.sepNonEmpty(Doc.symbol("|"),

--- a/syntax/src/main/java/org/aya/prettier/CorePrettier.java
+++ b/syntax/src/main/java/org/aya/prettier/CorePrettier.java
@@ -285,8 +285,8 @@ public class CorePrettier extends BasePrettier<Term> {
         var line1sep = Doc.sepNonEmpty(line1);
         yield switch (def.body()) {
           case Either.Left(var term) -> Doc.sep(line1sep, FN_DEFINED_AS, term(Outer.Free, term.instTele(subst)));
-          case Either.Right(FnClauseBody(var clauses)) -> Doc.vcat(line1sep,
-            Doc.nest(2, visitClauses(clauses.view().map(WithPos::data), tele.view().map(ParamLike::explicit))));
+          case Either.Right(var body) -> Doc.vcat(line1sep,
+            Doc.nest(2, visitClauses(body.clauses.view().map(WithPos::data), tele.view().map(ParamLike::explicit))));
         };
       }
       case MemberDef field -> Doc.sepNonEmpty(Doc.symbol("|"),

--- a/syntax/src/main/java/org/aya/prettier/CorePrettier.java
+++ b/syntax/src/main/java/org/aya/prettier/CorePrettier.java
@@ -2,11 +2,17 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.prettier;
 
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import static org.aya.prettier.Tokens.*;
+
 import com.intellij.openapi.util.text.StringUtil;
 import kala.collection.SeqLike;
 import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.mutable.MutableList;
+import kala.control.Either;
 import org.aya.generic.AyaDocile;
 import org.aya.generic.Renamer;
 import org.aya.generic.term.DTKind;
@@ -34,11 +40,6 @@ import org.aya.util.error.WithPos;
 import org.aya.util.prettier.PrettierOptions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.function.Function;
-import java.util.function.UnaryOperator;
-
-import static org.aya.prettier.Tokens.*;
 
 /**
  * It's the pretty printer.
@@ -205,7 +206,7 @@ public class CorePrettier extends BasePrettier<Term> {
 
         yield Doc.cblock(prefix, 2, clauseDoc);
       }
-      case MatchCall(JitMatchy _, var discriminant, var captures) -> {
+      case MatchCall(JitMatchy _, var discriminant, _) -> {
         var deltaDoc = discriminant.map(x -> term(Outer.Free, x));
         var prefix = Doc.sep(KW_MATCH, Doc.commaList(deltaDoc));
         yield Doc.sep(prefix, Doc.braced(Doc.spaced(Doc.styled(COMMENT, "compiled code"))));
@@ -282,10 +283,11 @@ public class CorePrettier extends BasePrettier<Term> {
           term(Outer.Free, def.result().instTeleVar(tele.view().map(ParamLike::ref)))
         });
         var line1sep = Doc.sepNonEmpty(line1);
-        yield def.body().fold(
-          term -> Doc.sep(line1sep, FN_DEFINED_AS, term(Outer.Free, term.instTele(subst))),
-          clauses -> Doc.vcat(line1sep,
-            Doc.nest(2, visitClauses(clauses.view().map(WithPos::data), tele.view().map(ParamLike::explicit)))));
+        yield switch (def.body()) {
+          case Either.Left(var term) -> Doc.sep(line1sep, FN_DEFINED_AS, term(Outer.Free, term.instTele(subst)));
+          case Either.Right(FnClauseBody(var clauses)) -> Doc.vcat(line1sep,
+            Doc.nest(2, visitClauses(clauses.view().map(WithPos::data), tele.view().map(ParamLike::explicit))));
+        };
       }
       case MemberDef field -> Doc.sepNonEmpty(Doc.symbol("|"),
         defVar(field.ref()),

--- a/syntax/src/main/java/org/aya/syntax/core/def/FnClauseBody.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/FnClauseBody.java
@@ -6,7 +6,7 @@ import kala.collection.immutable.ImmutableSeq;
 import org.aya.syntax.core.term.Term;
 import org.aya.util.error.WithPos;
 
-public record FnClauseBody(
-  ImmutableSeq<WithPos<Term.Matching>> clauses
-) {
+public final class FnClauseBody {
+  public final ImmutableSeq<WithPos<Term.Matching>> clauses;
+  public FnClauseBody(ImmutableSeq<WithPos<Term.Matching>> clauses) { this.clauses = clauses; }
 }

--- a/syntax/src/main/java/org/aya/syntax/core/def/FnClauseBody.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/FnClauseBody.java
@@ -2,13 +2,18 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.syntax.core.def;
 
+import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.syntax.core.term.Term;
 import org.aya.util.error.WithPos;
 import org.aya.util.tyck.pat.PatClass;
+import org.jetbrains.annotations.NotNull;
 
 public final class FnClauseBody {
   public final ImmutableSeq<WithPos<Term.Matching>> clauses;
   public ImmutableSeq<PatClass<ImmutableSeq<Term>>> classes;
   public FnClauseBody(ImmutableSeq<WithPos<Term.Matching>> clauses) { this.clauses = clauses; }
+  public @NotNull SeqView<Term.Matching> matchingsView() {
+    return clauses.view().map(WithPos::data);
+  }
 }

--- a/syntax/src/main/java/org/aya/syntax/core/def/FnClauseBody.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/FnClauseBody.java
@@ -1,0 +1,12 @@
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.syntax.core.def;
+
+import kala.collection.immutable.ImmutableSeq;
+import org.aya.syntax.core.term.Term;
+import org.aya.util.error.WithPos;
+
+public record FnClauseBody(
+  ImmutableSeq<WithPos<Term.Matching>> clauses
+) {
+}

--- a/syntax/src/main/java/org/aya/syntax/core/def/FnClauseBody.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/FnClauseBody.java
@@ -5,8 +5,10 @@ package org.aya.syntax.core.def;
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.syntax.core.term.Term;
 import org.aya.util.error.WithPos;
+import org.aya.util.tyck.pat.PatClass;
 
 public final class FnClauseBody {
   public final ImmutableSeq<WithPos<Term.Matching>> clauses;
+  public ImmutableSeq<PatClass<ImmutableSeq<Term>>> classes;
   public FnClauseBody(ImmutableSeq<WithPos<Term.Matching>> clauses) { this.clauses = clauses; }
 }

--- a/syntax/src/main/java/org/aya/syntax/core/def/FnDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/FnDef.java
@@ -3,7 +3,6 @@
 package org.aya.syntax.core.def;
 
 import java.util.EnumSet;
-import java.util.function.Function;
 
 import kala.control.Either;
 import org.aya.generic.Modifier;
@@ -18,11 +17,6 @@ public record FnDef(
   @NotNull Either<Term, FnClauseBody> body
 ) implements TopLevelDef {
   public FnDef { ref.initialize(this); }
-
-  public static <T> Function<Either<Term, FnClauseBody>, T>
-  factory(Function<Either<Term, FnClauseBody>, T> function) {
-    return function;
-  }
 
   public boolean is(@NotNull Modifier mod) { return modifiers.contains(mod); }
   public static final class Delegate extends TyckAnyDef<FnDef> implements FnDefLike {

--- a/syntax/src/main/java/org/aya/syntax/core/def/FnDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/FnDef.java
@@ -21,8 +21,7 @@ public record FnDef(
   public boolean is(@NotNull Modifier mod) { return modifiers.contains(mod); }
   public static final class Delegate extends TyckAnyDef<FnDef> implements FnDefLike {
     public Delegate(@NotNull DefVar<FnDef, ?> ref) { super(ref); }
-    @Override
-    public boolean is(@NotNull Modifier mod) {
+    @Override public boolean is(@NotNull Modifier mod) {
       var core = ref.core;
       if (core != null) return core.is(mod);
       return ((FnDecl) ref.concrete).modifiers.contains(mod);

--- a/syntax/src/main/java/org/aya/syntax/core/def/FnDef.java
+++ b/syntax/src/main/java/org/aya/syntax/core/def/FnDef.java
@@ -1,28 +1,26 @@
-// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.syntax.core.def;
 
-import kala.collection.immutable.ImmutableSeq;
+import java.util.EnumSet;
+import java.util.function.Function;
+
 import kala.control.Either;
 import org.aya.generic.Modifier;
 import org.aya.syntax.concrete.stmt.decl.FnDecl;
 import org.aya.syntax.core.term.Term;
 import org.aya.syntax.ref.DefVar;
-import org.aya.util.error.WithPos;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.EnumSet;
-import java.util.function.Function;
 
 public record FnDef(
   @NotNull DefVar<FnDef, FnDecl> ref,
   @NotNull EnumSet<Modifier> modifiers,
-  @NotNull Either<Term, ImmutableSeq<WithPos<Term.Matching>>> body
+  @NotNull Either<Term, FnClauseBody> body
 ) implements TopLevelDef {
   public FnDef { ref.initialize(this); }
 
-  public static <T> Function<Either<Term, ImmutableSeq<WithPos<Term.Matching>>>, T>
-  factory(Function<Either<Term, ImmutableSeq<WithPos<Term.Matching>>>, T> function) {
+  public static <T> Function<Either<Term, FnClauseBody>, T>
+  factory(Function<Either<Term, FnClauseBody>, T> function) {
     return function;
   }
 

--- a/tools-kala/src/main/java/org/aya/util/tyck/pat/PatClass.java
+++ b/tools-kala/src/main/java/org/aya/util/tyck/pat/PatClass.java
@@ -1,12 +1,13 @@
-// Copyright (c) 2020-2023 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.util.tyck.pat;
+
+import java.util.function.Function;
 
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.immutable.primitive.ImmutableIntSeq;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.function.Function;
+import org.jetbrains.annotations.Nullable;
 
 public record PatClass<T>(@NotNull T term, @NotNull ImmutableIntSeq cls) {
   public <R> @NotNull PatClass<R> map(Function<T, R> f) {
@@ -15,5 +16,10 @@ public record PatClass<T>(@NotNull T term, @NotNull ImmutableIntSeq cls) {
 
   public <P> @NotNull ImmutableSeq<P> extract(@NotNull ImmutableSeq<P> seq) {
     return cls.mapToObj(seq::get);
+  }
+
+  public @NotNull PatClass<T> ignoreAbsurd(@Nullable ImmutableIntSeq absurdPrefixCount) {
+    if (absurdPrefixCount == null) return this;
+    return new PatClass<>(term, cls.map(i -> i - absurdPrefixCount.get(i)));
   }
 }


### PR DESCRIPTION
This PR simplifies confluence check by using a prefix count array data structure for the clause index in MCTs.

It also stores MCTs in the core, which will be helpful later.