### PR TITLE
Try Fix #1380 in a compatible way

### DIFF
--- a/base/src/main/java/org/aya/tyck/StmtTycker.java
+++ b/base/src/main/java/org/aya/tyck/StmtTycker.java
@@ -142,7 +142,7 @@ public record StmtTycker(
                 var rawParams = signature.params();
                 var confluence = new YouTrack(rawParams, tycker, fnDecl.nameSourcePos());
                 var classes = PatClassifier.classify(
-                  patResult.clauses().view().map(Pat.Preclause::pats),
+                  patResult.clauses().view().map(cls -> cls.pats().view()),
                   rawParams.view(), tycker, fnDecl.nameSourcePos());
                 var absurds = patResult.absurdPrefixCount();
                 coreBody.classes = classes.map(cls -> cls.ignoreAbsurd(absurds));
@@ -297,12 +297,12 @@ public record StmtTycker(
       if (lhsResult.hasError()) {
         return;
       }
-      var patWithTypeBound = Pat.collectVariables(lhsResult.freePats().view());
+      var patWithTypeBound = Pat.collectVariables(lhsResult.allPats());
       wellPats = patWithTypeBound.component2();
       tycker.setLocalCtx(lhsResult.localCtx());
       lhsResult.dumpLocalLetTo(ownerBinds, tycker);
       // Here we don't use wellPats but instead a "freePats" because we want them to be bound
-      freeDataCall = new DataCall(dataDef, 0, lhsResult.freePats().map(PatToTerm::visit));
+      freeDataCall = new DataCall(dataDef, 0, lhsResult.allPats().map(PatToTerm::visit).toSeq());
 
       var allTypedBinds = Pat.collectBindings(wellPats.view());
       ownerBinds = patWithTypeBound.component1().toSeq();

--- a/base/src/main/java/org/aya/tyck/pat/ClauseTycker.java
+++ b/base/src/main/java/org/aya/tyck/pat/ClauseTycker.java
@@ -128,10 +128,14 @@ public final class ClauseTycker implements Problematic, Stateful {
           telescope.view().concat(unpi.params()), parent.exprTycker, overallPos);
         if (clauses.isNotEmpty()) {
           var usages = PatClassifier.firstMatchDomination(clauses, parent, classes);
+          // for the `i`-th clause
           for (int i = 0; i < usages.size(); i++) {
+            // skip absurd clauses
             if (clauses.get(i).expr.isEmpty()) continue;
             var currentClasses = usages.get(i);
+            // if the clause is only reachable for a single leaf in the case tree
             if (currentClasses.sizeEquals(1)) {
+              // try to refine the patterns
               var newLhs = refinePattern(lhs.get(i), currentClasses.getAny());
               if (newLhs != null) lhs.set(i, newLhs);
             }

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -7,7 +7,6 @@ import kala.collection.SeqView;
 import kala.collection.immutable.ImmutableSeq;
 import kala.collection.immutable.primitive.ImmutableIntSeq;
 import kala.collection.mutable.MutableList;
-import kala.collection.mutable.MutableSeq;
 import kala.control.Result;
 import org.aya.generic.State;
 import org.aya.generic.term.DTKind;
@@ -26,7 +25,6 @@ import org.aya.tyck.tycker.AbstractTycker;
 import org.aya.tyck.tycker.Problematic;
 import org.aya.tyck.tycker.Stateful;
 import org.aya.util.Pair;
-import org.aya.util.position.SourceNode;
 import org.aya.util.position.SourcePos;
 import org.aya.util.reporter.Reporter;
 import org.aya.util.tyck.pat.ClassifierUtil;
@@ -190,15 +188,6 @@ public record PatClassifier(
       case Pat.Bind _ -> new Indexed<>(conTele.view().map(Param::toFreshPat), ix);
       default -> null;
     };
-  }
-
-  /// @return `result[i] : List<T>` means the `i`-th user clause is used by these pat classes
-  public static <T extends PatClass> MutableSeq<MutableList<T>> firstMatchDomination(
-    @NotNull ImmutableSeq<? extends SourceNode> clauses,
-    @NotNull Problematic reporter, @NotNull ImmutableSeq<T> classes
-  ) {
-    return ClassifierUtil.firstMatchDomination(clauses, (pos, i) -> reporter.fail(
-      new ClausesProblem.FMDomination(i, pos)), classes);
   }
 
   private record ConTele(

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -192,6 +192,7 @@ public record PatClassifier(
     };
   }
 
+  /// @return `result[i] : List<T>` means the `i`-th user clause is used by these pat classes
   public static <T extends PatClass> MutableSeq<MutableList<T>> firstMatchDomination(
     @NotNull ImmutableSeq<? extends SourceNode> clauses,
     @NotNull Problematic reporter, @NotNull ImmutableSeq<T> classes

--- a/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
+++ b/base/src/main/java/org/aya/tyck/pat/PatClassifier.java
@@ -66,14 +66,15 @@ public record PatClassifier(
     return subst.appended(term);
   }
 
+  /// @param freePats the second layer of [SeqView] should be friendly for random access
   public static @NotNull ImmutableSeq<PatClass.Seq<Term, Pat>> classify(
-    @NotNull SeqView<ImmutableSeq<Pat>> freePats,
+    @NotNull SeqView<SeqView<Pat>> freePats,
     @NotNull SeqView<Param> telescope, @NotNull AbstractTycker tycker,
     @NotNull SourcePos pos
   ) {
     var classifier = new PatClassifier(tycker, pos);
     var cl = classifier.classifyN(ImmutableSeq.empty(), telescope, freePats
-      .mapIndexed((i, clause) -> new Indexed<>(clause.view(), i))
+      .mapIndexed((i, clause) -> new Indexed<>(clause, i))
       .toSeq(), 4);
     var p = cl.partition(c -> c.cls().isEmpty());
     var missing = p.component1();

--- a/cli-impl/src/test/resources/success/src/Pattern.aya
+++ b/cli-impl/src/test/resources/success/src/Pattern.aya
@@ -49,6 +49,10 @@ module PullRequest1268 {
   def allInOneNoElim {A : Type} (a : A) {B : Type} (b : B) {C : Type} : Fn (D : Type) (d : D) D -> D
   | a, b, D => fn d => id D
 
+  // allInOneNoElim cannot cover the pusheen from body case (but cover the pusheen from signature case)
+  def allInOneNoElim^C (A : Type) (B : Type) : Fn (b : B) B -> B
+  | A => fn B => fn d => id B
+
   // telescope: A a B b C
   // unpi: D d0 -> d1
   @suppress(LocalShadow)

--- a/cli-impl/src/test/resources/success/src/Pattern.aya
+++ b/cli-impl/src/test/resources/success/src/Pattern.aya
@@ -55,3 +55,12 @@ module PullRequest1268 {
   def elims {A : Type} (a : A) (B : Type) (b : B) {C : Type} : Fn (D : Type) D -> D elim a, b
   | a => fn b D => id D
 }
+
+module Issue1380 {
+  def id (A : Type) : A -> A => fn a => a
+
+  def test (A : Type) : Fn (B: Type) (b : B) -> B
+  | a, B => fn b => id B b
+
+  def eval : test Nat Nat 0 = 0 => refl
+}

--- a/tools-kala/src/main/java/org/aya/util/tyck/pat/ClassifierUtil.java
+++ b/tools-kala/src/main/java/org/aya/util/tyck/pat/ClassifierUtil.java
@@ -8,12 +8,10 @@ import kala.collection.mutable.MutableList;
 import kala.collection.mutable.MutableSeq;
 import org.aya.util.Pair;
 import org.aya.util.position.SourceNode;
-import org.aya.util.position.SourcePos;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
-import java.util.function.ObjIntConsumer;
 
 public interface ClassifierUtil<Subst, Term, Param, Pat> {
   Param subst(Subst subst, Param param);
@@ -56,17 +54,16 @@ public interface ClassifierUtil<Subst, Term, Param, Pat> {
         .map(args -> args.pair(subclauses)));
   }
 
+  /// @return `result[i] : List<T>` means the `i`-th user clause is used by these pat classes
   static <T extends PatClass> MutableSeq<MutableList<T>> firstMatchDomination(
     @NotNull ImmutableSeq<? extends SourceNode> clauses,
-    @NotNull ObjIntConsumer<SourcePos> report, @NotNull ImmutableSeq<T> classes
+    @NotNull ImmutableSeq<T> classes
   ) {
     // StackOverflow says they're initialized to zero
     var numbers = MutableSeq.fill(clauses.size(), _ -> MutableList.<T>create());
     classes.forEach(results ->
       numbers.get(results.cls().min()).append(results));
     // ^ The minimum is not always the first one
-    for (int i = 0; i < numbers.size(); i++)
-      if (numbers.get(i).isEmpty()) report.accept(clauses.get(i).sourcePos(), i + 1);
     return numbers;
   }
 }


### PR DESCRIPTION
Fixes #1380.
`LhsResult` separates `missingPats` (constructed after tyck patterns) and `tyckedPats` (produced by pattern tycker) from `freePats` and gets rid of `unpiParamSize`.