### PR TITLE
ci: fix trigger conditions for nightly-build-nix

### DIFF
--- a/.github/workflows/check-deps-lock.yaml
+++ b/.github/workflows/check-deps-lock.yaml
@@ -1,11 +1,10 @@
 name: check if deps.json is up-to-date
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   merge_group:
     types: [checks_requested]
+  workflow_call: {}
 jobs:
   check-deps-lock:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-nix-gradle-lock.sh
+++ b/.github/workflows/check-nix-gradle-lock.sh
@@ -11,8 +11,12 @@ fi
 eval $(nix build .#Aya.mitmCache.updateScript --no-link --print-out-paths)
 
 # Check whether nix/deps.json is modified or not
-git diff --exit-code nix/deps.json || \
+if ! git diff --quiet nix/deps.json; then
   if [[ -n $CI ]]; then
-    printf "ERROR: Outdated nix/deps.json detected.
-    Please run .github/workflows/check-nix-gradle.lock.sh and commit changes."
+    printf "ERROR: Outdated nix/deps.json detected.\n"
+    printf "Please run .github/workflows/check-nix-gradle-lock.sh and commit changes.\n"
+    exit 1
   fi
+fi
+
+

--- a/.github/workflows/nightly-build-nix.yaml
+++ b/.github/workflows/nightly-build-nix.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   check-deps-lock:
-    uses: aya-prover/aya-dev/.github/workflows/check-deps-lock.yaml@main
+    uses: ./.github/workflows/check-deps-lock.yaml
 
   nightly-build-nix:
     needs: [check-deps-lock]


### PR DESCRIPTION
Try fixing previous error at https://github.com/aya-prover/aya-dev/actions/runs/18925616187
```
 Invalid workflow file: .github/workflows/nightly-build-nix.yaml#L8
error parsing called workflow
".github/workflows/nightly-build-nix.yaml"
-> "aya-prover/aya-dev/.github/workflows/check-deps-lock.yaml@main" (source branch with sha:6454a225c01448770a090cb33e83bd1906e08128)
: workflow is not reusable as it is missing a `on.workflow_call` trigger
```