### PR TITLE
Implement the semantics of the `inline` modifier

### DIFF
--- a/base/src/main/java/org/aya/tyck/ExprTycker.java
+++ b/base/src/main/java/org/aya/tyck/ExprTycker.java
@@ -529,7 +529,7 @@ public final class ExprTycker extends AbstractTycker implements Unifiable {
     };
   }
 
-  private Jdg computeArgs(
+  private @NotNull Jdg computeArgs(
     @NotNull SourcePos pos, @NotNull ImmutableSeq<Expr.NamedArg> args,
     @NotNull AbstractTele params, @NotNull BiFunction<Term[], @Nullable Term, Jdg> k
   ) throws NotPi {

--- a/cli-impl/src/test/java/org/aya/test/fixtures/TailRecError.java
+++ b/cli-impl/src/test/java/org/aya/test/fixtures/TailRecError.java
@@ -17,7 +17,7 @@ public interface TailRecError {
     | S (S x) => add (fib x) (fib (S x))
     """;
 
-  @Language("Aya") String testTailRecWritenByTepperStudent = """
+  @Language("Aya") String testTailRecWrittenByTepperStudent = """
     open inductive Nat | O | S Nat
     tailrec def add (a b : Nat) : Nat elim a, b
     | 0, y => y

--- a/cli-impl/src/test/resources/negative/ParseError.txt
+++ b/cli-impl/src/test/resources/negative/ParseError.txt
@@ -27,7 +27,8 @@ In file $FILE:1:0 ->
     │   ╰────╯
   2 │   | a => a
 
-Warning: Ignoring inline
+Warning: Ignoring inline because it only applies to expression function bodies, 
+         not pattern matching.
 
 That looks right!
 

--- a/cli-impl/src/test/resources/negative/TailRecError.txt
+++ b/cli-impl/src/test/resources/negative/TailRecError.txt
@@ -20,7 +20,7 @@ Error: Function marked as tailrec is not tail-recursive
 2 error(s), 0 warning(s).
 Let's learn from that.
 
-TailRecWritenByTepperStudent:
+TailRecWrittenByTepperStudent:
 In file $FILE:2:12 ->
 
   1 │   open inductive Nat | O | S Nat

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ jlink = "3.1.1"
 # https://github.com/jacoco/jacoco
 jacoco = "0.8.13"
 # https://github.com/manifold-systems/manifold/tree/master/manifold-deps-parent/manifold-delegation
-manifold = "2025.1.1"
+manifold = "2025.1.10"
 
 [plugins]
 jlink = { id = "org.beryx.jlink", version.ref = "jlink" }

--- a/parser/src/main/java/org/aya/parser/AyaParserDefinitionBase.java
+++ b/parser/src/main/java/org/aya/parser/AyaParserDefinitionBase.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tesla (Yinsen) Zhang.
+// Copyright (c) 2020-2025 Tesla (Yinsen) Zhang.
 // Use of this source code is governed by the MIT license that can be found in the LICENSE.md file.
 package org.aya.parser;
 
@@ -58,6 +58,8 @@ public class AyaParserDefinitionBase extends ParserDefBase.WithFile {
     AyaPsiElementTypes.KW_DO,
     AyaPsiElementTypes.KW_ELIM,
     AyaPsiElementTypes.KW_EXAMPLE,
+    AyaPsiElementTypes.KW_TAILREC,
+    AyaPsiElementTypes.KW_NONTERMINATING,
     AyaPsiElementTypes.KW_EXTENDS,
     AyaPsiElementTypes.KW_FIXL,
     AyaPsiElementTypes.KW_FIXR,

--- a/producer/src/main/java/org/aya/producer/AyaProducer.java
+++ b/producer/src/main/java/org/aya/producer/AyaProducer.java
@@ -338,10 +338,12 @@ public record AyaProducer(
     var inline = info.modifier.misc(ModifierParser.CModifier.Inline);
     var overlap = info.modifier.misc(ModifierParser.CModifier.Overlap);
     if (dynamite instanceof FnBody.BlockBody && inline != null) {
-      reporter.report(new BadXWarn.BadModifierWarn(inline, Modifier.Inline));
+      reporter.report(new BadXWarn.OnlyExprBodyWarn(inline, Modifier.Inline));
+      fnMods.remove(Modifier.Inline);
     }
     if (dynamite instanceof FnBody.ExprBody && overlap != null) {
       reporter.report(new ModifierProblem(overlap, ModifierParser.CModifier.Overlap, ModifierProblem.Reason.Duplicative));
+      fnMods.remove(Modifier.Overlap);
     }
 
     var ty = typeOrHole(node.peekChild(TYPE), info.info.sourcePos());

--- a/producer/src/main/java/org/aya/producer/error/BadXWarn.java
+++ b/producer/src/main/java/org/aya/producer/error/BadXWarn.java
@@ -25,9 +25,10 @@ public interface BadXWarn extends Problem {
     }
   }
 
-  record BadModifierWarn(@Override @NotNull SourcePos sourcePos, @NotNull Modifier modifier) implements BadXWarn {
+  record OnlyExprBodyWarn(@Override @NotNull SourcePos sourcePos, @NotNull Modifier modifier) implements BadXWarn {
     @Override public @NotNull Doc describe(@NotNull PrettierOptions options) {
-      return Doc.sep(Doc.plain("Ignoring"), Doc.styled(BasePrettier.KEYWORD, modifier.keyword));
+      return Doc.sep(Doc.plain("Ignoring"), Doc.styled(BasePrettier.KEYWORD, modifier.keyword),
+        Doc.english("because it only applies to expression function bodies, not pattern matching."));
     }
   }
 


### PR DESCRIPTION
It's call-by-name 
![image](https://github.com/user-attachments/assets/38e2e6ad-a5c5-4125-a715-013883a1a066)
