### PR TITLE
Some profile-guided optimization

### DIFF
--- a/jit-compiler/src/main/java/org/aya/compiler/AsmOutputCollector.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/AsmOutputCollector.java
@@ -18,7 +18,7 @@ public interface AsmOutputCollector {
     public Default() { this(MutableMap.create()); }
 
     public static @NotNull Path from(@NotNull ImmutableSeq<String> components) {
-      return Path.of(components.getFirst(), components.view().drop(1).toArray(new String[components.size() - 1]));
+      return Path.of(components.getFirst(), components.view().drop(1).toArray(String[]::new));
     }
 
     public static @NotNull Path getPath(@NotNull ClassDesc className) {

--- a/jit-compiler/src/main/java/org/aya/compiler/free/morphism/asm/AsmClassBuilder.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/free/morphism/asm/AsmClassBuilder.java
@@ -65,13 +65,8 @@ public final class AsmClassBuilder implements FreeClassBuilder {
     )));
   }
 
-  public @NotNull ClassDesc owner() {
-    return classData.className();
-  }
-
-  public @NotNull ClassDesc ownerSuper() {
-    return classData.classSuper();
-  }
+  public @NotNull ClassDesc owner() { return classData.className(); }
+  public @NotNull ClassDesc ownerSuper() { return classData.classSuper(); }
 
   @Override
   public void buildNestedClass(@NotNull CompiledAya compiledAya, @NotNull String name, @NotNull Class<?> superclass, @NotNull Consumer<FreeClassBuilder> builder) {
@@ -178,7 +173,8 @@ public final class AsmClassBuilder implements FreeClassBuilder {
         InnerClassInfo.of(owner().nested(cd), Optional.of(owner()), Optional.of(cd), ClassData.AF_NESTED));
     } else {
       assert nestedMembers.isEmpty();
-      innerClassesEntries = ImmutableSeq.of(InnerClassInfo.of(owner(), Optional.of(outerClassData.data().classSuper()), Optional.of(outerClassData.thisName()), ClassData.AF_NESTED));
+      innerClassesEntries = ImmutableSeq.of(InnerClassInfo.of(owner(), Optional.of(outerClassData.data().classSuper()),
+        Optional.of(outerClassData.thisName()), ClassData.AF_NESTED));
     }
 
     if (innerClassesEntries.isNotEmpty()) {

--- a/syntax/src/main/java/org/aya/syntax/concrete/Expr.java
+++ b/syntax/src/main/java/org/aya/syntax/concrete/Expr.java
@@ -450,8 +450,7 @@ public sealed interface Expr extends AyaDocile {
     ///
     /// @param generator `x * y` part above
     /// @param binds     `x <- [1, 2, 3], y <- [4, 5, 6]` part above
-    /// @param names     the bind (`>>=`) function, it is [#monadBind] in default,
-    ///                                                    the pure (`return`) function, it is [#functorPure] in default
+    /// @param names     bind (`>>=`) is [#monadBind] by default and pure (`return`) is [#functorPure] by default
     /// @apiNote a ArrayCompBlock will be desugar to a do-block. For the example above,
     /// it will be desugared to `do x <- [1, 2, 3], y <- [4, 5, 6], return x * y`
     public record CompBlock(
@@ -475,9 +474,7 @@ public sealed interface Expr extends AyaDocile {
       }
     }
 
-    /**
-     * helper constructor, also find constructor calls easily in IDE
-     */
+    /// Helper constructor, also find constructor calls easily in IDE
     public static Array newList(@NotNull ImmutableSeq<WithPos<Expr>> exprs) {
       return new Array(Either.right(new ElementList(exprs)));
     }

--- a/syntax/src/main/java/org/aya/syntax/ref/ModulePath.java
+++ b/syntax/src/main/java/org/aya/syntax/ref/ModulePath.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.syntax.ref;
 
@@ -10,9 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.Serializable;
 
 public record ModulePath(@NotNull ImmutableSeq<String> module) implements Serializable {
-  public static @NotNull ModulePath of(@NotNull String... names) {
-    return new ModulePath(ImmutableSeq.from(names));
-  }
+  public static @NotNull ModulePath of(@NotNull String... names) { return new ModulePath(ImmutableSeq.from(names)); }
 
   public boolean isInModule(@NotNull ModulePath other) {
     var moduleName = other.module;
@@ -20,27 +18,14 @@ public record ModulePath(@NotNull ImmutableSeq<String> module) implements Serial
     return module.sliceView(0, moduleName.size()).sameElements(moduleName);
   }
 
-  public ModulePath dropLast(int n) {
-    return new ModulePath(module.dropLast(n));
-  }
-
-  public boolean sameElements(ModulePath other) {
-    return module.sameElements(other.module);
-  }
-
-  public @NotNull ModuleName.Qualified asName() {
-    return ModuleName.qualified(module);
-  }
-
-  public @NotNull ModulePath derive(@NotNull String modName) {
-    return new ModulePath(module.appended(modName));
-  }
-
+  public ModulePath dropLast(int n) { return new ModulePath(module.dropLast(n)); }
+  public boolean sameElements(ModulePath other) { return module.sameElements(other.module); }
+  public @NotNull ModuleName.Qualified asName() { return ModuleName.qualified(module); }
+  public @NotNull ModulePath derive(@NotNull String modName) { return new ModulePath(module.appended(modName)); }
   public @NotNull ModulePath derive(@NotNull ModulePath modName) {
     return new ModulePath(module.concat(modName.module));
   }
-
-  @Override public String toString() { return QualifiedID.join(module); }
+  @Override public @NotNull String toString() { return QualifiedID.join(module); }
   public boolean isEmpty() { return module.isEmpty(); }
   public int size() { return module.size(); }
   public @NotNull String last() { return module.getLast(); }

--- a/tools/src/main/java/org/aya/util/error/SourcePos.java
+++ b/tools/src/main/java/org/aya/util/error/SourcePos.java
@@ -1,6 +1,8 @@
-// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.util.error;
+
+import java.util.Objects;
 
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.text.LineColumn;
@@ -8,8 +10,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import kala.collection.SeqView;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
 
 /**
  * Position in source code for error reporting only.
@@ -108,10 +108,6 @@ public record SourcePos(
     return startLine == endLine;
   }
 
-  public @NotNull SourcePos sourcePosForSubExpr(@NotNull SeqView<SourcePos> params) {
-    return sourcePosForSubExpr(file, params);
-  }
-
   public @NotNull SourcePos sourcePosForSubExpr(@NotNull SourceFile sourceFile, @NotNull SeqView<SourcePos> params) {
     var restParamSourcePos = params.fold(SourcePos.NONE, (acc, it) -> {
       if (acc == SourcePos.NONE) return it;
@@ -129,7 +125,7 @@ public record SourcePos(
     );
   }
 
-  @Override public String toString() {
+  @Override public @NotNull String toString() {
     return "(" + tokenStartIndex + "-" + tokenEndIndex + ") [" + lineColumnString() + ']';
   }
   public @NotNull String lineColumnString() {


### PR DESCRIPTION
Recursive `buildNested` has made the profiler output harder to read:
![image](https://github.com/user-attachments/assets/719c6741-7e96-4d56-9551-f121bc0bc9ce)

After turning it into iteration, it's easier:
![image](https://github.com/user-attachments/assets/2f785a9c-320d-49e3-849c-7eef762c30bf)

The `sourcePosForSubExpr` is taking a lot of time. Shit!