### PR TITLE
Perform WHNF when pattern matching and invoke

### DIFF
--- a/base/src/main/java/org/aya/normalize/Normalizer.java
+++ b/base/src/main/java/org/aya/normalize/Normalizer.java
@@ -76,7 +76,7 @@ public final class Normalizer implements UnaryOperator<Term> {
           continue;
         }
         case FnCall(JitFn instance, int ulift, var args) -> {
-          var result = instance.invoke(args);
+          var result = instance.invoke(this, args);
           if (result instanceof FnCall(var ref, _, var newArgs) &&
             ref == instance && newArgs.sameElements(args, true)
           ) return defaultValue;
@@ -169,7 +169,7 @@ public final class Normalizer implements UnaryOperator<Term> {
           continue;
         }
         case MatchCall(JitMatchy fn, var discr, var captures) -> {
-          var result = fn.invoke(captures, discr);
+          var result = fn.invoke(this, captures, discr);
           if (result instanceof MatchCall(var ref, var newDiscr, var newCaptures) &&
             ref == fn && newDiscr.sameElements(discr, true) &&
             newCaptures.sameElements(captures, true)

--- a/base/src/main/java/org/aya/tyck/pat/PatternTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatternTycker.java
@@ -494,7 +494,7 @@ public class PatternTycker implements Problematic, Stateful {
     @NotNull DataCall type, @NotNull ConDefLike con, @NotNull TyckState state
   ) {
     return switch (con) {
-      case JitCon jitCon -> jitCon.isAvailable(type.args());
+      case JitCon jitCon -> jitCon.isAvailable(new Normalizer(state), type.args());
       case ConDef.Delegate conDef -> {
         var pats = conDef.core().pats;
         if (pats.isNotEmpty()) {

--- a/jit-compiler/src/main/java/org/aya/compiler/morphism/Constants.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/morphism/Constants.java
@@ -233,6 +233,10 @@ public final class Constants {
     true
   );
 
+  public static @NotNull JavaExpr unaryOperatorIdentity(@NotNull ExprBuilder builder) {
+    return builder.invoke(CLOSURE_ID, ImmutableSeq.empty());
+  }
+
   /**
    * @see PatMatcher#apply(ImmutableSeq, ImmutableSeq)
    */

--- a/jit-compiler/src/main/java/org/aya/compiler/morphism/Constants.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/morphism/Constants.java
@@ -43,13 +43,14 @@ public final class Constants {
   public static final @NotNull ClassDesc CD_MutableSeq = AstUtil.fromClass(MutableSeq.class);
   public static final @NotNull ClassDesc CD_Thunk = AstUtil.fromClass(Supplier.class);
   public static final @NotNull ClassDesc CD_Closure = AstUtil.fromClass(Closure.class);
+  public static final @NotNull ClassDesc CD_UnaryOperator = FreeUtil.fromClass(UnaryOperator.class);
   public static final @NotNull ClassDesc CD_Result = AstUtil.fromClass(Result.class);
   public static final @NotNull String NAME_OF = "of";
   public static final @NotNull String NAME_EMPTY = "empty";
 
   // Term -> Term
   public static final @NotNull MethodRef CLOSURE = new MethodRef(
-    AstUtil.fromClass(UnaryOperator.class),
+    CD_UnaryOperator,
     "apply",
     ConstantDescs.CD_Object, ImmutableSeq.of(ConstantDescs.CD_Object),
     true

--- a/jit-compiler/src/main/java/org/aya/compiler/morphism/Constants.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/morphism/Constants.java
@@ -43,7 +43,7 @@ public final class Constants {
   public static final @NotNull ClassDesc CD_MutableSeq = AstUtil.fromClass(MutableSeq.class);
   public static final @NotNull ClassDesc CD_Thunk = AstUtil.fromClass(Supplier.class);
   public static final @NotNull ClassDesc CD_Closure = AstUtil.fromClass(Closure.class);
-  public static final @NotNull ClassDesc CD_UnaryOperator = FreeUtil.fromClass(UnaryOperator.class);
+  public static final @NotNull ClassDesc CD_UnaryOperator = AstUtil.fromClass(UnaryOperator.class);
   public static final @NotNull ClassDesc CD_Result = AstUtil.fromClass(Result.class);
   public static final @NotNull String NAME_OF = "of";
   public static final @NotNull String NAME_EMPTY = "empty";

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/AbstractExprializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/AbstractExprializer.java
@@ -14,8 +14,12 @@ import java.lang.constant.ConstantDescs;
 
 public abstract class AbstractExprializer<T> {
   protected final @NotNull ExprBuilder builder;
+  protected final @NotNull SerializerContext context;
 
-  protected AbstractExprializer(@NotNull ExprBuilder builder) { this.builder = builder; }
+  protected AbstractExprializer(@NotNull ExprBuilder builder, @NotNull SerializerContext context) {
+    this.builder = builder;
+    this.context = context;
+  }
 
   public @NotNull JavaExpr makeImmutableSeq(
     @NotNull Class<?> typeName,

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/ClassTargetSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/ClassTargetSerializer.java
@@ -74,8 +74,8 @@ public abstract class ClassTargetSerializer<T> {
   }
 
   /// Construct a {@link SerializerContext} with a no-op normalizer
-  public @NotNull SerializerContext buildSerializerContext(@NotNull ExprBuilder builder) {
-    return new SerializerContext(builder.invoke(Constants.CLOSURE_ID, ImmutableSeq.empty()), recorder);
+  public @NotNull SerializerContext buildSerializerContext() {
+    return new SerializerContext(null, recorder);
   }
 
   public @NotNull JavaExpr serializeTermUnderTeleWithoutNormalizer(
@@ -90,7 +90,7 @@ public abstract class ClassTargetSerializer<T> {
     @NotNull Term term,
     @NotNull ImmutableSeq<JavaExpr> argTerms
   ) {
-    return new TermExprializer(builder, buildSerializerContext(builder), argTerms)
+    return new TermExprializer(builder, buildSerializerContext(), argTerms)
       .serialize(term);
   }
 

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/ClassTargetSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/ClassTargetSerializer.java
@@ -69,24 +69,24 @@ public abstract class ClassTargetSerializer<T> {
 
   public abstract @NotNull ClassTargetSerializer<T> serialize(@NotNull ClassBuilder builder, T unit);
 
-  public @NotNull SerializerContext buildSerializerContext(@NotNull FreeJavaExpr normalizer) {
+  public @NotNull SerializerContext buildSerializerContext(@NotNull JavaExpr normalizer) {
     return new SerializerContext(normalizer, recorder);
   }
 
   /// Construct a {@link SerializerContext} with a no-op normalizer
-  public @NotNull SerializerContext buildSerializerContext(@NotNull FreeExprBuilder builder) {
+  public @NotNull SerializerContext buildSerializerContext(@NotNull ExprBuilder builder) {
     return new SerializerContext(builder.invoke(Constants.CLOSURE_ID, ImmutableSeq.empty()), recorder);
   }
 
-  public @NotNull FreeJavaExpr serializeTermUnderTeleWithoutNormalizer(
-    @NotNull FreeExprBuilder builder, @NotNull Term term,
-    @NotNull FreeJavaExpr argsTerm, int size
+  public @NotNull JavaExpr serializeTermUnderTeleWithoutNormalizer(
+    @NotNull ExprBuilder builder, @NotNull Term term,
+    @NotNull JavaExpr argsTerm, int size
   ) {
     return serializeTermUnderTeleWithoutNormalizer(builder, term, AbstractExprializer.fromSeq(builder, Constants.CD_Term, argsTerm, size));
   }
 
-  public @NotNull FreeJavaExpr serializeTermUnderTeleWithoutNormalizer(
-    @NotNull FreeExprBuilder builder,
+  public @NotNull JavaExpr serializeTermUnderTeleWithoutNormalizer(
+    @NotNull ExprBuilder builder,
     @NotNull Term term,
     @NotNull ImmutableSeq<JavaExpr> argTerms
   ) {
@@ -94,7 +94,7 @@ public abstract class ClassTargetSerializer<T> {
       .serialize(term);
   }
 
-  public @NotNull FreeJavaExpr serializeTermWithoutNormalizer(@NotNull FreeCodeBuilder builder, @NotNull Term term) {
+  public @NotNull JavaExpr serializeTermWithoutNormalizer(@NotNull CodeBuilder builder, @NotNull Term term) {
     return serializeTermUnderTeleWithoutNormalizer(builder, term, ImmutableSeq.empty());
   }
 }

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/ClassTargetSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/ClassTargetSerializer.java
@@ -69,23 +69,32 @@ public abstract class ClassTargetSerializer<T> {
 
   public abstract @NotNull ClassTargetSerializer<T> serialize(@NotNull ClassBuilder builder, T unit);
 
-  public @NotNull JavaExpr serializeTermUnderTele(
-    @NotNull ExprBuilder builder, @NotNull Term term,
-    @NotNull JavaExpr argsTerm, int size
-  ) {
-    return serializeTermUnderTele(builder, term, AbstractExprializer.fromSeq(builder, Constants.CD_Term, argsTerm, size));
+  public @NotNull SerializerContext buildSerializerContext(@NotNull FreeJavaExpr normalizer) {
+    return new SerializerContext(normalizer, recorder);
   }
 
-  public @NotNull JavaExpr serializeTermUnderTele(
-    @NotNull ExprBuilder builder,
+  /// Construct a {@link SerializerContext} with a no-op normalizer
+  public @NotNull SerializerContext buildSerializerContext(@NotNull FreeExprBuilder builder) {
+    return new SerializerContext(builder.invoke(Constants.CLOSURE_ID, ImmutableSeq.empty()), recorder);
+  }
+
+  public @NotNull FreeJavaExpr serializeTermUnderTeleWithoutNormalizer(
+    @NotNull FreeExprBuilder builder, @NotNull Term term,
+    @NotNull FreeJavaExpr argsTerm, int size
+  ) {
+    return serializeTermUnderTeleWithoutNormalizer(builder, term, AbstractExprializer.fromSeq(builder, Constants.CD_Term, argsTerm, size));
+  }
+
+  public @NotNull FreeJavaExpr serializeTermUnderTeleWithoutNormalizer(
+    @NotNull FreeExprBuilder builder,
     @NotNull Term term,
     @NotNull ImmutableSeq<JavaExpr> argTerms
   ) {
-    return new TermExprializer(builder, argTerms, recorder)
+    return new TermExprializer(builder, buildSerializerContext(builder), argTerms)
       .serialize(term);
   }
 
-  public @NotNull JavaExpr serializeTerm(@NotNull CodeBuilder builder, @NotNull Term term) {
-    return serializeTermUnderTele(builder, term, ImmutableSeq.empty());
+  public @NotNull FreeJavaExpr serializeTermWithoutNormalizer(@NotNull FreeCodeBuilder builder, @NotNull Term term) {
+    return serializeTermUnderTeleWithoutNormalizer(builder, term, ImmutableSeq.empty());
   }
 }

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/ConSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/ConSerializer.java
@@ -98,7 +98,7 @@ public final class ConSerializer extends JitTeleSerializer<ConDef> {
           "isAvailable",
           helper.parameters(),
           (ap, builder1) ->
-            buildIsAvailable(builder1, unit, helper.normalizer(ap), helper.arg(ap, 0)));
+            buildIsAvailable(builder1, unit, InvokeSignatureHelper.normalizer(ap), InvokeSignatureHelper.arg(ap, 0)));
       }
 
       if (unit.equality != null) {

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/ConSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/ConSerializer.java
@@ -92,11 +92,10 @@ public final class ConSerializer extends JitTeleSerializer<ConDef> {
   @Override public @NotNull ConSerializer serialize(@NotNull ClassBuilder builder0, ConDef unit) {
     buildFramework(builder0, unit, builder -> {
       if (unit.pats.isNotEmpty()) {
-        var helper = new InvokeSignatureHelper(ImmutableSeq.of(Constants.CD_ImmutableSeq));
         builder.buildMethod(
           AstUtil.fromClass(Result.class),
           "isAvailable",
-          helper.parameters(),
+          InvokeSignatureHelper.parameters(ImmutableSeq.of(Constants.CD_ImmutableSeq).view()),
           (ap, builder1) ->
             buildIsAvailable(builder1, unit, InvokeSignatureHelper.normalizer(ap), InvokeSignatureHelper.arg(ap, 0)));
       }

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/FnSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/FnSerializer.java
@@ -134,9 +134,9 @@ public final class FnSerializer extends JitTeleSerializer<FnDef> {
         "invoke",
         fixedInvokeHelper.parameters(),
         (ap, cb) -> {
-          var pre = fixedInvokeHelper.normalizer(ap);
+          var pre = InvokeSignatureHelper.normalizer(ap);
           var args = ImmutableSeq.fill(unit.telescope().size(),
-            i -> fixedInvokeHelper.arg(ap, i));
+            i -> InvokeSignatureHelper.arg(ap, i));
           buildInvoke(cb, unit, pre, args);
         }
       );
@@ -147,7 +147,7 @@ public final class FnSerializer extends JitTeleSerializer<FnDef> {
         "invoke",
         varargInvokeHelper.parameters(),
         (ap, cb) ->
-          buildInvoke(cb, unit, fixedInvoke, varargInvokeHelper.normalizer(ap), varargInvokeHelper.arg(ap, 0))
+          buildInvoke(cb, unit, fixedInvoke, InvokeSignatureHelper.normalizer(ap), InvokeSignatureHelper.arg(ap, 0))
       );
     });
 

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/InvokeSignatureHelper.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/InvokeSignatureHelper.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.constant.ClassDesc;
 
+///
 public class InvokeSignatureHelper {
   private final @NotNull ImmutableSeq<ClassDesc> extraParams;
 
@@ -21,12 +22,28 @@ public class InvokeSignatureHelper {
     return extraParams.prepended(Constants.CD_UnaryOperator);
   }
 
+  public static @NotNull ImmutableSeq<ClassDesc> parameters(@NotNull SeqView<ClassDesc> extraParams) {
+    return extraParams.prepended(Constants.CD_UnaryOperator).toSeq();
+  }
+
+  public static @NotNull ImmutableSeq<JavaExpr> captures(@NotNull JavaExpr normalizer, @NotNull SeqView<JavaExpr> extraCaptures) {
+    return extraCaptures.prepended(normalizer).toSeq();
+  }
+
   public static @NotNull LocalVariable normalizer(@NotNull ArgumentProvider ap) {
     return ap.arg(0);
   }
 
+  public static @NotNull JavaExpr normalizer(@NotNull ArgumentProvider.Lambda ap) {
+    return ap.capture(0);
+  }
+
   public static @NotNull LocalVariable arg(@NotNull ArgumentProvider ap, int nth) {
-    return ap.arg(nth + 1);
+    return ap.arg(1 + nth);
+  }
+
+  public static @NotNull JavaExpr capture(@NotNull ArgumentProvider.Lambda apl, int nth) {
+    return apl.capture(1 + nth);
   }
 
   public static @NotNull ImmutableSeq<JavaExpr> args(@NotNull JavaExpr normalizer, @NotNull SeqView<JavaExpr> args) {

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/InvokeSignatureHelper.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/InvokeSignatureHelper.java
@@ -3,9 +3,9 @@
 package org.aya.compiler.serializers;
 
 import kala.collection.immutable.ImmutableSeq;
-import org.aya.compiler.free.ArgumentProvider;
-import org.aya.compiler.free.Constants;
-import org.aya.compiler.free.data.LocalVariable;
+import org.aya.compiler.LocalVariable;
+import org.aya.compiler.morphism.ArgumentProvider;
+import org.aya.compiler.morphism.Constants;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.constant.ClassDesc;

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/InvokeSignatureHelper.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/InvokeSignatureHelper.java
@@ -2,10 +2,12 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.compiler.serializers;
 
+import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableSeq;
 import org.aya.compiler.LocalVariable;
 import org.aya.compiler.morphism.ArgumentProvider;
 import org.aya.compiler.morphism.Constants;
+import org.aya.compiler.morphism.JavaExpr;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.constant.ClassDesc;
@@ -19,11 +21,15 @@ public class InvokeSignatureHelper {
     return extraParams.prepended(Constants.CD_UnaryOperator);
   }
 
-  public @NotNull LocalVariable normalizer(@NotNull ArgumentProvider ap) {
+  public static @NotNull LocalVariable normalizer(@NotNull ArgumentProvider ap) {
     return ap.arg(0);
   }
 
-  public @NotNull LocalVariable arg(@NotNull ArgumentProvider ap, int nth) {
+  public static @NotNull LocalVariable arg(@NotNull ArgumentProvider ap, int nth) {
     return ap.arg(nth + 1);
+  }
+
+  public static @NotNull ImmutableSeq<JavaExpr> args(@NotNull JavaExpr normalizer, @NotNull SeqView<JavaExpr> args) {
+    return args.prepended(normalizer).toSeq();
   }
 }

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/InvokeSignatureHelper.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/InvokeSignatureHelper.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.compiler.serializers;
+
+import kala.collection.immutable.ImmutableSeq;
+import org.aya.compiler.free.ArgumentProvider;
+import org.aya.compiler.free.Constants;
+import org.aya.compiler.free.data.LocalVariable;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.constant.ClassDesc;
+
+public class InvokeSignatureHelper {
+  private final @NotNull ImmutableSeq<ClassDesc> extraParams;
+
+  public InvokeSignatureHelper(@NotNull ImmutableSeq<ClassDesc> extraParams) { this.extraParams = extraParams; }
+
+  public @NotNull ImmutableSeq<ClassDesc> parameters() {
+    return extraParams.prepended(Constants.CD_UnaryOperator);
+  }
+
+  public @NotNull LocalVariable normalizer(@NotNull ArgumentProvider ap) {
+    return ap.arg(0);
+  }
+
+  public @NotNull LocalVariable arg(@NotNull ArgumentProvider ap, int nth) {
+    return ap.arg(nth + 1);
+  }
+}

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/JitTeleSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/JitTeleSerializer.java
@@ -97,7 +97,7 @@ public abstract class JitTeleSerializer<T extends TyckDef> extends JitDefSeriali
       iTerm,
       IntRange.closedOpen(0, tele.size()).collect(ImmutableIntSeq.factory()),
       (cb, kase) -> {
-        var result = serializeTermUnderTele(
+        var result = serializeTermUnderTeleWithoutNormalizer(
           cb,
           tele.get(kase).type(),
           teleArgsTerm.ref(), kase
@@ -112,7 +112,7 @@ public abstract class JitTeleSerializer<T extends TyckDef> extends JitDefSeriali
    * @see JitTele#result
    */
   protected void buildResult(@NotNull CodeBuilder builder, @NotNull T unit, @NotNull LocalVariable teleArgsTerm) {
-    var result = serializeTermUnderTele(
+    var result = serializeTermUnderTeleWithoutNormalizer(
       builder,
       unit.result(),
       teleArgsTerm.ref(),

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/MatchySerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/MatchySerializer.java
@@ -101,16 +101,16 @@ public class MatchySerializer extends ClassTargetSerializer<MatchySerializer.Mat
    */
   private void buildInvoke(
     @NotNull CodeBuilder builder, @NotNull MatchyData data,
-    @NotNull LocalVariable pre,
+    @NotNull LocalVariable normalizer,
     @NotNull LocalVariable captures, @NotNull LocalVariable args
   ) {
     var capturec = data.capturesSize;
     int argc = data.argsSize;
     var invokeRef = resolveInvoke(NameSerializer.getClassDesc(data.matchy), capturec, argc);
-    var fullArgs = SeqView.of(pre.ref())
-      .appendedAll(AbstractExprializer.fromSeq(builder, Constants.CD_Term, captures.ref(), capturec))
-      .appendedAll(AbstractExprializer.fromSeq(builder, Constants.CD_Term, args.ref(), argc))
-      .collect(ImmutableSeq.factory());
+    var preArgs = AbstractExprializer.fromSeq(builder, Constants.CD_Term, captures.ref(), capturec)
+      .view()
+      .appendedAll(AbstractExprializer.fromSeq(builder, Constants.CD_Term, args.ref(), argc));
+    var fullArgs = InvokeSignatureHelper.args(normalizer.ref(), preArgs);
     var invokeExpr = builder.invoke(invokeRef, builder.thisRef(), fullArgs);
 
     builder.returnWith(invokeExpr);

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/MatchySerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/MatchySerializer.java
@@ -141,9 +141,9 @@ public class MatchySerializer extends ClassTargetSerializer<MatchySerializer.Mat
       var helper = makeHelper(capturec, argc);
 
       builder.buildMethod(Constants.CD_Term, "invoke", helper.parameters(), (ap, cb) -> {
-        var pre = helper.normalizer(ap);
-        var captures = ImmutableSeq.fill(capturec, i -> helper.arg(ap, i));
-        var args = ImmutableSeq.fill(argc, i -> helper.arg(ap, i + capturec));
+        var pre = InvokeSignatureHelper.normalizer(ap);
+        var captures = ImmutableSeq.fill(capturec, i -> InvokeSignatureHelper.arg(ap, i));
+        var args = ImmutableSeq.fill(argc, i -> InvokeSignatureHelper.arg(ap, i + capturec));
         buildInvoke(cb, unit, pre, captures, args);
       });
 

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/MemberSerializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/MemberSerializer.java
@@ -36,7 +36,7 @@ public final class MemberSerializer extends JitTeleSerializer<MemberDef> {
     return super.superConArgs(builder, unit).appendedAll(ImmutableSeq.of(
       AbstractExprializer.getInstance(builder, AnyDef.fromVar(unit.classRef())),
       builder.iconst(unit.index()),
-      serializeTerm(builder, unit.type())
+      serializeTermWithoutNormalizer(builder, unit.type())
     ));
   }
 

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/PatternExprializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/PatternExprializer.java
@@ -15,19 +15,16 @@ import org.jetbrains.annotations.NotNull;
 
 public final class PatternExprializer extends AbstractExprializer<Pat> {
   private final boolean allowLocalTerm;
-  private final @NotNull MatchyRecorder recorder;
 
   PatternExprializer(
-          @NotNull ExprBuilder builder, boolean allowLocalTerm,
-          @NotNull MatchyRecorder recorder
+          @NotNull ExprBuilder builder, @NotNull SerializerContext context, boolean allowLocalTerm
   ) {
-    super(builder);
+    super(builder, context);
     this.allowLocalTerm = allowLocalTerm;
-    this.recorder = recorder;
   }
 
   private @NotNull JavaExpr serializeTerm(@NotNull Term term) {
-    return new TermExprializer(builder, ImmutableSeq.empty(), allowLocalTerm, recorder)
+    return new TermExprializer(builder, ImmutableSeq.empty(), allowLocalTerm)
       .serialize(term);
   }
 

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/PatternExprializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/PatternExprializer.java
@@ -24,12 +24,12 @@ public final class PatternExprializer extends AbstractExprializer<Pat> {
   }
 
   private @NotNull JavaExpr serializeTerm(@NotNull Term term) {
-    return new TermExprializer(builder, ImmutableSeq.empty(), allowLocalTerm)
+    return new TermExprializer(builder, context, ImmutableSeq.empty(), allowLocalTerm)
       .serialize(term);
   }
 
   private @NotNull JavaExpr serializeConHead(@NotNull ConCallLike.Head head) {
-    var termSer = new TermExprializer(builder, ImmutableSeq.empty(), allowLocalTerm, recorder);
+    var termSer = new TermExprializer(builder, context, ImmutableSeq.empty(), allowLocalTerm);
 
     return builder.mkNew(ConCallLike.Head.class, ImmutableSeq.of(
       getInstance(head.ref()),

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/SerializerContext.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/SerializerContext.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
+// Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
+package org.aya.compiler.serializers;
+
+import kala.collection.immutable.ImmutableSeq;
+import org.aya.compiler.free.Constants;
+import org.aya.compiler.free.FreeCodeBuilder;
+import org.aya.compiler.free.FreeExprBuilder;
+import org.aya.compiler.free.FreeJavaExpr;
+import org.aya.syntax.core.term.Term;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public record SerializerContext(
+  @Nullable FreeJavaExpr normalizer,
+  @NotNull ModuleSerializer.MatchyRecorder recorder
+) {
+  public @NotNull FreeJavaExpr serializeTermUnderTele(
+    @NotNull FreeExprBuilder builder,
+    @NotNull Term term,
+    @NotNull ImmutableSeq<FreeJavaExpr> argTerms
+  ) {
+    return new TermExprializer(builder, this, argTerms)
+      .serialize(term);
+  }
+
+  public @NotNull FreeJavaExpr serializeTermUnderTele(
+    @NotNull FreeExprBuilder builder, @NotNull Term term,
+    @NotNull FreeJavaExpr argsTerm, int size
+  ) {
+    return serializeTermUnderTele(builder, term, AbstractExprializer.fromSeq(builder, Constants.CD_Term, argsTerm, size));
+  }
+
+  /**
+   * Apply {@link #normalizer} to {@param term}, note that this method may introduce statements (i.e. variable declaration).
+   *
+   * @return the java expr of whnfed term
+   */
+  public @NotNull FreeJavaExpr whnf(@NotNull FreeCodeBuilder builder, @NotNull FreeJavaExpr term) {
+    if (normalizer == null) return term;
+    var whnfed = builder.checkcast(builder.invoke(Constants.CLOSURE, normalizer, ImmutableSeq.of(term)), Constants.CD_Term);
+    var var = builder.makeVar(Constants.CD_Term, whnfed);
+    return builder.refVar(var);
+  }
+}

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/SerializerContext.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/SerializerContext.java
@@ -3,30 +3,30 @@
 package org.aya.compiler.serializers;
 
 import kala.collection.immutable.ImmutableSeq;
-import org.aya.compiler.free.Constants;
-import org.aya.compiler.free.FreeCodeBuilder;
-import org.aya.compiler.free.FreeExprBuilder;
-import org.aya.compiler.free.FreeJavaExpr;
+import org.aya.compiler.morphism.CodeBuilder;
+import org.aya.compiler.morphism.Constants;
+import org.aya.compiler.morphism.ExprBuilder;
+import org.aya.compiler.morphism.JavaExpr;
 import org.aya.syntax.core.term.Term;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public record SerializerContext(
-  @Nullable FreeJavaExpr normalizer,
+  @Nullable JavaExpr normalizer,
   @NotNull ModuleSerializer.MatchyRecorder recorder
 ) {
-  public @NotNull FreeJavaExpr serializeTermUnderTele(
-    @NotNull FreeExprBuilder builder,
+  public @NotNull JavaExpr serializeTermUnderTele(
+    @NotNull ExprBuilder builder,
     @NotNull Term term,
-    @NotNull ImmutableSeq<FreeJavaExpr> argTerms
+    @NotNull ImmutableSeq<JavaExpr> argTerms
   ) {
     return new TermExprializer(builder, this, argTerms)
       .serialize(term);
   }
 
-  public @NotNull FreeJavaExpr serializeTermUnderTele(
-    @NotNull FreeExprBuilder builder, @NotNull Term term,
-    @NotNull FreeJavaExpr argsTerm, int size
+  public @NotNull JavaExpr serializeTermUnderTele(
+    @NotNull ExprBuilder builder, @NotNull Term term,
+    @NotNull JavaExpr argsTerm, int size
   ) {
     return serializeTermUnderTele(builder, term, AbstractExprializer.fromSeq(builder, Constants.CD_Term, argsTerm, size));
   }
@@ -36,7 +36,7 @@ public record SerializerContext(
    *
    * @return the java expr of whnfed term
    */
-  public @NotNull FreeJavaExpr whnf(@NotNull FreeCodeBuilder builder, @NotNull FreeJavaExpr term) {
+  public @NotNull JavaExpr whnf(@NotNull CodeBuilder builder, @NotNull JavaExpr term) {
     if (normalizer == null) return term;
     var whnfed = builder.checkcast(builder.invoke(Constants.CLOSURE, normalizer, ImmutableSeq.of(term)), Constants.CD_Term);
     var var = builder.makeVar(Constants.CD_Term, whnfed);

--- a/jit-compiler/src/main/java/org/aya/compiler/serializers/TermExprializer.java
+++ b/jit-compiler/src/main/java/org/aya/compiler/serializers/TermExprializer.java
@@ -134,7 +134,7 @@ public final class TermExprializer extends AbstractExprializer<Term> {
       normalizer = Constants.unaryOperatorIdentity(builder);
     }
 
-    var fullArgs = InvokeSignatureHelper.args(normalizer, args.view().appendedAll(captures));
+    var fullArgs = InvokeSignatureHelper.args(normalizer, captures.view().appendedAll(args));
 
     return builder.invoke(
       MatchySerializer.resolveInvoke(matchyClass, captures.size(), args.size()),

--- a/jit-compiler/src/test/java/CompileTest.java
+++ b/jit-compiler/src/test/java/CompileTest.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.function.UnaryOperator;
 
 import static org.aya.compiler.serializers.NameSerializer.getClassName;
 
@@ -76,8 +77,8 @@ public class CompileTest {
     var two = new ConCall(S, ImmutableSeq.empty(), 0, ImmutableSeq.of(one));
     var three = new ConCall(S, ImmutableSeq.empty(), 0, ImmutableSeq.of(two));
 
-    var mResult = plus.invoke(ImmutableSeq.of(two, three));
-    var idLamResult = idLam.invoke(ImmutableSeq.empty());
+    var mResult = plus.invoke(UnaryOperator.identity(), ImmutableSeq.of(two, three));
+    var idLamResult = idLam.invoke(UnaryOperator.identity(), ImmutableSeq.empty());
     var finalResult = new AppTerm(idLamResult, mResult).make();
     System.out.println(finalResult.easyToString());
   }

--- a/jit-compiler/src/test/java/CompileTest.java
+++ b/jit-compiler/src/test/java/CompileTest.java
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 
 import kala.collection.immutable.ImmutableSeq;
+import org.aya.compiler.serializers.SerializerContext;
 import source.SourceClassBuilder;
 import source.SourceCodeBuilder;
 import source.SourceFreeJavaBuilder;
@@ -86,7 +87,7 @@ public class CompileTest {
     var dummy = new SourceCodeBuilder(new SourceClassBuilder(fjb, ConstantDescs.CD_Object, fjb.sourceBuilder()), fjb.sourceBuilder());
     // \ t. (\0. 0 t)
     var lam = new LamTerm(new Closure.Jit(t -> new LamTerm(new Closure.Locns(new AppTerm(new LocalTerm(0), t)))));
-    var out = new TermExprializer(dummy, ImmutableSeq.empty(), new ModuleSerializer.MatchyRecorder())
+    var out = new TermExprializer(dummy, new SerializerContext(null, new ModuleSerializer.MatchyRecorder()), ImmutableSeq.empty())
       .serialize(lam);
 
     System.out.println(out);

--- a/jit-compiler/src/test/java/RedBlackTreeTest.java
+++ b/jit-compiler/src/test/java/RedBlackTreeTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Random;
+import java.util.function.UnaryOperator;
 
 import static org.aya.compiler.serializers.NameSerializer.getClassName;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -65,19 +66,19 @@ public class RedBlackTreeTest {
     System.out.println("Input: " + largeList);
     var args = ImmutableSeq.of(mkList(largeList));
 
-    var term = tree_sortNat.invoke(args);
+    var term = tree_sortNat.invoke(UnaryOperator.identity(), args);
     assertNotNull(term);
     System.out.println(term.easyToString());
 
     TimeUtil.profileMany("Running many times on the same input...", 10, () ->
-      tree_sortNat.invoke(args));
+      tree_sortNat.invoke(UnaryOperator.identity(), args));
   }
 
   @Test public void varyingInput() {
     var random = new Random(1919810L);
     TimeUtil.profileMany("Running many times on new inputs....", 5, () -> {
       var newList = mkList(ImmutableIntSeq.fill(500, () -> random.nextInt(400)));
-      tree_sortNat.invoke(ImmutableSeq.of(newList));
+      tree_sortNat.invoke(UnaryOperator.identity(), ImmutableSeq.of(newList));
     });
   }
 }

--- a/syntax/src/main/java/org/aya/syntax/compile/JitCon.java
+++ b/syntax/src/main/java/org/aya/syntax/compile/JitCon.java
@@ -18,6 +18,8 @@ import org.aya.util.Panic;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnknownNullability;
 
+import java.util.function.UnaryOperator;
+
 public abstract non-sealed class JitCon extends JitTele implements ConDefLike {
   public final JitData dataType;
   private final boolean hasEq;
@@ -37,9 +39,12 @@ public abstract non-sealed class JitCon extends JitTele implements ConDefLike {
   /// Whether this constructor is available of data type.
   /// The default impl is for non-indexed constructors, where it's always available.
   ///
+  /// @implSpec the implementation is invoking {@link org.aya.syntax.core.pat.PatMatcher},
+  ///           cause serializing meta solving is complicated and not worth.
+  ///
   /// @param args the argument to the data type
   /// @return a match result, a sequence of substitution if success
-  public @NotNull Result<ImmutableSeq<Term>, State> isAvailable(@NotNull ImmutableSeq<Term> args) {
+  public @NotNull Result<ImmutableSeq<Term>, State> isAvailable(@NotNull UnaryOperator<Term> pre, @NotNull ImmutableSeq<Term> args) {
     return Result.ok(args);
   }
 

--- a/syntax/src/main/java/org/aya/syntax/compile/JitFn.java
+++ b/syntax/src/main/java/org/aya/syntax/compile/JitFn.java
@@ -3,6 +3,7 @@
 package org.aya.syntax.compile;
 
 import java.util.EnumSet;
+import java.util.function.UnaryOperator;
 
 import kala.collection.Seq;
 import org.aya.generic.Modifier;
@@ -22,7 +23,7 @@ public abstract non-sealed class JitFn extends JitTele implements FnDefLike {
   /**
    * Unfold this function
    */
-  abstract public @NotNull Term invoke(@NotNull Seq<@NotNull Term> args);
+  abstract public @NotNull Term invoke(@NotNull UnaryOperator<Term> pre, @NotNull Seq<@NotNull Term> args);
   @Override public boolean is(@NotNull Modifier mod) {
     return (modifiers & (1 << mod.ordinal())) != 0;
   }

--- a/syntax/src/main/java/org/aya/syntax/compile/JitMatchy.java
+++ b/syntax/src/main/java/org/aya/syntax/compile/JitMatchy.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.syntax.compile;
 
@@ -8,13 +8,15 @@ import org.aya.syntax.core.term.Term;
 import org.aya.syntax.ref.QName;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.function.UnaryOperator;
+
 public non-sealed abstract class JitMatchy extends JitUnit implements MatchyLike {
   protected JitMatchy() {
     super();
   }
 
-  /** @return null if stuck */
   public abstract @NotNull Term invoke(
+    @NotNull UnaryOperator<Term> pre,
     @NotNull Seq<@NotNull Term> captures,
     @NotNull Seq<@NotNull Term> args
   );


### PR DESCRIPTION
Currently, our PatternSerializer missing the part of whnf the argument, which may stuck in certain situations. Also, `TermExperialize` is responsible for doing some `Normalizer` work, such as normalizing the argument before `invoke`.

This PR:
+ [x] Add a `UnaryOperator` argument (can be `Normalizer`) to `JitFn#invoke`, `JitMatchy#invoke`, and `JitCon#isAvailable`
+ [x] Use `InvokeSignatureHelper` to handle the change above.